### PR TITLE
Feature/pool summaries

### DIFF
--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -70,7 +70,7 @@ loop:
 
 				// Proposer Duties
 
-				for _, item := range stateMetrics.GetMetricsBase().CurrentState.EpochStructs.ProposerDuties {
+				for _, item := range stateMetrics.GetMetricsBase().NextState.EpochStructs.ProposerDuties {
 
 					newDuty := spec.ProposerDuty{
 						ValIdx:       item.ValidatorIndex,

--- a/pkg/db/migrations/000023_update_summary_table.down.sql
+++ b/pkg/db/migrations/000023_update_summary_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t_pool_summary;

--- a/pkg/db/migrations/000023_update_summary_table.up.sql
+++ b/pkg/db/migrations/000023_update_summary_table.up.sql
@@ -1,0 +1,15 @@
+DROP TABLE t_pool_summary;
+CREATE TABLE IF NOT EXISTS t_pool_summary(
+		f_pool_name TEXT,
+		f_epoch INT,
+		aggregated_rewards BIGINT,
+		aggregated_max_rewards BIGINT,
+		count_sync_committee INT,
+		count_missing_source INT,
+		count_missing_target INT,
+		count_missing_head INT,
+		count_attestations INT,
+		proposed_blocks_performance INT,
+		missed_blocks_performance INT,
+		number_active_vals INT,
+		CONSTRAINT t_pool_summary_pkey PRIMARY KEY (f_pool_name, f_epoch));

--- a/pkg/db/migrations/000023_update_summary_table.up.sql
+++ b/pkg/db/migrations/000023_update_summary_table.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS t_pool_summary(
 		count_missing_source INT,
 		count_missing_target INT,
 		count_missing_head INT,
-		count_attestations INT,
+		count_expected_attestations INT,
 		proposed_blocks_performance INT,
 		missed_blocks_performance INT,
 		number_active_vals INT,

--- a/pkg/db/migrations/000024_create_pools_table.down.sql
+++ b/pkg/db/migrations/000024_create_pools_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE t_eth2_pubkeys;

--- a/pkg/db/migrations/000024_create_pools_table.up.sql
+++ b/pkg/db/migrations/000024_create_pools_table.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS t_eth2_pubkeys(
+		f_val_idx INT PRIMARY KEY,
+		f_public_key TEXT,
+		f_pool_name TEXT,
+		f_pool TEXT);

--- a/pkg/db/migrations/000025_create_summary_trigger.down.sql
+++ b/pkg/db/migrations/000025_create_summary_trigger.down.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE FUNCTION notify_epoch_insert() RETURNS TRIGGER AS $$ 
+	DECLARE 
+	row RECORD; 
+	output TEXT;
+	last_epoch integer;
+	last_validator integer;
+    BEGIN 
+    row = NEW; 
+
+	-- Check if the epoch is greater than the previous one
+	SELECT f_epoch INTO last_epoch
+	FROM t_epoch_metrics_summary
+	order by f_epoch desc
+	limit 1;
+
+	IF row.f_epoch > last_epoch THEN
+	    -- Forming the Output as notification. You can choose you own notification. 
+		output = 'OPERATION = ' || TG_OP || ' and Epoch = ' || row.f_epoch; 
+		-- Calling the pg_notify for my_table_update event with output as payload 
+		PERFORM pg_notify('new_epoch_finalized',output); 
+	END IF;
+
+	SELECT f_num_vals INTO last_validator
+	FROM t_epoch_metrics_summary
+	order by f_epoch desc
+	limit 1;
+
+	IF row.f_num_vals > last_validator THEN
+		output = 'Validator Num = ' || row.f_num_vals; 
+		PERFORM pg_notify('new_validator', output); 
+	END IF;
+
+
+    -- Returning null because it is an after trigger. 
+    RETURN NEW; 
+    END; 
+$$ LANGUAGE plpgsql; 

--- a/pkg/db/migrations/000025_create_summary_trigger.up.sql
+++ b/pkg/db/migrations/000025_create_summary_trigger.up.sql
@@ -1,0 +1,69 @@
+DROP TRIGGER IF EXISTS trigger_notify_new_epoch ON t_epoch_metrics_summary;
+DROP function IF EXISTS notify_epoch_insert;
+
+CREATE OR REPLACE FUNCTION notify_epoch_insert() RETURNS TRIGGER AS $$ 
+	DECLARE 
+	row RECORD; 
+	output TEXT;
+	last_epoch integer;
+	last_validator integer;
+    BEGIN 
+    row = NEW; 
+
+	-- Check if the epoch is greater than the previous one
+	SELECT f_epoch INTO last_epoch
+	FROM t_epoch_metrics_summary
+	order by f_epoch desc
+	limit 1;
+
+	IF row.f_epoch > last_epoch THEN
+	    -- Forming the Output as notification. You can choose you own notification. 
+		output = 'OPERATION = ' || TG_OP || ' and Epoch = ' || row.f_epoch; 
+		-- Calling the pg_notify for my_table_update event with output as payload 
+		PERFORM pg_notify('new_epoch_finalized',output); 
+	END IF;
+
+	SELECT f_num_vals INTO last_validator
+	FROM t_epoch_metrics_summary
+	order by f_epoch desc
+	limit 1;
+
+	IF row.f_num_vals > last_validator THEN
+		output = 'Validator Num = ' || row.f_num_vals; 
+		PERFORM pg_notify('new_validator', output); 
+	END IF;
+	
+	INSERT INTO t_pool_summary
+		SELECT 
+			t_eth2_pubkeys.f_pool_name, f_epoch,
+			SUM(CASE WHEN (f_reward <= f_max_reward) THEN f_reward ELSE 0 END) as aggregated_rewards,
+			SUM(CASE WHEN (f_reward <= f_max_reward) THEN f_max_reward ELSE 0 END) as aggregated_max_rewards,
+			COUNT(CASE WHEN f_in_sync_committee = TRUE THEN 1 ELSE null END) as count_sync_committee,
+			COUNT(CASE WHEN f_missing_source = TRUE THEN 1 ELSE null END) as count_missing_source,
+			COUNT(CASE WHEN f_missing_target = TRUE THEN 1 ELSE null END) as count_missing_target,
+			COUNT(CASE WHEN f_missing_head = TRUE THEN 1 ELSE null END) as count_missing_head,
+			COUNT(*) as count_attestations,
+			SUM(CASE WHEN t_proposer_duties.f_proposed = TRUE THEN 1 ELSE 0 END) as proposed_blocks_performance,
+			SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE THEN 1 ELSE 0 END) as missed_blocks_performance,
+			count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals
+		FROM t_validator_rewards_summary
+		LEFT JOIN t_proposer_duties 
+			ON t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx 
+			AND t_validator_rewards_summary.f_epoch = t_proposer_duties.f_proposer_slot/32
+		LEFT JOIN t_eth2_pubkeys 
+			ON t_validator_rewards_summary.f_val_idx = t_eth2_pubkeys.f_val_idx
+		WHERE f_epoch = row.f_epoch AND f_status IN (1, 3)
+		GROUP BY t_eth2_pubkeys.f_pool_name, f_epoch;
+		
+		
+    -- Returning null because it is an after trigger. 
+    RETURN NEW; 
+    END; 
+$$ LANGUAGE plpgsql; 
+
+
+CREATE TRIGGER trigger_notify_new_epoch
+  BEFORE INSERT 
+  ON t_epoch_metrics_summary 
+  FOR EACH ROW 
+  EXECUTE PROCEDURE notify_epoch_insert();

--- a/pkg/db/migrations/000025_create_summary_trigger.up.sql
+++ b/pkg/db/migrations/000025_create_summary_trigger.up.sql
@@ -42,7 +42,7 @@ CREATE OR REPLACE FUNCTION notify_epoch_insert() RETURNS TRIGGER AS $$
 			COUNT(CASE WHEN f_missing_source = TRUE THEN 1 ELSE null END) as count_missing_source,
 			COUNT(CASE WHEN f_missing_target = TRUE THEN 1 ELSE null END) as count_missing_target,
 			COUNT(CASE WHEN f_missing_head = TRUE THEN 1 ELSE null END) as count_missing_head,
-			COUNT(*) as count_attestations,
+			COUNT(*) as count_expected_attestations,
 			SUM(CASE WHEN t_proposer_duties.f_proposed = TRUE THEN 1 ELSE 0 END) as proposed_blocks_performance,
 			SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE THEN 1 ELSE 0 END) as missed_blocks_performance,
 			count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals

--- a/pkg/spec/metrics/state_phase0.go
+++ b/pkg/spec/metrics/state_phase0.go
@@ -169,7 +169,7 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		MissingSource:       false,
 		MissingTarget:       false,
 		MissingHead:         false,
-		Status:              0,
+		Status:              p.baseMetrics.NextState.GetValStatus(valIdx),
 		BaseReward:          baseReward,
 		ProposerSlot:        proposerSlot,
 		InSyncCommittee:     false,


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
As the product grows, demand also grows. Ethseer shows the consensus performance from an entity perspective and, thus, we want to support from GotEth. This already works but really slow when there is a big number of validators. So we aim to deploy summaries at every epoch of every single entity we register in the database.

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->

To do this, we are deploying a trigger that will be launched with every new epoch inserted in the `epochs` table.
This trigger will calculate the summary of entities (in the `t_eth2_pubkeys` table) and insert it in the `t_pool_summary` table.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Create `t_pool_summary` table
- [x] Create `t_eth2_pubkeys` table (so we have permissions)
- [x] Deploy trigger    

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->
![image](https://github.com/migalabs/goteth/assets/18716811/521551cd-45de-4694-a695-7975821fd790)


