### PR TITLE
Add DB integrity checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,20 @@
-results/
 eth2-state-analyzer
-.vscode/**
 test*.json
 .ipynb_checkpoints/**
 metrika/**
-.config
+
+# results
+results/
 *.csv
+
+# configurations
+.config
 .env
+
+# IDE configurations
+.idea
+.vscode/**
+
+# DB Testing
+**/venv
+**/__pycache__

--- a/tests/.env-example
+++ b/tests/.env-example
@@ -1,0 +1,5 @@
+DB_USER="user"
+DB_PASSWORD="password"
+DB_HOST="localhost"
+DB_PORT="5432"
+DB_DATABASE="database_name"

--- a/tests/db_blocks_test.py
+++ b/tests/db_blocks_test.py
@@ -1,0 +1,69 @@
+import unittest
+import unit_db_test.testcase as dbtest
+
+class CheckIntegrityOfDB(dbtest.DBintegrityTest):
+    db_config_file = ".env"
+
+    def test_orphan_blocks_in_block_metrics(self):
+        """ Edgy case where two blocks are assigned to the same slot (one of them is an orphan) """
+        sql_query = """
+        select f_el_block_number, count(*)
+        from t_block_metrics
+        where f_proposed = true
+        group by f_el_block_number
+        having count(*) > 1
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    def test_missed_blocks_tagged_as_orphan(self):
+        """ Edgy case where a missed blocks is added to the orphan table """
+        sql_query = """
+        select *
+        from t_orphans
+        where f_proposed = false
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    def test_transactions_per_block(self):
+        """ make sure that the number of tracked transactions match the ones included in the corresponding block """
+        sql_query = """
+        select t_block_metrics.f_slot, count(distinct(f_hash))
+        from t_block_metrics
+        inner join t_transactions
+        on t_block_metrics.f_slot = t_transactions.f_slot
+        group by t_block_metrics.f_slot
+        having f_el_transactions != count(distinct(f_hash))
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    def test_block_gaps(self):
+        """ make sure that there are no gaps between the indexed blocks """
+        sql_query = """
+        WITH Gaps AS (
+            SELECT
+                f_el_block_number AS preceding_block,
+                LEAD(f_el_block_number) OVER (ORDER BY f_el_block_number) - 1 AS end_of_missing_range
+            FROM
+                t_block_metrics
+            WHERE f_el_block_number > 16307594
+        )
+        SELECT
+            preceding_block + 1 AS start_of_missing_range,
+            end_of_missing_range
+        FROM
+            Gaps
+        WHERE
+            end_of_missing_range - preceding_block > 1
+        ORDER BY
+            preceding_block;        
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/tests/db_validator_test.py
+++ b/tests/db_validator_test.py
@@ -1,0 +1,41 @@
+import unittest
+import unit_db_test.testcase as dbtest
+
+class CheckIntegrityOfDB(dbtest.DBintegrityTest):
+    db_config_file = ".env"
+
+    def test_orphan_blocks_in_block_metrics(self):
+        """ After the last update to v2.0.0 the rewards must never exceed the f_max_reward """
+        sql_query = """
+        select *
+        from t_validator_rewards_summary
+        where (f_status = 1 or f_status = 3) and abs(f_reward) > abs(f_max_reward)
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    def test_unpersisted_queries_for_validator_duties(self):
+        """ There shouldn't be less proposer duties than the 32 slots per epoch, if so, there were some DB queries lost on the way """
+        sql_query = """
+        select f_proposed, count(*)
+        from t_proposer_duties
+        group by f_proposed
+        having count(*) < 32 
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    def test_craicy_error_tracking_validator_duties(self):
+        """ We could expect less that 32 duties/epoch because some queries were lost, but if we have more, there is something weird going on """
+        sql_query = """
+        select f_proposed, count(*)
+        from t_proposer_duties
+        group by f_proposed
+        having count(*) > 32 
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,12 @@
+greenlet==2.0.2
+numpy==1.24.4
+pandas==2.0.3
+psycopg2-binary==2.9.7
+python-dateutil==2.8.2
+python-dotenv==1.0.0
+pytz==2023.3.post1
+six==1.16.0
+SQLAlchemy==2.0.21
+typing_extensions==4.8.0
+tzdata==2023.3
+unit-db-test==0.1.12


### PR DESCRIPTION
# Motivation
With the large updates that the tool has received in the last 2-3 months, our production DB has been filled with many different versions of GotEth. This makes it susceptible to data misalignments generated from broken changes or simply process updates. There is a huge need to integrate a DB integrity checker that can:
- Help identify anomalies in the stored data
- Test that newer versions of the tool don't break anything that was previously working well

 
# Description
This PR adds a new folder with some basic `unit tests` that can be triggered about any given DB. It's written in Python and relies on `unittest` and our `unit-db-test` module, created explicitly for this purpose. 
At this moment, the tests need to be run locally:
```sh
cd tests
pip install -r requirements.txt
python -m unittest <test.py>
``` 
More info can be found [here](https://github.com/cortze/unit-db-test)
Most tests might take a while due to the complexity of the queries (be patient)

IMPORTANT: the test reads the Postgres DB connection from the `.env` file; please update the credentials with the correct ones :)

# Tasks
- [x] Create a baseline for testing data about blocks and validators (thanks @tdahar for handling the queries)
- [x] Prepare the `requirements.txt`
- [x] Test it

# Future Work
It would be nice to integrate this in the GitHub Actions, but that would require having a dedicated server that can run GotEth for 3-4 hours and then run the tests :)

# Proof of Success 
I've been able to find a few errors so far in the `test_db`: (launching the tests should look something like this)
```Python
$ python -m unittest db_blocks_test.py 
FF.F
======================================================================
FAIL: test_block_gaps (db_blocks_test.CheckIntegrityOfDB)
make sure that there are no gaps between the indexed blocks
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cortze/devel/migalabs/goteth/tests/db_blocks_test.py", line 64, in test_block_gaps
    self.assertNoRows(df)
  File "/home/cortze/devel/migalabs/goteth/tests/venv/lib/python3.10/site-packages/unit_db_test/testcase.py", line 56, in assertNoRows
    self.assertNRows(df, 0)
  File "/home/cortze/devel/migalabs/goteth/tests/venv/lib/python3.10/site-packages/unit_db_test/testcase.py", line 60, in assertNRows
    raise AssertionError(f"df has {len(df)} rows, expected {target_rows}\n{self.addDFtoLog(df)}")
AssertionError: df has 2 rows, expected 0

DF that generated the error:
   start_of_missing_range  end_of_missing_range
0                18167602              18167603
1                18176922              18176923

======================================================================
FAIL: test_missed_blocks_tagged_as_orphan (db_blocks_test.CheckIntegrityOfDB)
Edgy case where a missed blocks is added to the orphan table
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cortze/devel/migalabs/goteth/tests/db_blocks_test.py", line 27, in test_missed_blocks_tagged_as_orphan
    self.assertNoRows(df)
  File "/home/cortze/devel/migalabs/goteth/tests/venv/lib/python3.10/site-packages/unit_db_test/testcase.py", line 56, in assertNoRows
    self.assertNRows(df, 0)
  File "/home/cortze/devel/migalabs/goteth/tests/venv/lib/python3.10/site-packages/unit_db_test/testcase.py", line 60, in assertNRows
    raise AssertionError(f"df has {len(df)} rows, expected {target_rows}\n{self.addDFtoLog(df)}")
AssertionError: df has 20 rows, expected 0

DF that generated the error:
    f_timestamp  f_epoch   f_slot f_graffiti  f_proposer_index  f_proposed  ...  f_el_gas_used  f_el_base_fee_per_gas                                    f_el_block_hash  f_el_transactions  f_el_block_number  f_size_bytes
0             0   219459  7022688                       422187       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
1             0   220115  7043680                       578296       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
2             0   220532  7057025                       581896       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
3             0   220909  7069088                       250697       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
4             0   221389  7084448                       278169       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
5             0   221456  7086593                       128605       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
6             0   221924  7101568                       259656       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
7             0   222022  7104704                       608125       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
8             0   222570  7122241                       330834       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
9             0   222631  7124192                       436839       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
10            0   222659  7125089                       171107       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
11            0   222926  7133633                       791069       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
12            0   222976  7135233                       705779       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
13            0   223160  7141121                        26466       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
14            0   223534  7153089                        43680       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
15            0   224090  7170881                       761514       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
16            0   225764  7224448                       124785       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
17            0   225765  7224480                       555747       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
18            0   225892  7228545                        15050       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0
19            0   229850  7355200                       574106       False  ...              0                      0  0x00000000000000000000000000000000000000000000...                  0                  0           0.0

[20 rows x 20 columns]

======================================================================
FAIL: test_transactions_per_block (db_blocks_test.CheckIntegrityOfDB)
make sure that the number of tracked transactions match the ones included in the corresponding block
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cortze/devel/migalabs/goteth/tests/db_blocks_test.py", line 40, in test_transactions_per_block
    self.assertNoRows(df)
  File "/home/cortze/devel/migalabs/goteth/tests/venv/lib/python3.10/site-packages/unit_db_test/testcase.py", line 56, in assertNoRows
    self.assertNRows(df, 0)
  File "/home/cortze/devel/migalabs/goteth/tests/venv/lib/python3.10/site-packages/unit_db_test/testcase.py", line 60, in assertNRows
    raise AssertionError(f"df has {len(df)} rows, expected {target_rows}\n{self.addDFtoLog(df)}")
AssertionError: df has 1 rows, expected 0

DF that generated the error:
    f_slot  count
0  7318974     89

----------------------------------------------------------------------
Ran 4 tests in 433.718s

FAILED (failures=3)
```

