### PR TITLE
Allow one validator to be proposer several times in epoch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       --metrics=${ANALYZER_METRICS}
       --prometheus-port=${BLOCK_PROMETHEUS_PORT:-9081}
     network_mode: 'host'
-    restart: unless-stopped
                 
 
                 

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -27,7 +27,6 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, err
 		return spec.AgnosticBlock{}, fmt.Errorf("unable to retrieve Beacon Block at slot %d: %s", slot, err.Error())
 	}
 
-	log.Infof("block at slot %d downloaded in %f seconds", slot, time.Since(startTime).Seconds())
 	customBlock, err := spec.GetCustomBlock(*newBlock)
 
 	if err != nil {
@@ -55,6 +54,7 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, err
 
 		customBlock.Reward = reward
 	}
+	log.Infof("block at slot %d downloaded in %f seconds", slot, time.Since(startTime).Seconds())
 
 	return customBlock, nil
 }

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -28,29 +28,19 @@ func (p AltairMetrics) GetMetricsBase() StateMetricsBase {
 
 // TODO: to be implemented once we can process each block
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#modified-process_attestation
-func (p AltairMetrics) GetMaxProposerAttReward(valIdx phase0.ValidatorIndex) (phase0.Gwei, phase0.Slot) {
+func (p AltairMetrics) GetProposerApiReward(valIdx phase0.ValidatorIndex) phase0.Gwei {
 
-	proposerSlot := phase0.Slot(0)
+	reward := phase0.Gwei(0)
 
 	duties := p.baseMetrics.NextState.EpochStructs.ProposerDuties
 	// validator will only have duties it is active at this point
 	for _, duty := range duties {
 		if duty.ValidatorIndex == phase0.ValidatorIndex(valIdx) {
-			proposerSlot = duty.Slot
+			reward += phase0.Gwei(p.baseMetrics.NextState.Blocks[duty.Slot%spec.SlotsPerEpoch].Reward.Data.Total)
 			break
 		}
 	}
-	reward := p.baseMetrics.NextState.Blocks[proposerSlot%spec.SlotsPerEpoch].Reward.Data.Attestations
-
-	return phase0.Gwei(reward), proposerSlot
-
-}
-
-// TODO: to be implemented once we can process each block
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#sync-aggregate-processing
-func (p AltairMetrics) GetMaxProposerSyncReward(proposerSlot phase0.Slot) phase0.Gwei {
-
-	return phase0.Gwei(p.baseMetrics.NextState.Blocks[proposerSlot%spec.SlotsPerEpoch].Reward.Data.SyncAggregate)
+	return phase0.Gwei(reward)
 
 }
 
@@ -125,12 +115,7 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		inSyncCommitte = true
 	}
 
-	_, proposerSlot := p.GetMaxProposerAttReward(
-		valIdx)
-	proposerReward := phase0.Gwei(0)
-	if proposerSlot > 0 {
-		proposerReward = phase0.Gwei(p.baseMetrics.NextState.Blocks[proposerSlot%spec.SlotsPerEpoch].Reward.Data.Total)
-	}
+	proposerReward := p.GetProposerApiReward(valIdx)
 
 	maxReward := flagIndexMaxReward + syncComMaxReward + proposerReward
 
@@ -150,7 +135,6 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		MissingHead:         flags[2],
 		Status:              p.baseMetrics.NextState.GetValStatus(valIdx),
 		BaseReward:          baseReward,
-		ProposerSlot:        proposerSlot,
 		ProposerReward:      int64(proposerReward),
 		InSyncCommittee:     inSyncCommitte,
 	}

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -37,7 +37,6 @@ func (p AltairMetrics) GetProposerApiReward(valIdx phase0.ValidatorIndex) phase0
 	for _, duty := range duties {
 		if duty.ValidatorIndex == phase0.ValidatorIndex(valIdx) {
 			reward += phase0.Gwei(p.baseMetrics.NextState.Blocks[duty.Slot%spec.SlotsPerEpoch].Reward.Data.Total)
-			break
 		}
 	}
 	return phase0.Gwei(reward)


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
Until now the rewards calculation only contemplated that a validator would be proposer only once maximum in an epoch.
However, we recently discovered this is not true, one validator can be chosen to propose several blocks in the same epoch (although very unlikely).
This PR aims to solve this issue and aggregate rewards accordingly.


_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->

The max block rewards methods must disappear and only leave one method which should return the reward obtained from the block API endpoint (included in the block data structure)

# Tasks
<!-- Checklist of tasks to do -->
- [x] Remove old methods (max block rewards)
- [x] Add a new method to get the block API rewards
- [x] Remove proposer slot from the end result (not used anymore in the validators table)   

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

The error came at this row:
Validator `102082` was proposer twice in epoch [229444](https://beaconcha.in/epoch/229444)
![image](https://github.com/migalabs/goteth/assets/18716811/3dc1b13e-13cd-4c34-a498-e1223cc2c17b)

Solved here
![image](https://github.com/migalabs/goteth/assets/18716811/940080d7-dec1-4d09-a884-bb709c0a8d4e)

