### PR TITLE
Feature/download only needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Or if you prefer to install the client locally type:
 make install
 ```
 
+### Metrics: database tables
+
+- block: downloads withdrawals, blocks and block rewards
+- epoch: download epoch metrics, proposer duties, validator last status,
+- rewards: persists validator rewards metrics to database (activates epoch metrics)
+- transactions: requests transaction receipts from the execution layer (activates block metrics)
+
 ### Running the tool
 To execute the tool, you can simply modify the `.env` file with your own configuration. The `.env` file first exports all the variables as system environment variables, and then uses them as arguments when calling the tool.
 
@@ -51,10 +58,10 @@ OPTIONS:
    --final-slot value      init slot from where to finish (default: 0)
    --log-level value       log level: debug, warn, info, error
    --db-url value          example: postgresql://beaconchain:beaconchain@localhost:5432/beacon_states
-   --workers-num value     example: 50 (default: 0)
-   --db-workers-num value  example: 50 (default: 0)
+   --workers-num value     example: 3 (default: 4)
+   --db-workers-num value  example: 3 (default: 4)
    --download-mode value   example: hybrid,historical,finalized. Default: hybrid
-   --metrics value         example: epoch,validator,transactions. Empty for all (default: epoch)
+   --metrics value         example: epoch,block,rewards,transactions. Empty for all (default: epoch,block)
    --help, -h              show help (default: false)
 ```
 

--- a/cmd/blocks_cmd.go
+++ b/cmd/blocks_cmd.go
@@ -76,9 +76,9 @@ var BlocksCommand = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:        "metrics",
-			Usage:       "Metrics to be persisted to the database",
+			Usage:       "Metrics to be persisted to the database: epoch,block,rewards,transactions",
 			EnvVars:     []string{"ANALYZER_METRICS"},
-			DefaultText: "epoch",
+			DefaultText: "epoch,block",
 		},
 		&cli.IntFlag{
 			Name:        "prometheus-port",

--- a/pkg/analyzer/block.go
+++ b/pkg/analyzer/block.go
@@ -70,7 +70,7 @@ func NewChainAnalyzer(
 		log.Infof("generating new Block Analyzer from slots %d:%d", iConfig.InitSlot, iConfig.FinalSlot)
 	}
 
-	metricsObj, err := NewMetrics(iConfig.Metrics)
+	metricsObj, err := db.NewMetrics(iConfig.Metrics)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read metric.")
 	}
@@ -83,7 +83,10 @@ func NewChainAnalyzer(
 	idbClient.Connect()
 
 	// generate the httpAPI client
-	cli, err := clientapi.NewAPIClient(pCtx, iConfig.BnEndpoint, clientapi.WithELEndpoint(iConfig.ElEndpoint))
+	cli, err := clientapi.NewAPIClient(pCtx,
+		iConfig.BnEndpoint,
+		clientapi.WithELEndpoint(iConfig.ElEndpoint),
+		clientapi.WithDBMetrics(metricsObj))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to generate API Client.")
 	}

--- a/pkg/analyzer/block.go
+++ b/pkg/analyzer/block.go
@@ -40,7 +40,7 @@ type ChainAnalyzer struct {
 
 	downloadMode       string
 	validatorWorkerNum int
-	metrics            DBMetrics
+	metrics            db.DBMetrics
 
 	// Control Variables
 	stop              bool

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -43,7 +43,7 @@ loop:
 			s.DownloadNewBlock(&queue, phase0.Slot(slot))
 
 			// if epoch boundary, download state
-			if slot%spec.SlotsPerEpoch == 0 {
+			if slot%spec.SlotsPerEpoch == 0 && slot > 0 {
 				// new epoch
 				s.DownloadNewState(&queue, slot-1, false)
 				// refresh map as we dont need to store the history
@@ -128,7 +128,7 @@ func (s *ChainAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 				s.DownloadNewBlock(&queue, phase0.Slot(nextSlotDownload))
 
 				// if epoch boundary, download state
-				if nextSlotDownload%spec.SlotsPerEpoch == 0 {
+				if nextSlotDownload%spec.SlotsPerEpoch == 0 && nextSlotDownload > 0 {
 					// new epoch
 					s.DownloadNewState(&queue, nextSlotDownload-1, true)
 				}

--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -40,7 +40,6 @@ loop:
 				break loop
 			}
 
-			log.Infof("requesting Beacon Block from endpoint: slot %d", slot)
 			s.DownloadNewBlock(&queue, phase0.Slot(slot))
 
 			// if epoch boundary, download state
@@ -183,6 +182,11 @@ func (s *ChainAnalyzer) runDownloadBlocksFinalized(wgDownload *sync.WaitGroup) {
 }
 
 func (s ChainAnalyzer) DownloadNewBlock(queue *StateQueue, slot phase0.Slot) {
+
+	if !s.metrics.Block {
+		log.Infof("skipping block download at slot %d: no metrics activated for block...", slot)
+		return
+	}
 
 	ticker := time.NewTicker(minBlockReqTime)
 	newBlock, err := s.cli.RequestBeaconBlock(slot)

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -12,7 +12,7 @@ func (s *ChainAnalyzer) DownloadNewState(
 	slot phase0.Slot,
 	finalized bool) {
 
-	if !s.metrics.StateDownload {
+	if !s.metrics.Epoch {
 		log.Infof("skipping state download: no metrics activated for state...")
 		return
 	}

--- a/pkg/analyzer/download_state.go
+++ b/pkg/analyzer/download_state.go
@@ -12,6 +12,10 @@ func (s *ChainAnalyzer) DownloadNewState(
 	slot phase0.Slot,
 	finalized bool) {
 
+	if !s.metrics.StateDownload {
+		log.Infof("skipping state download: no metrics activated for state...")
+		return
+	}
 	log := log.WithField("routine", "download")
 	ticker := time.NewTicker(minStateReqTime)
 

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/spec/metrics"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/utils"
@@ -29,7 +30,10 @@ loop:
 				log.Errorf(err.Error())
 				continue
 			}
-			if task.NextState.Slot <= s.finalSlot || task.Finalized {
+			emptyRoot := phase0.Root{}
+			if (task.NextState.Slot <= s.finalSlot || task.Finalized) &&
+				stateMetrics.GetMetricsBase().PrevState.StateRoot != emptyRoot { // we cannot calculate validator rewards without prevstate
+
 				log.Debugf("Creating validator batches for slot %d...", task.State.Slot)
 				// divide number of validators into number of workers equally
 

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -56,7 +56,7 @@ func (s *StateQueue) AddNewState(newState spec.AgnosticState) {
 
 func (s StateQueue) Complete() bool {
 	emptyRoot := phase0.Root{}
-	if s.prevState.StateRoot != emptyRoot {
+	if s.currentState.StateRoot != emptyRoot { // if we have currentState we can already write epoch metrics
 		return true
 	}
 	return false

--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/http"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/db"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/rs/zerolog"
 	"github.com/sirupsen/logrus"
@@ -21,9 +22,10 @@ var (
 type APIClientOption func(*APIClient) error
 
 type APIClient struct {
-	ctx   context.Context
-	Api   *http.Service     // Beacon Node
-	ELApi *ethclient.Client // Execution Node
+	ctx     context.Context
+	Api     *http.Service     // Beacon Node
+	ELApi   *ethclient.Client // Execution Node
+	Metrics db.DBMetrics
 }
 
 func NewAPIClient(ctx context.Context, bnEndpoint string, options ...APIClientOption) (*APIClient, error) {
@@ -70,6 +72,13 @@ func WithELEndpoint(url string) APIClientOption {
 			return err
 		}
 		s.ELApi = client
+		return nil
+	}
+}
+
+func WithDBMetrics(metrics db.DBMetrics) APIClientOption {
+	return func(s *APIClient) error {
+		s.Metrics = metrics
 		return nil
 	}
 }

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -47,7 +47,7 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, err
 
 	customBlock.StateRoot = s.RequestStateRoot(slot)
 
-	if s.Metrics.RewardsDownload {
+	if s.Metrics.ValidatorRewards {
 		reward, err := s.RequestBlockRewards(slot)
 		if err != nil {
 			log.Error("cannot request block reward: %s", err)
@@ -111,6 +111,11 @@ func (s APIClient) CreateMissingBlock(slot phase0.Slot) spec.AgnosticBlock {
 func (s APIClient) RequestBlockByHash(hash common.Hash) (*types.Block, error) {
 	if s.ELApi == nil {
 		return nil, fmt.Errorf("execution layer client is not initialized")
+	}
+	emptyHash := common.Hash{}
+
+	if hash == emptyHash {
+		return nil, nil // empty hash, not even try (probably we are before Bellatrix)
 	}
 	block, err := s.ELApi.BlockByHash(s.ctx, hash)
 	if err != nil {

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -36,6 +36,7 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, err
 	}
 
 	// fill in block size on custom block using RequestBlockByHash
+	// shows error inside function if ELApi is not defined
 	block, err := s.RequestBlockByHash(common.Hash(customBlock.ExecutionPayload.BlockHash))
 	if err != nil {
 		log.Error("cannot request block by hash: %s", err)
@@ -46,12 +47,14 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, err
 
 	customBlock.StateRoot = s.RequestStateRoot(slot)
 
-	reward, err := s.RequestBlockRewards(slot)
-	if err != nil {
-		log.Error("cannot request block reward: %s", err)
-	}
+	if s.Metrics.RewardsDownload {
+		reward, err := s.RequestBlockRewards(slot)
+		if err != nil {
+			log.Error("cannot request block reward: %s", err)
+		}
 
-	customBlock.Reward = reward
+		customBlock.Reward = reward
+	}
 
 	return customBlock, nil
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -10,6 +10,6 @@ var (
 	DefaultDownloadMode   string = "finalized"
 	DefaultWorkerNum      int    = 4
 	DefaultDbWorkerNum    int    = 4
-	DefaultMetrics        string = "epoch"
+	DefaultMetrics        string = "epoch,block"
 	DefaultPrometheusPort int    = 9080
 )

--- a/pkg/db/metrics.go
+++ b/pkg/db/metrics.go
@@ -24,8 +24,10 @@ func NewMetrics(input string) (DBMetrics, error) {
 			dbMetrics.Epoch = true
 		case "rewards":
 			dbMetrics.ValidatorRewards = true
+			dbMetrics.Epoch = true
 		case "transactions":
 			dbMetrics.Transactions = true
+			dbMetrics.Block = true
 		default:
 			return DBMetrics{}, fmt.Errorf("could not parse metric: %s", item)
 		}

--- a/pkg/db/metrics.go
+++ b/pkg/db/metrics.go
@@ -1,4 +1,4 @@
-package analyzer
+package db
 
 import (
 	"fmt"
@@ -14,6 +14,10 @@ type DBMetrics struct {
 	ValidatorRewards    bool
 	Withdrawals         bool
 	Transactions        bool
+
+	BlockDownload   bool
+	StateDownload   bool
+	RewardsDownload bool
 }
 
 func NewMetrics(input string) (DBMetrics, error) {
@@ -24,18 +28,25 @@ func NewMetrics(input string) (DBMetrics, error) {
 		switch item {
 		case "block":
 			dbMetrics.Block = true
+			dbMetrics.BlockDownload = true
 		case "epoch":
 			dbMetrics.Epoch = true
+			dbMetrics.StateDownload = true
 		case "pool_summary":
 			dbMetrics.PoolSummary = true
 		case "validator_last_status":
 			dbMetrics.ValidatorLastStatus = true
+			dbMetrics.StateDownload = true
 		case "validator":
 			dbMetrics.ValidatorRewards = true
+			dbMetrics.StateDownload = true
+			dbMetrics.RewardsDownload = true
 		case "withdrawals":
 			dbMetrics.Withdrawals = true
+			dbMetrics.BlockDownload = true
 		case "transactions":
 			dbMetrics.Transactions = true
+			dbMetrics.BlockDownload = true
 		default:
 			return DBMetrics{}, fmt.Errorf("could not parse metric: %s", item)
 		}

--- a/pkg/db/metrics.go
+++ b/pkg/db/metrics.go
@@ -6,18 +6,10 @@ import (
 )
 
 type DBMetrics struct {
-	Block               bool
-	Epoch               bool
-	PoolSummary         bool
-	ProposerDuties      bool
-	ValidatorLastStatus bool
-	ValidatorRewards    bool
-	Withdrawals         bool
-	Transactions        bool
-
-	BlockDownload   bool
-	StateDownload   bool
-	RewardsDownload bool
+	Block            bool
+	Epoch            bool
+	ValidatorRewards bool
+	Transactions     bool
 }
 
 func NewMetrics(input string) (DBMetrics, error) {
@@ -28,25 +20,12 @@ func NewMetrics(input string) (DBMetrics, error) {
 		switch item {
 		case "block":
 			dbMetrics.Block = true
-			dbMetrics.BlockDownload = true
 		case "epoch":
 			dbMetrics.Epoch = true
-			dbMetrics.StateDownload = true
-		case "pool_summary":
-			dbMetrics.PoolSummary = true
-		case "validator_last_status":
-			dbMetrics.ValidatorLastStatus = true
-			dbMetrics.StateDownload = true
-		case "validator":
+		case "rewards":
 			dbMetrics.ValidatorRewards = true
-			dbMetrics.StateDownload = true
-			dbMetrics.RewardsDownload = true
-		case "withdrawals":
-			dbMetrics.Withdrawals = true
-			dbMetrics.BlockDownload = true
 		case "transactions":
 			dbMetrics.Transactions = true
-			dbMetrics.BlockDownload = true
 		default:
 			return DBMetrics{}, fmt.Errorf("could not parse metric: %s", item)
 		}


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
After joining both routines into one, now the main routine downloads both blocks and states.
However, it may be possible that a user only wants metrics about one of them, making it useless to download both structures, which takes time and resources. It is our intention with this feature to only download needed structures for the specified metrics.


_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->

We will read the metrics inserted by the user and evaluate which structures need to be downloaded. We will also restrict some metrics persisting if they consume too much disk (for example, not write validator metrics if the user did not specify them).

# Tasks
<!-- Checklist of tasks to do -->
- [x] Evaluate which structures need to be downloaded based on metrics argument
- [x] Apply those conditionals in the code
- [x] Also condition metrics storage based on the metrics   

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

```
analyzer_1  | time="2023-08-30T09:27:23Z" level=info msg="block at slot 5909532 downloaded in 0.016796 seconds" module=api-cli
analyzer_1  | time="2023-08-30T09:27:23Z" level=info msg="requesting Beacon Block from endpoint: slot 5909533" module=analyzer
analyzer_1  | time="2023-08-30T09:27:23Z" level=info msg="block at slot 5909533 downloaded in 0.017210 seconds" module=api-cli
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="requesting Beacon Block from endpoint: slot 5909534" module=analyzer
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="block at slot 5909534 downloaded in 0.014532 seconds" module=api-cli
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="requesting Beacon Block from endpoint: slot 5909535" module=analyzer
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="block at slot 5909535 downloaded in 0.010085 seconds" module=api-cli
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="requesting Beacon Block from endpoint: slot 5909536" module=analyzer
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="block at slot 5909536 downloaded in 0.010272 seconds" module=api-cli
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="skipping state download: no metrics activated for state..." module=analyzer
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="requesting Beacon Block from endpoint: slot 5909537" module=analyzer
analyzer_1  | time="2023-08-30T09:27:24Z" level=info msg="block at slot 5909537 downloaded in 0.012847 seconds" module=api-cli

```
