### PR TITLE
Fix block number and timestamp not stored in the transactions table

### DIFF
--- a/pkg/analyzer/download_blocks.go
+++ b/pkg/analyzer/download_blocks.go
@@ -210,8 +210,10 @@ func (s ChainAnalyzer) DownloadNewBlock(queue *StateQueue, slot phase0.Slot) {
 		for _, tx := range newBlock.ExecutionPayload.Transactions {
 			log.Tracef("sending a new tx task for slot %d", slot)
 			s.transactionTaskChan <- &TransactionTask{
-				Slot:        slot,
-				Transaction: tx,
+				Slot:           slot,
+				Transaction:    tx,
+				BlockNumber:    newBlock.ExecutionPayload.BlockNumber,
+				BlockTimestamp: newBlock.ExecutionPayload.Timestamp,
 			}
 		}
 	}


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
We recently encountered that some transactions did not have a block number and timestamp.
We have identified the issue and this pull request should correct it.
_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
In order to solve the issue we simply needed to pass the arguments to the transaction task.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Give arguments to task 

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

Some random slot
![image](https://github.com/migalabs/goteth/assets/18716811/562c68df-b113-4bbc-95a6-a092bdab5098)

