### PR TITLE
Feat/add generic map

### DIFF
--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -15,7 +15,7 @@ func (s *ChainAnalyzer) ProcessBlock(slot phase0.Slot) {
 	routineKey := "slot=" + fmt.Sprintf("%d", slot)
 	s.processerBook.Acquire(routineKey) // register a new slot to process, good for monitoring
 
-	block := s.queue.BlockHistory.Wait(slot)
+	block := s.queue.BlockHistory.Wait(SlotTo[uint64](slot))
 	s.dbClient.Persist(block)
 
 	if s.metrics.Transactions {

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -27,12 +27,12 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 
 	// this state may never be downloaded if it is below initSlot
 	if epoch-2 >= 0 && epoch-2 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
-		prevState = s.queue.StateHistory.Wait(epoch - 2)
+		prevState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch) - 2)
 	}
 	if epoch-1 >= 0 && epoch-1 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
-		currentState = s.queue.StateHistory.Wait(epoch - 1)
+		currentState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch) - 1)
 	}
-	nextState = s.queue.StateHistory.Wait(epoch)
+	nextState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch))
 
 	bundle, err := metrics.StateMetricsByForkVersion(nextState, currentState, prevState, s.cli.Api)
 	if err != nil {

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -130,7 +130,7 @@ func (m *AgnosticMap[T]) Wait(key uint64) T {
 	var item T
 	select {
 	case <-ticker.C:
-		log.Fatalf("Waiting for too long for slot %d...", key)
+		log.Fatalf("Waiting for too long for %T %d...", *new(T), key)
 		return item
 	case item = <-ch:
 		return item
@@ -141,7 +141,7 @@ func (m *AgnosticMap[T]) Delete(key uint64) {
 	m.Lock()
 	prevItem, ok := m.m[key]
 	if ok {
-		m.setCollisionF(prevItem)
+		m.deleteF(prevItem)
 	}
 	delete(m.m, key)
 	delete(m.subs, key)


### PR DESCRIPTION
# Description
Making a map to handle asynchronously block and state downloads and processing is cool, being able to reduce the total codebase is even cooler ; ) 
This PR merge both `BlockMap` and `StateMap` into a generic Map (`AgnosticMap`) that could be anyone of them.
NOTE: this could be extrapolated to `[T any]` if there is interest in doing so. 

_Related links:_
- #84 

# Tasks
- [x] Add generic `AgnosticMap`
- [x] add `setCollisionF` and `deleteF` in case we want any specific function to be executed in any of the cases

# Proof of Success 
compiles and keeps the exact same logic as before, thus, should be fine to test
