### PR TITLE
Use direct migrate.ErrNoChange for specific Error check case

### DIFF
--- a/pkg/db/migrate.go
+++ b/pkg/db/migrate.go
@@ -17,7 +17,7 @@ func (s *PostgresDBService) makeMigrations() {
 	}
 	wlog.Infof("applying database migrations...")
 	if err := m.Up(); err != nil {
-		if err.Error() != "no change" {
+		if err != migrate.ErrNoChange {
 			wlog.Fatalf(err.Error())
 		}
 	}


### PR DESCRIPTION
# Description
To prevent a broken change with future `migrate` package versions, use the original `migrate.ErrNoChange` error on the error check.

# Proof of Success 

