### PR TITLE
Feat/optional api rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ make install
 - block: downloads withdrawals, blocks and block rewards
 - epoch: download epoch metrics, proposer duties, validator last status,
 - rewards: persists validator rewards metrics to database (activates epoch metrics)
+- api_rewards: block rewards are hard to calculate, but they can be downloaded from the Beacon API. However, keep in mind this takes a few seconds per block when not at the head. Without this, reward cannot be compared to max_reward when a validator is a proposer (32/900K validators in an epoch).
 - transactions: requests transaction receipts from the execution layer (activates block metrics)
 
 ### Running the tool

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 // indirect
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
 	github.com/r3labs/sse/v2 v2.10.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/crypto v0.10.0 // indirect

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -46,7 +46,7 @@ func (s APIClient) RequestBeaconBlock(slot phase0.Slot) (spec.AgnosticBlock, err
 
 	customBlock.StateRoot = s.RequestStateRoot(slot)
 
-	if s.Metrics.ValidatorRewards {
+	if s.Metrics.APIRewards {
 		reward, err := s.RequestBlockRewards(slot)
 		if err != nil {
 			log.Error("cannot request block reward: %s", err)

--- a/pkg/db/metrics.go
+++ b/pkg/db/metrics.go
@@ -9,6 +9,7 @@ type DBMetrics struct {
 	Block            bool
 	Epoch            bool
 	ValidatorRewards bool
+	APIRewards       bool
 	Transactions     bool
 }
 
@@ -22,9 +23,13 @@ func NewMetrics(input string) (DBMetrics, error) {
 			dbMetrics.Block = true
 		case "epoch":
 			dbMetrics.Epoch = true
+			dbMetrics.Block = true
 		case "rewards":
 			dbMetrics.ValidatorRewards = true
 			dbMetrics.Epoch = true
+			dbMetrics.Block = true
+		case "api_rewards":
+			dbMetrics.APIRewards = true
 		case "transactions":
 			dbMetrics.Transactions = true
 			dbMetrics.Block = true


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->

We recently introduced downloading the block reward from the Beacon API. This is possible to be done with block, attestations and sync committees.
However, we have experienced this to be very slow when running historical blocks. This why we would like to enable a flag to download rewards from the API or not.

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
We aim to add a new flag `api_rewards`, which enables downloading block API rewards. When not enabled, rewards from block proposers cannot be compared to the max reward (32/900k validators in the epoch).

# Tasks
<!-- Checklist of tasks to do -->
- [x] Add a new flag in the metrics argument
- [x] Use this flag as condition when processing new blocks  

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

Before:

```
goteth_1  | time="2023-10-02T13:17:15Z" level=info msg="Launching Beacon Block Processor" module=analyzer
goteth_1  | time="2023-10-02T13:17:15Z" level=info msg="Launching Beacon Block Requester" module=analyzer
goteth_1  | time="2023-10-02T13:17:15Z" level=info msg="prometheus metrics listening on: 0.0.0.0:9081"
goteth_1  | time="2023-10-02T13:17:15Z" level=info msg="initializing exporter last_processed_slot"
goteth_1  | time="2023-10-02T13:17:15Z" level=info msg="initializing exporter last_processed_epoch"
goteth_1  | time="2023-10-02T13:17:15Z" level=info msg="Launching Beacon State Pre-Processer" module=analyzer
goteth_1  | time="2023-10-02T13:17:19Z" level=info msg="block at slot 7342108 downloaded in 3.616589 seconds" module=api-cli
goteth_1  | time="2023-10-02T13:17:23Z" level=info msg="block at slot 7342108 downloaded in 3.851762 seconds" module=api-cli
```

After:

```
goteth_1  | time="2023-10-02T13:21:46Z" level=info msg="block at slot 7342108 downloaded in 0.165984 seconds" module=api-cli
goteth_1  | time="2023-10-02T13:21:47Z" level=info msg="block at slot 7342109 downloaded in 0.095556 seconds" module=api-cli
goteth_1  | time="2023-10-02T13:21:47Z" level=info msg="block at slot 7342110 downloaded in 0.086756 seconds" module=api-cli
goteth_1  | time="2023-10-02T13:21:47Z" level=info msg="block at slot 7342111 downloaded in 0.135713 seconds" module=api-cli
goteth_1  | time="2023-10-02T13:21:47Z" level=info msg="block at slot 7342112 downloaded in 0.204514 seconds" module=api-cli
```
![image](https://github.com/migalabs/goteth/assets/18716811/c260ce52-1c3f-4e6d-ad4a-db1e85423213)



