### PR TITLE
Feature/better rewards

### DIFF
--- a/pkg/analyzer/block.go
+++ b/pkg/analyzer/block.go
@@ -220,6 +220,7 @@ type EpochTask struct {
 	State     spec.AgnosticState
 	PrevState spec.AgnosticState
 	Finalized bool
+	BlockList []spec.AgnosticBlock
 }
 
 type ValTask struct {

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -47,10 +47,10 @@ loop:
 			if slot%spec.SlotsPerEpoch == 0 {
 				// new epoch
 				s.DownloadNewState(&queue, slot-1, false)
+				// refresh map as we dont need to store the history
+				// only store history of last epoch processed
+				queue.AdvanceFinalized(slot - spec.SlotsPerEpoch)
 			}
-
-			// refresh map as we dont need to store the history
-			queue.BlockHistory = make(map[phase0.Slot]spec.AgnosticBlock)
 
 		}
 

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -22,6 +22,16 @@ func (s *ChainAnalyzer) DownloadNewState(
 		log.Panicf("unable to retrieve beacon state from the beacon node, closing requester routine. %s", err.Error())
 	}
 
+	blockList := make([]spec.AgnosticBlock, 0)
+	epochStartSlot := phase0.Slot(nextBstate.Epoch * spec.SlotsPerEpoch)
+	epochEndSlot := phase0.Slot((nextBstate.Epoch+1)*spec.SlotsPerEpoch - 1)
+
+	for i := epochStartSlot; i <= epochEndSlot; i++ {
+		blockList = append(blockList, queue.BlockHistory[i])
+	}
+	nextBstate.Blocks = blockList
+	nextBstate.CalculateWithdrawals()
+
 	queue.AddNewState(*nextBstate)
 
 	if queue.Complete() {

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -45,6 +45,14 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, err
 	}
 
 	customBlock.StateRoot = s.RequestStateRoot(slot)
+
+	reward, err := s.RequestBlockRewards(slot)
+	if err != nil {
+		log.Error("cannot request block reward: %s", err)
+	}
+
+	customBlock.Reward = reward
+
 	return customBlock, nil
 }
 

--- a/pkg/clientapi/rewards.go
+++ b/pkg/clientapi/rewards.go
@@ -1,0 +1,35 @@
+package clientapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
+)
+
+func (s APIClient) RequestBlockRewards(slot phase0.Slot) (spec.BlockRewards, error) {
+
+	uri := s.Api.Address() + "/eth/v1/beacon/rewards/blocks/" + fmt.Sprintf("%d", slot)
+	resp, err := http.Get(uri)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	//We Read the response body on the line below.
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	var rewards spec.BlockRewards
+	err = json.Unmarshal(body, &rewards)
+
+	if err != nil {
+		log.Fatalf("error parsing block rewards response: %s", err)
+	}
+
+	return rewards, err
+
+}

--- a/pkg/db/migrations/000026_add_block_reward_column.down.sql
+++ b/pkg/db/migrations/000026_add_block_reward_column.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE t_validator_rewards_summary
+DROP COLUMN f_block_api_reward;

--- a/pkg/db/migrations/000026_add_block_reward_column.up.sql
+++ b/pkg/db/migrations/000026_add_block_reward_column.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE t_validator_rewards_summary
+ADD COLUMN f_block_api_reward BIGINT;

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -22,8 +22,9 @@ var (
 		f_missing_source,
 		f_missing_target,
 		f_missing_head,
-		f_status)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		f_status,
+		f_block_api_reward)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 	ON CONFLICT ON CONSTRAINT t_validator_rewards_summary_pkey
 		DO NOTHING;
 	`
@@ -50,6 +51,7 @@ func insertValidator(inputValidator spec.ValidatorRewards) (string, []interface{
 	resultArgs = append(resultArgs, inputValidator.MissingTarget)
 	resultArgs = append(resultArgs, inputValidator.MissingHead)
 	resultArgs = append(resultArgs, inputValidator.Status)
+	resultArgs = append(resultArgs, inputValidator.ProposerReward)
 	return InsertValidator, resultArgs
 }
 

--- a/pkg/spec/block.go
+++ b/pkg/spec/block.go
@@ -25,6 +25,7 @@ type AgnosticBlock struct {
 	SyncAggregate     *altair.SyncAggregate
 	ExecutionPayload  AgnosticExecutionPayload
 	Size              uint32
+	Reward            BlockRewards
 }
 
 // This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -156,6 +156,7 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		Status:              p.baseMetrics.NextState.GetValStatus(valIdx),
 		BaseReward:          baseReward,
 		ProposerSlot:        proposerSlot,
+		ProposerReward:      int64(proposerReward),
 		InSyncCommittee:     inSyncCommitte,
 	}
 	return result, nil

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -31,7 +31,7 @@ func (p AltairMetrics) GetMetricsBase() StateMetricsBase {
 func (p AltairMetrics) GetMaxProposerAttReward(valIdx phase0.ValidatorIndex) (phase0.Gwei, phase0.Slot) {
 
 	proposerSlot := phase0.Slot(0)
-	reward := phase0.Gwei(0)
+
 	duties := p.baseMetrics.NextState.EpochStructs.ProposerDuties
 	// validator will only have duties it is active at this point
 	for _, duty := range duties {
@@ -40,6 +40,7 @@ func (p AltairMetrics) GetMaxProposerAttReward(valIdx phase0.ValidatorIndex) (ph
 			break
 		}
 	}
+	reward := p.baseMetrics.NextState.Blocks[proposerSlot%spec.SlotsPerEpoch].Reward.Data.Attestations
 
 	return reward, proposerSlot
 
@@ -47,9 +48,9 @@ func (p AltairMetrics) GetMaxProposerAttReward(valIdx phase0.ValidatorIndex) (ph
 
 // TODO: to be implemented once we can process each block
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#sync-aggregate-processing
-func (p AltairMetrics) GetMaxProposerSyncReward(valIdx uint64, valPubKey phase0.BLSPubKey, valEffectiveBalance uint64, totalEffectiveBalance uint64) int64 {
+func (p AltairMetrics) GetMaxProposerSyncReward(proposerSlot phase0.Slot) phase0.Gwei {
 
-	return 0
+	return p.baseMetrics.NextState.Blocks[proposerSlot%spec.SlotsPerEpoch].Reward.Data.SyncAggregate
 
 }
 
@@ -131,8 +132,12 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 
 	_, proposerSlot := p.GetMaxProposerAttReward(
 		valIdx)
+	proposerReward := phase0.Gwei(0)
+	if proposerSlot > 0 {
+		proposerReward = p.baseMetrics.NextState.Blocks[proposerSlot%spec.SlotsPerEpoch].Reward.Data.Total
+	}
 
-	maxReward := flagIndexMaxReward + syncComMaxReward
+	maxReward := flagIndexMaxReward + syncComMaxReward + proposerReward
 
 	flags := p.baseMetrics.CurrentState.MissingFlags(valIdx)
 
@@ -140,7 +145,7 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		ValidatorIndex:      valIdx,
 		Epoch:               p.baseMetrics.NextState.Epoch,
 		ValidatorBalance:    p.baseMetrics.NextState.Balances[valIdx],
-		Reward:              p.baseMetrics.EpochReward(valIdx),
+		Reward:              p.baseMetrics.EpochReward(valIdx) + int64(p.baseMetrics.NextState.Withdrawals[valIdx]),
 		MaxReward:           maxReward,
 		AttestationReward:   flagIndexMaxReward,
 		SyncCommitteeReward: syncComMaxReward,

--- a/pkg/spec/metrics/state_phase0.go
+++ b/pkg/spec/metrics/state_phase0.go
@@ -172,6 +172,7 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		Status:              p.baseMetrics.NextState.GetValStatus(valIdx),
 		BaseReward:          baseReward,
 		ProposerSlot:        proposerSlot,
+		ProposerReward:      int64(proposerReward),
 		InSyncCommittee:     false,
 	}
 	return result, nil

--- a/pkg/spec/utils.go
+++ b/pkg/spec/utils.go
@@ -1,9 +1,26 @@
 package spec
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/sirupsen/logrus"
+)
 
 var (
 	log = logrus.WithField(
 		"module", "spec",
 	)
 )
+
+type BlockRewards struct {
+	ExecutionOptimistic bool                `json:"execution_optimistic"`
+	Data                BlockRewardsContent `json:"data"`
+}
+
+type BlockRewardsContent struct {
+	ProposerIndex     phase0.ValidatorIndex `json:"proposer_index,string"`
+	Total             phase0.Gwei           `json:"total,string"`
+	Attestations      phase0.Gwei           `json:"attestations,string"`
+	SyncAggregate     phase0.Gwei           `json:"sync_aggregate,string"`
+	ProposerSlashings phase0.Gwei           `json:"proposer_slashings,string"`
+	AttesterSlashings phase0.Gwei           `json:"attester_slashings,string"`
+}

--- a/pkg/spec/validator_rewards.go
+++ b/pkg/spec/validator_rewards.go
@@ -16,6 +16,7 @@ type ValidatorRewards struct {
 	AttSlot             phase0.Slot
 	InSyncCommittee     bool
 	ProposerSlot        phase0.Slot
+	ProposerReward      int64
 	MissingSource       bool
 	MissingTarget       bool
 	MissingHead         bool


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
Until now we were measuring the plain reward a validator obtains. However, with the introduction of automatic withdrawals, we usually see negative rewards as a result of withdrawing the funds.

Also, we have never taken into account the maximum block reward, which we are still unable to calculate but we can request from the recently added API endpoint: [/eth/v1/beacon/rewards/blocks/{block_id}](https://ethereum.github.io/beacon-APIs/#/Rewards/getBlockRewards)

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->

From the Reward we will add any withdrawal amount we observe for a given validator. This way the negative reward should be balanced with the same amount we add.
From the max reward we will request the block reward and add this to the maximum reward, which solve the issue of having some cases where the reward is greater than the maximum reward.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Give list of blocks to state
- [x] Calculate Withdrawals from every single validator
- [x] Request block reward with each block and store in block
- [x] Add block reward to maximum reward
- [x] Store new column with block reward     

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

