### PR TITLE
Test non-existent tx data for tracked blocks

### DIFF
--- a/tests/db_blocks_test.py
+++ b/tests/db_blocks_test.py
@@ -5,11 +5,11 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
     db_config_file = ".env"
 
     def test_orphan_blocks_in_block_metrics(self):
-        """ Edgy case where two blocks are assigned to the same slot (one of them is an orphan) """
+        """ Edgy case where two blocks are assigned to the same slot (one of them is an orphan) (after Merge) """
         sql_query = """
         select f_el_block_number, count(*)
         from t_block_metrics
-        where f_proposed = true
+        where f_proposed = true and f_slot > 4700012
         group by f_el_block_number
         having count(*) > 1
         """
@@ -22,19 +22,6 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
         select *
         from t_orphans
         where f_proposed = false
-        """
-        df = self.db.get_df_from_sql_query(sql_query)
-        self.assertNoRows(df)
-
-    def test_transactions_per_block(self):
-        """ make sure that the number of tracked transactions match the ones included in the corresponding block """
-        sql_query = """
-        select t_block_metrics.f_slot, count(distinct(f_hash))
-        from t_block_metrics
-        inner join t_transactions
-        on t_block_metrics.f_slot = t_transactions.f_slot
-        group by t_block_metrics.f_slot
-        having f_el_transactions != count(distinct(f_hash))
         """
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)
@@ -63,19 +50,6 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)
 
-    def test_missing_transactions_from_block(self):
-        """ Check if there are no blocks that is not present in the transaction table, but had transactions and was proposed """
-        sql_query = """
-        select *
-        from t_block_metrics
-        where f_slot not in (
-            select distinct(f_slot)
-            from t_transactions
-        ) and f_el_transactions > 0 and f_proposed = true
-        order by f_slot desc
-        """
-        df = self.db.get_df_from_sql_query(sql_query)
-        self.assertNoRows(df)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/db_blocks_test.py
+++ b/tests/db_blocks_test.py
@@ -63,6 +63,20 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)
 
+    def test_missing_transactions_from_block(self):
+        """ Check if there are no blocks that is not present in the transaction table, but had transactions and was proposed """
+        sql_query = """
+        select *
+        from t_block_metrics
+        where f_slot not in (
+            select distinct(f_slot)
+            from t_transactions
+        ) and f_el_transactions > 0 and f_proposed = true
+        order by f_slot desc
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/db_transactions_test.py
+++ b/tests/db_transactions_test.py
@@ -1,0 +1,49 @@
+import unittest
+import unit_db_test.testcase as dbtest
+
+class CheckIntegrityOfDB(dbtest.DBintegrityTest):
+    db_config_file = ".env"
+
+    def test_transactions_per_block(self):
+        """ make sure that the number of tracked transactions match the ones included in the corresponding block """
+        sql_query = """
+        select t_block_metrics.f_slot, count(distinct(f_hash))
+        from t_block_metrics
+        inner join t_transactions
+        on t_block_metrics.f_slot = t_transactions.f_slot
+        group by t_block_metrics.f_slot
+        having f_el_transactions != count(distinct(f_hash))
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    def test_missing_transactions_from_existing_blocks(self):
+        """ Check if there are no blocks that aren't present in the transaction table, but had transactions and was proposed """
+        sql_query = """
+       select *
+       from t_block_metrics
+       where f_slot not in (
+           select distinct(f_slot)
+           from t_transactions
+       ) and f_el_transactions > 0 and f_proposed = true
+       order by f_slot desc
+       """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    def test_number_of_blocks_across_tables(self):
+        """The test ensures that the are the same number of blocks in across the existing tables"""
+        sql_query = """
+        select *
+        from t_transactions
+        inner join t_block_metrics
+        on t_transactions.f_slot = t_block_metrics.f_slot
+        where f_el_transactions = 0 or f_proposed = false
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/tests/db_validator_test.py
+++ b/tests/db_validator_test.py
@@ -17,21 +17,21 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
     def test_unpersisted_queries_for_validator_duties(self):
         """ There shouldn't be less proposer duties than the 32 slots per epoch, if so, there were some DB queries lost on the way """
         sql_query = """
-        select f_proposed, count(*)
+        select f_proposer_slot/32 as epoch, count(*)
         from t_proposer_duties
-        group by f_proposed
-        having count(*) < 32 
+        group by f_proposer_slot/32
+        having count(*) < 32
         """
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)
 
-    def test_craicy_error_tracking_validator_duties(self):
+    def test_weird_error_tracking_validator_duties(self):
         """ We could expect less that 32 duties/epoch because some queries were lost, but if we have more, there is something weird going on """
         sql_query = """
-        select f_proposed, count(*)
+        select f_proposer_slot/32 as epoch, count(*)
         from t_proposer_duties
-        group by f_proposed
-        having count(*) > 32 
+        group by f_proposer_slot/32
+        having count(*) > 32
         """
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)


### PR DESCRIPTION
# Motivation
having too many versions of GotEth coexisting in the  Database might lead to have data-holes or gaps that make the analysis of data a bit difficult. This can also happen across multiple tables, i.e., if we indexed slots 1.000-5.000 with blocks but not transactions and 5.000-10.000 with Tx, we can't take for analysis the entire range 1.000-10.000.  

_Related links:_
- Extension of #75  

# Description
This PR focuses on adding more DB integrity checks to ensure the cohesion of the Database.

# Tasks
- [x] Make sure that if we tracked a block that had transactions, the transactions are present in the respective table linked to the block

# Proof of Success 
Prior:
```
Failure
Traceback (most recent call last):
  File "/home/cortze/devel/migalabs/goteth/tests/db_blocks_test.py", line 78, in test_missing_transactions_from_block
    self.assertNoRows(df)
AssertionError: df has 1 rows, expected 0

DF that generated the error:
   f_timestamp  f_epoch  ...  f_el_block_number f_size_bytes
0   1691327495   220061  ...           17856133    1452623.0

[1 rows x 20 columns]
```

Fixed:
```
Ran 1 test in 16.784s

OK

Process finished with exit code 0
```
