### PR TITLE
Feat/extend batch tracked errors

### DIFF
--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -93,7 +93,7 @@ func (q *QueryBatch) persistBatch() error {
 	var rows pgx.Rows
 	nextQuery := true
 	cnt := 0
-	for nextQuery {
+	for nextQuery && qerr == nil {
 		rows, qerr = batchResults.Query()
 		nextQuery = rows.Next() // it closes all the rows if all the rows are readed
 		cnt++
@@ -109,11 +109,11 @@ func (q *QueryBatch) persistBatch() error {
 	}
 	if ctx.Err() == context.DeadlineExceeded {
 		log.WithFields(log.Fields{
-			"error":  qerr.Error(),
+			"error":  ctx.Err().Error(),
 			"query":  q.persistables[cnt-1].query,
 			"values": q.persistables[cnt-1].values,
 		}).Errorf("timed-out (query number %d)", cnt-1)
-		return errors.Wrap(qerr, "error persisting batch")
+		return errors.Wrap(ctx.Err(), "error persisting batch")
 	}
 	return nil
 }

--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -112,7 +112,7 @@ func (q *QueryBatch) persistBatch() error {
 			"error":  ctx.Err().Error(),
 			"query":  q.persistables[cnt-1].query,
 			"values": q.persistables[cnt-1].values,
-		}).Errorf("timed-out (query number %d)", cnt-1)
+		}).Errorf("timed-out [query %d]", cnt-1)
 		return errors.Wrap(ctx.Err(), "error persisting batch")
 	}
 	return nil

--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -107,7 +107,7 @@ func (q *QueryBatch) persistBatch() error {
 		}).Errorf("unable to persist query [%d]", cnt-1)
 		return errors.Wrap(qerr, "error persisting batch")
 	}
-	if ctx.Err() != nil {
+	if ctx.Err() == context.DeadlineExceeded {
 		log.WithFields(log.Fields{
 			"error":  qerr.Error(),
 			"query":  q.persistables[cnt-1].query,

--- a/pkg/db/batcher.go
+++ b/pkg/db/batcher.go
@@ -107,6 +107,14 @@ func (q *QueryBatch) persistBatch() error {
 		}).Errorf("unable to persist query [%d]", cnt-1)
 		return errors.Wrap(qerr, "error persisting batch")
 	}
+	if ctx.Err() != nil {
+		log.WithFields(log.Fields{
+			"error":  qerr.Error(),
+			"query":  q.persistables[cnt-1].query,
+			"values": q.persistables[cnt-1].values,
+		}).Errorf("timed-out (query number %d)", cnt-1)
+		return errors.Wrap(qerr, "error persisting batch")
+	}
 	return nil
 }
 

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -221,6 +221,7 @@ func (p *PostgresDBService) runWriters() {
 						wlog.Tracef("flushing batcher")
 						err := batcher.PersistBatch()
 						if err != nil {
+							wlogWriter.Errorf("Error processing batch", err.Error())
 						}
 					}
 

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -208,7 +208,7 @@ func (p *PostgresDBService) runWriters() {
 					if batcher.IsReadyToPersist() {
 						err := batcher.PersistBatch()
 						if err != nil {
-							wlogWriter.Errorf("Error processing batch", err.Error())
+							wlogWriter.Error("Error processing batch", err.Error())
 						}
 					}
 
@@ -221,7 +221,7 @@ func (p *PostgresDBService) runWriters() {
 						wlog.Tracef("flushing batcher")
 						err := batcher.PersistBatch()
 						if err != nil {
-							wlogWriter.Errorf("Error processing batch", err.Error())
+							wlogWriter.Error("Error processing batch", err.Error())
 						}
 					}
 


### PR DESCRIPTION
# Motivation
As the complexity of the tool evolves and the disk requirements to keep track of the new functionalities evolve with it, there is a huge need to simplify or aggregate the amount of data we keep.  
Following this philosophy, PR #69 tried to aggregate all the metrics of the validators (which take the biggest part of the db) by the pool they belong to.
 
# Description
With the aggregation of the `pool_summary` table, the [SQL triggered](https://github.com/migalabs/goteth/blob/7673df250e891a0b68c08589ec99221f151fa7fc/pkg/db/migrations/000025_create_summary_trigger.up.sql#L55) was included. Unfortunately, it had a wrong join directive that was causing deadlocks internally in the DB driver, causing the SQL batching to crash without any reported error.

This PR addresses this kind of scenario by checking if the batching was completed successfully or due to a `timeout` of the context.

# Tasks
- [x] track if the timeout was triggered during the `SendBatch()` method
- [x] add missing error log when flashing the batched queries 

# Proof of Success 
```
goteth-experimental-analyzer-1  | time="2023-09-14T10:12:56Z" level=error msg="unable to persist query [0]" error="ERROR: permission denied for table t_eth2_pubkeys (SQLSTATE 42501)" query="\n\tINSERT INTO t_epoch_metrics_summary (\n\t\tf_epoch, \n\t\tf_slot, \n\t\tf_num_att, \n\t\tf_num_att_vals, \n\t\tf_num_vals, \n\t\tf_total_balance_eth,\n\t\tf_att_effective_balance_eth,  \n\t\tf_total_effective_balance_eth, \n\t\tf_missing_source, \n\t\tf_missing_target, \n\t\tf_missing_head)\n\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n\t\tON CONFLICT ON CONSTRAINT PK_Epoch\n\t\tDO \n\t\t\tUPDATE SET \n\t\t\t\tf_num_att = excluded.f_num_att, \n\t\t\t\tf_num_att_vals = excluded.f_num_att_vals,\n\t\t\t\tf_num_vals = excluded.f_num_vals,\n\t\t\t\tf_total_balance_eth = excluded.f_total_balance_eth,\n\t\t\t\tf_att_effective_balance_eth = excluded.f_att_effective_balance_eth,\n\t\t\t\tf_total_effective_balance_eth = excluded.f_total_effective_balance_eth,\n\t\t\t\tf_missing_source = excluded.f_missing_source,\n\t\t\t\tf_missing_target = excluded.f_missing_target,\n\t\t\t\tf_missing_head = excluded.f_missing_head;\n\t" values="[203582 6514655 0 419819 515119 1.7165026e+07 1.3430114e+07 1.6431349e+07 117787 95300 199206]"
goteth-experimental-analyzer-1  | time="2023-09-14T10:12:56Z" level=error msg="Error processing batchunable to persist batch query: error persisting batch: ERROR: permission denied for table t_eth2_pubkeys (SQLSTATE 42501)" DBWriter=1 module=postgres-db
```

