### PR TITLE
Add Finalized checker in async routine (step1)

### DIFF
--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -127,6 +127,7 @@ func NewChainAnalyzer(
 
 	analyzerMet := analyzer.GetPrometheusMetrics()
 	promethMetrics.AddMeticsModule(analyzerMet)
+	promethMetrics.AddMeticsModule(analyzer.processerBook.GetPrometheusMetrics())
 
 	return analyzer, nil
 }
@@ -146,6 +147,7 @@ func (s *ChainAnalyzer) Run() {
 	if s.downloadMode == "historical" {
 		// Block requester + Task generator
 		s.wgMainRoutine.Add(1)
+
 		go s.runHistorical(s.initSlot, s.finalSlot)
 	}
 

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -55,6 +55,9 @@ func NewChainAnalyzer(
 	// gen new ctx from parent
 	ctx, cancel := context.WithCancel(pCtx)
 
+	// generate the central exporting service
+	promethMetrics := prom_metrics.NewPrometheusMetrics(ctx, "0.0.0.0", iConfig.PrometheusPort)
+
 	// calculate the list of slots that we will analyze
 
 	if iConfig.DownloadMode == "historical" {
@@ -92,16 +95,14 @@ func NewChainAnalyzer(
 	cli, err := clientapi.NewAPIClient(pCtx,
 		iConfig.BnEndpoint,
 		clientapi.WithELEndpoint(iConfig.ElEndpoint),
-		clientapi.WithDBMetrics(metricsObj))
+		clientapi.WithDBMetrics(metricsObj),
+		clientapi.WithPromMetrics(promethMetrics))
 	if err != nil {
 		return &ChainAnalyzer{
 			ctx:    ctx,
 			cancel: cancel,
 		}, errors.Wrap(err, "unable to generate API Client.")
 	}
-
-	// generate the central exporting service
-	promethMetrics := prom_metrics.NewPrometheusMetrics(ctx, "0.0.0.0", iConfig.PrometheusPort)
 
 	analyzer := &ChainAnalyzer{
 		ctx:              ctx,

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -117,7 +117,7 @@ func NewChainAnalyzer(
 		metrics:          metricsObj,
 		PromMetrics:      promethMetrics,
 		queue:            NewQueue(),
-		processerBook:    utils.NewRoutineBook(10),
+		processerBook:    utils.NewRoutineBook(10, "processer"),
 		wgMainRoutine:    &sync.WaitGroup{},
 		wgDownload:       &sync.WaitGroup{},
 	}

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -117,7 +117,7 @@ func NewChainAnalyzer(
 		metrics:          metricsObj,
 		PromMetrics:      promethMetrics,
 		queue:            NewQueue(),
-		processerBook:    utils.NewRoutineBook(10, "processer"),
+		processerBook:    utils.NewRoutineBook(50, "processer"),
 		wgMainRoutine:    &sync.WaitGroup{},
 		wgDownload:       &sync.WaitGroup{},
 	}

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -117,7 +117,7 @@ func NewChainAnalyzer(
 		metrics:          metricsObj,
 		PromMetrics:      promethMetrics,
 		queue:            NewQueue(),
-		processerBook:    utils.NewRoutineBook(2, "processer"),
+		processerBook:    utils.NewRoutineBook(10, "processer"),
 		wgMainRoutine:    &sync.WaitGroup{},
 		wgDownload:       &sync.WaitGroup{},
 	}

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -42,7 +42,7 @@ type ChainAnalyzer struct {
 	metrics       db.DBMetrics       // waht metrics to be downloaded / processed
 	processerBook *utils.RoutineBook // defines slot to process new metrics into the database, good for monitoring
 
-	queue Queue // store the blocks and states downloaded
+	downloadCache ChainCache // store the blocks and states downloaded
 
 	initTime    time.Time
 	PromMetrics *prom_metrics.PrometheusMetrics // metrics to be stored to prometheus
@@ -116,7 +116,7 @@ func NewChainAnalyzer(
 		downloadMode:     iConfig.DownloadMode,
 		metrics:          metricsObj,
 		PromMetrics:      promethMetrics,
-		queue:            NewQueue(),
+		downloadCache:    NewQueue(),
 		processerBook:    utils.NewRoutineBook(50, "processer"),
 		wgMainRoutine:    &sync.WaitGroup{},
 		wgDownload:       &sync.WaitGroup{},

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -118,7 +118,7 @@ func NewChainAnalyzer(
 		metrics:          metricsObj,
 		PromMetrics:      promethMetrics,
 		downloadCache:    NewQueue(),
-		processerBook:    utils.NewRoutineBook(50, "processer"),
+		processerBook:    utils.NewRoutineBook(32, "processer"), // one whole epoch
 		wgMainRoutine:    &sync.WaitGroup{},
 		wgDownload:       &sync.WaitGroup{},
 	}

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -117,7 +117,7 @@ func NewChainAnalyzer(
 		metrics:          metricsObj,
 		PromMetrics:      promethMetrics,
 		queue:            NewQueue(),
-		processerBook:    utils.NewRoutineBook(10, "processer"),
+		processerBook:    utils.NewRoutineBook(2, "processer"),
 		wgMainRoutine:    &sync.WaitGroup{},
 		wgDownload:       &sync.WaitGroup{},
 	}

--- a/pkg/analyzer/chain_cache.go
+++ b/pkg/analyzer/chain_cache.go
@@ -39,7 +39,7 @@ func (s *ChainCache) AddNewState(newState *spec.AgnosticState) {
 	newState.AddBlocks(blockList)
 
 	s.StateHistory.Set(EpochTo[uint64](newState.Epoch), newState)
-	log.Tracef("state at slot %d successfully added to the queue", newState.Slot)
+	log.Debugf("state at slot %d successfully added to the queue", newState.Slot)
 }
 
 func (s *ChainCache) AddNewBlock(block *spec.AgnosticBlock) {

--- a/pkg/analyzer/chain_cache.go
+++ b/pkg/analyzer/chain_cache.go
@@ -69,8 +69,8 @@ func (s *ChainCache) CleanUpTo(maxSlot phase0.Slot) {
 	// Delete from History
 
 	for _, epoch := range stateKeys {
-		if epoch >= uint64(maxSlot) {
-			continue // only process epochs that are before the finalized
+		if (epoch * spec.SlotsPerEpoch) >= uint64(maxSlot) {
+			continue // only process epochs that are before the maxSlot
 		}
 
 		s.StateHistory.Delete(epoch)

--- a/pkg/analyzer/chain_cache.go
+++ b/pkg/analyzer/chain_cache.go
@@ -38,7 +38,7 @@ func (s *ChainCache) AddNewState(newState spec.AgnosticState) {
 	// the 32 blocks were retrieved
 	newState.AddBlocks(blockList)
 
-	s.StateHistory.Set(EpochTo[uint64](newState.Epoch), newState)
+	s.StateHistory.Set(EpochTo[uint64](newState.Epoch), &newState)
 	log.Tracef("state at slot %d successfully added to the queue", newState.Slot)
 }
 
@@ -46,7 +46,7 @@ func (s *ChainCache) AddNewBlock(block spec.AgnosticBlock) {
 
 	keys := s.BlockHistory.GetKeyList()
 
-	s.BlockHistory.Set(SlotTo[uint64](block.Slot), block)
+	s.BlockHistory.Set(SlotTo[uint64](block.Slot), &block)
 	log.Tracef("block at slot %d successfully added to the queue", block.Slot)
 
 	for _, key := range keys {

--- a/pkg/analyzer/chain_cache.go
+++ b/pkg/analyzer/chain_cache.go
@@ -12,8 +12,8 @@ type ChainCache struct {
 	BlockHistory *AgnosticMap[spec.AgnosticBlock] // Here we will store stateroots from the blocks
 
 	sync.Mutex
-	HeadBlock       spec.AgnosticBlock
-	LatestFinalized spec.AgnosticBlock
+	HeadBlock       *spec.AgnosticBlock
+	LatestFinalized *spec.AgnosticBlock
 }
 
 func NewQueue() ChainCache {
@@ -23,7 +23,7 @@ func NewQueue() ChainCache {
 	}
 }
 
-func (s *ChainCache) AddNewState(newState spec.AgnosticState) {
+func (s *ChainCache) AddNewState(newState *spec.AgnosticState) {
 
 	blockList := make([]spec.AgnosticBlock, 0)
 	epochStartSlot := phase0.Slot(newState.Epoch * spec.SlotsPerEpoch)
@@ -38,15 +38,15 @@ func (s *ChainCache) AddNewState(newState spec.AgnosticState) {
 	// the 32 blocks were retrieved
 	newState.AddBlocks(blockList)
 
-	s.StateHistory.Set(EpochTo[uint64](newState.Epoch), &newState)
+	s.StateHistory.Set(EpochTo[uint64](newState.Epoch), newState)
 	log.Tracef("state at slot %d successfully added to the queue", newState.Slot)
 }
 
-func (s *ChainCache) AddNewBlock(block spec.AgnosticBlock) {
+func (s *ChainCache) AddNewBlock(block *spec.AgnosticBlock) {
 
 	keys := s.BlockHistory.GetKeyList()
 
-	s.BlockHistory.Set(SlotTo[uint64](block.Slot), &block)
+	s.BlockHistory.Set(SlotTo[uint64](block.Slot), block)
 	log.Tracef("block at slot %d successfully added to the queue", block.Slot)
 
 	for _, key := range keys {

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -63,7 +63,7 @@ func (s *ChainAnalyzer) WaitForPrevState(slot phase0.Slot) {
 	stateWaitLoop:
 		for range ticker.C {
 			if slot%spec.SlotsPerEpoch == 0 { // only print for first slot of epoch
-				log.Debugf("slot %d waiting for state at slot %d (epoch %d) to be downloaded...", slot, prevStateSlot, prevStateEpoch)
+				log.Debugf("slot %d waiting for state at slot %d (epoch %d) to be downloaded or processed...", slot, prevStateSlot, prevStateEpoch)
 			}
 
 			prevStateAvailable = s.downloadCache.StateHistory.Available(uint64(prevStateEpoch))

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -24,7 +24,7 @@ func (s *ChainAnalyzer) DownloadBlock(slot phase0.Slot) {
 		log.Errorf("block error at slot %d: %s", slot, err)
 		s.stop = true
 	}
-	s.queue.AddNewBlock(newBlock)
+	s.downloadCache.AddNewBlock(newBlock)
 	// check if the min Request time has been completed (to avoid spaming the API)
 }
 
@@ -42,12 +42,12 @@ func (s *ChainAnalyzer) DownloadState(slot phase0.Slot) {
 		s.stop = true
 	}
 
-	s.queue.AddNewState(*state)
+	s.downloadCache.AddNewState(*state)
 	// check if the min Request time has been completed (to avoid spaming the API)
 }
 
 func (s *ChainAnalyzer) WaitForPrevState(slot phase0.Slot) {
-	prevStateAvailable := s.queue.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
+	prevStateAvailable := s.downloadCache.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
 	prevStateSlot := slot/spec.SlotsPerEpoch*spec.SlotsPerEpoch - 1
 
 	// do not continue until previous state is available
@@ -56,7 +56,7 @@ func (s *ChainAnalyzer) WaitForPrevState(slot phase0.Slot) {
 	stateWaitLoop:
 		for range ticker.C {
 			log.Tracef("slot %d waiting for state at slot %d (epoch %d) to be downloaded...", slot, prevStateSlot, (slot/spec.SlotsPerEpoch)-1)
-			prevStateAvailable = s.queue.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
+			prevStateAvailable = s.downloadCache.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
 			if prevStateAvailable {
 				ticker.Stop()
 				break stateWaitLoop

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/migalabs/goteth/pkg/spec"
-	"github.com/migalabs/goteth/pkg/utils"
 )
 
 func (s *ChainAnalyzer) DownloadBlockCotrolled(slot phase0.Slot) {
@@ -57,10 +56,13 @@ func (s *ChainAnalyzer) WaitForPrevState(slot phase0.Slot) {
 
 	// do not continue until previous state is available
 	if !prevStateAvailable && prevStateSlot >= s.initSlot {
-		ticker := time.NewTicker(utils.RoutineFlushTimeout)
+		ticker := time.NewTicker(4 * time.Second) // average max time for a state to be downloaded
 	stateWaitLoop:
 		for range ticker.C {
-			log.Tracef("slot %d waiting for state at slot %d (epoch %d) to be downloaded...", slot, prevStateSlot, prevStateEpoch)
+			if slot%spec.SlotsPerEpoch == 0 { // only print for first slot of epoch
+				log.Debugf("slot %d waiting for state at slot %d (epoch %d) to be downloaded...", slot, prevStateSlot, prevStateEpoch)
+			}
+
 			prevStateAvailable = s.downloadCache.StateHistory.Available(uint64(prevStateEpoch))
 			if prevStateAvailable {
 				ticker.Stop()

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -53,9 +54,11 @@ func (s *ChainAnalyzer) WaitForPrevState(slot phase0.Slot) {
 	prevStateSlot := (prevStateEpoch+1)*spec.SlotsPerEpoch - 1 // slot at which the check state was downloaded
 
 	prevStateAvailable := s.downloadCache.StateHistory.Available(uint64(prevStateEpoch))
+	prevStateProcessing := s.processerBook.CheckPageActive(fmt.Sprintf("%s%d", epochProcesserTag, prevStateEpoch))
 
-	// do not continue until previous state is available
-	if !prevStateAvailable && prevStateSlot >= s.initSlot {
+	// do not continue until previous state is available and is not being processed anymore
+	// also check that prevstate was supposed to be downloaded
+	if (!prevStateAvailable || prevStateProcessing) && prevStateSlot >= s.initSlot {
 		ticker := time.NewTicker(4 * time.Second) // average max time for a state to be downloaded
 	stateWaitLoop:
 		for range ticker.C {
@@ -64,7 +67,9 @@ func (s *ChainAnalyzer) WaitForPrevState(slot phase0.Slot) {
 			}
 
 			prevStateAvailable = s.downloadCache.StateHistory.Available(uint64(prevStateEpoch))
-			if prevStateAvailable {
+			prevStateProcessing = s.processerBook.CheckPageActive(fmt.Sprintf("%s%d", epochProcesserTag, prevStateEpoch))
+			if prevStateAvailable && !prevStateProcessing {
+				// it was available in the queue and processed
 				ticker.Stop()
 				break stateWaitLoop
 			}

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -41,7 +41,7 @@ func (s *ChainAnalyzer) DownloadState(slot phase0.Slot) {
 		s.stop = true
 	}
 
-	s.downloadCache.AddNewState(*state)
+	s.downloadCache.AddNewState(state)
 	// check if the min Request time has been completed (to avoid spaming the API)
 }
 

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -1,13 +1,33 @@
 package analyzer
 
 import (
+	"time"
+
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/migalabs/goteth/pkg/spec"
+	"github.com/migalabs/goteth/pkg/utils"
 )
 
 func (s *ChainAnalyzer) DownloadBlock(slot phase0.Slot) {
 	if !s.metrics.Block {
 		log.Infof("skipping block download at slot %d: no metrics activated for block...", slot)
 		return
+	}
+
+	prevStateAvailable := s.queue.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
+
+	// do not continue until previous state is available
+	if !prevStateAvailable {
+		ticker := time.NewTicker(utils.RoutineFlushTimeout)
+		for range ticker.C {
+			if slot%spec.SlotsPerEpoch == 0 { // only show warning for the first slot in the epoch
+				log.Warnf("waiting for state at epoch %d to be downloaded...", (slot/spec.SlotsPerEpoch)-1)
+			}
+			prevStateAvailable = s.queue.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
+			if prevStateAvailable {
+				ticker.Stop()
+			}
+		}
 	}
 
 	newBlock, err := s.cli.RequestBeaconBlock(slot)

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -20,13 +20,13 @@ func (s *ChainAnalyzer) DownloadBlock(slot phase0.Slot) {
 	// do not continue until previous state is available
 	if !prevStateAvailable && prevStateSlot >= s.initSlot {
 		ticker := time.NewTicker(utils.RoutineFlushTimeout)
+	stateWaitLoop:
 		for range ticker.C {
-			if slot%spec.SlotsPerEpoch == 0 { // only show warning for the first slot in the epoch
-				log.Warnf("waiting for state at epoch %d to be downloaded...", (slot/spec.SlotsPerEpoch)-1)
-			}
+			log.Tracef("slot %d waiting for state at slot %d (epoch %d) to be downloaded...", slot, prevStateSlot, (slot/spec.SlotsPerEpoch)-1)
 			prevStateAvailable = s.queue.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
 			if prevStateAvailable {
 				ticker.Stop()
+				break stateWaitLoop
 			}
 		}
 	}

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -15,9 +15,10 @@ func (s *ChainAnalyzer) DownloadBlock(slot phase0.Slot) {
 	}
 
 	prevStateAvailable := s.queue.StateHistory.Available(uint64(slot/spec.SlotsPerEpoch) - 1)
+	prevStateSlot := slot/spec.SlotsPerEpoch*spec.SlotsPerEpoch - 1
 
 	// do not continue until previous state is available
-	if !prevStateAvailable {
+	if !prevStateAvailable && prevStateSlot >= s.initSlot {
 		ticker := time.NewTicker(utils.RoutineFlushTimeout)
 		for range ticker.C {
 			if slot%spec.SlotsPerEpoch == 0 { // only show warning for the first slot in the epoch

--- a/pkg/analyzer/finalized.go
+++ b/pkg/analyzer/finalized.go
@@ -82,18 +82,7 @@ func (s *ChainAnalyzer) AdvanceFinalized(newFinalizedSlot phase0.Slot) {
 		s.ProcessStateTransitionMetrics(epoch + 2)
 	}
 
-	// Delete from History
-
-	for _, epoch := range stateKeys {
-		if epoch >= uint64(finalizedEpoch) {
-			continue // only process epochs that are before the finalized
-		}
-		s.downloadCache.StateHistory.Delete(epoch)
-		// loop over slots in the epoch
-		for slot := (epoch * spec.SlotsPerEpoch); slot < ((epoch + 1) * spec.SlotsPerEpoch); slot++ {
-			s.downloadCache.BlockHistory.Delete(slot)
-		}
-	}
+	s.downloadCache.CleanUpTo(newFinalizedSlot)
 
 	log.Infof("checked states until slot %d, epoch %d", newFinalizedSlot, newFinalizedSlot/spec.SlotsPerEpoch)
 }

--- a/pkg/analyzer/finalized.go
+++ b/pkg/analyzer/finalized.go
@@ -1,0 +1,93 @@
+package analyzer
+
+import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+func (s *ChainAnalyzer) AdvanceFinalized(newFinalizedSlot phase0.Slot) {
+
+	finalizedEpoch := newFinalizedSlot / spec.SlotsPerEpoch
+
+	rewriteSlots := make([]phase0.Slot, 0)
+	rewriteEpochs := make([]phase0.Epoch, 0)
+
+	stateKeys := s.queue.StateHistory.GetKeyList()
+
+	for _, epoch := range stateKeys {
+		if epoch >= uint64(finalizedEpoch) {
+			continue // only process epochs that are before the given epoch
+		}
+
+		// Retrieve stored root and redownload root once finalized
+		queueState := s.queue.StateHistory.Wait(epoch)
+		finalizedStateRoot := s.cli.RequestStateRoot(phase0.Slot(queueState.Slot))
+		historyStateRoot := queueState.StateRoot
+
+		if finalizedStateRoot != historyStateRoot { // no match, reorg happened
+			log.Warnf("state root for state (slot=%d) incorrect, redownload", queueState.Slot)
+			// need to redownload the epoch
+			s.queue.StateHistory.Delete(epoch)
+			s.cli.RequestBeaconState(queueState.Slot) // -> inserts into the queue
+
+			// keep track of the rewrite metrics
+			rewriteEpochs = append(rewriteEpochs, phase0.Epoch(epoch))
+		}
+
+		// loop over slots in the epoch
+		for slot := (epoch * spec.SlotsPerEpoch); slot < ((epoch + 1) * spec.SlotsPerEpoch); slot++ {
+
+			// Retrieve stored root and redownload root once finalized
+			queueBlock := s.queue.StateHistory.Wait(slot)
+			finalizedBlockRoot := s.cli.RequestStateRoot(phase0.Slot(queueBlock.Slot))
+			historyBlockRoot := queueBlock.StateRoot
+
+			if finalizedBlockRoot != historyBlockRoot {
+				log.Warnf("state root for block (slot=%d) incorrect, redownload", queueBlock.Slot)
+				// need to redownload the epoch
+				s.queue.BlockHistory.Delete(slot)
+				s.cli.RequestBeaconBlock(phase0.Slot(slot)) // -> inserts into the queue
+
+				// keep track of the rewrite metrics
+				rewriteSlots = append(rewriteSlots, phase0.Slot(slot))
+			}
+
+		}
+
+	}
+
+	// Time to process rewrites
+
+	for _, slot := range rewriteSlots {
+		// delete slot metrics
+		s.dbClient.DeleteBlockMetrics(slot)
+		// write slot metrics
+		s.ProcessBlock(slot)
+
+	}
+
+	for _, epoch := range rewriteEpochs {
+		// delete epoch metrics
+		s.dbClient.DeleteStateMetrics(epoch)
+		// write epoch metrics
+		s.ProcessStateTransitionMetrics(epoch - 1)
+		s.ProcessStateTransitionMetrics(epoch)
+		s.ProcessStateTransitionMetrics(epoch + 1)
+		s.ProcessStateTransitionMetrics(epoch + 2)
+	}
+
+	// Delete from History
+
+	for _, epoch := range stateKeys {
+		if epoch >= uint64(finalizedEpoch) {
+			continue // only process epochs that are before the finalized
+		}
+		s.queue.StateHistory.Delete(epoch)
+		// loop over slots in the epoch
+		for slot := (epoch * spec.SlotsPerEpoch); slot < ((epoch + 1) * spec.SlotsPerEpoch); slot++ {
+			s.queue.BlockHistory.Delete(slot)
+		}
+	}
+
+	log.Infof("checked states until slot %d, epoch %d", newFinalizedSlot, newFinalizedSlot/spec.SlotsPerEpoch)
+}

--- a/pkg/analyzer/finalized.go
+++ b/pkg/analyzer/finalized.go
@@ -29,7 +29,7 @@ func (s *ChainAnalyzer) AdvanceFinalized(newFinalizedSlot phase0.Slot) {
 			log.Warnf("state root for state (slot=%d) incorrect, redownload", queueState.Slot)
 			// need to redownload the epoch
 			s.queue.StateHistory.Delete(epoch)
-			s.cli.RequestBeaconState(queueState.Slot) // -> inserts into the queue
+			s.DownloadState(queueState.Slot) // -> inserts into the queue
 
 			// keep track of the rewrite metrics
 			rewriteEpochs = append(rewriteEpochs, phase0.Epoch(epoch))
@@ -47,7 +47,7 @@ func (s *ChainAnalyzer) AdvanceFinalized(newFinalizedSlot phase0.Slot) {
 				log.Warnf("state root for block (slot=%d) incorrect, redownload", queueBlock.Slot)
 				// need to redownload the epoch
 				s.queue.BlockHistory.Delete(slot)
-				s.cli.RequestBeaconBlock(phase0.Slot(slot)) // -> inserts into the queue
+				s.DownloadBlock(phase0.Slot(slot)) // -> inserts into the queue
 
 				// keep track of the rewrite metrics
 				rewriteSlots = append(rewriteSlots, phase0.Slot(slot))

--- a/pkg/analyzer/finalized.go
+++ b/pkg/analyzer/finalized.go
@@ -54,7 +54,7 @@ func (s *ChainAnalyzer) AdvanceFinalized(newFinalizedSlot phase0.Slot) {
 
 				// keep orphans
 				if queueBlock.Proposed {
-					s.dbClient.Persist(db.OrphanBlock(queueBlock))
+					s.dbClient.Persist(db.OrphanBlock(*queueBlock))
 				}
 			}
 

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -24,7 +24,7 @@ func (s *ChainAnalyzer) ProcessBlock(slot phase0.Slot) {
 	s.processerBook.FreePage(routineKey)
 }
 
-func (s ChainAnalyzer) processTransactions(block spec.AgnosticBlock) {
+func (s *ChainAnalyzer) processTransactions(block spec.AgnosticBlock) {
 
 	for idx, tx := range block.ExecutionPayload.Transactions {
 		go func(txID int, transaction bellatrix.Transaction) {
@@ -34,7 +34,7 @@ func (s ChainAnalyzer) processTransactions(block spec.AgnosticBlock) {
 				block.ExecutionPayload.BlockNumber,
 				block.ExecutionPayload.Timestamp)
 			if err != nil {
-				log.Errorf("could not request transaction details in slot %s for transaction %d: %s", block.Slot, txID, err)
+				log.Errorf("could not request transaction details in slot %d for transaction %d: %s", block.Slot, txID, err)
 			}
 			log.Tracef("persisting transaction metrics: slot %d, tx number: %d", block.Slot, txID)
 			s.dbClient.Persist(detailedTx)

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -16,7 +16,7 @@ func (s *ChainAnalyzer) ProcessBlock(slot phase0.Slot) {
 	s.processerBook.Acquire(routineKey) // register a new slot to process, good for monitoring
 
 	block := s.queue.BlockHistory.Wait(SlotTo[uint64](slot))
-	s.dbClient.Persist(block)
+	s.dbClient.Persist(*block)
 
 	if s.metrics.Transactions {
 		s.processTransactions(block)

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -24,7 +24,7 @@ func (s *ChainAnalyzer) ProcessBlock(slot phase0.Slot) {
 	s.processerBook.FreePage(routineKey)
 }
 
-func (s *ChainAnalyzer) processTransactions(block spec.AgnosticBlock) {
+func (s *ChainAnalyzer) processTransactions(block *spec.AgnosticBlock) {
 
 	for idx, tx := range block.ExecutionPayload.Transactions {
 		go func(txID int, transaction bellatrix.Transaction) {

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -15,7 +15,7 @@ func (s *ChainAnalyzer) ProcessBlock(slot phase0.Slot) {
 	routineKey := "slot=" + fmt.Sprintf("%d", slot)
 	s.processerBook.Acquire(routineKey) // register a new slot to process, good for monitoring
 
-	block := s.queue.BlockHistory.Wait(SlotTo[uint64](slot))
+	block := s.downloadCache.BlockHistory.Wait(SlotTo[uint64](slot))
 	s.dbClient.Persist(*block)
 
 	if s.metrics.Transactions {

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -8,6 +8,10 @@ import (
 	"github.com/migalabs/goteth/pkg/spec/metrics"
 )
 
+var (
+	epochProcesserTag = "epoch="
+)
+
 // We always provide the epoch we transition to
 // To process the transition from epoch 9 to 10, we provide 10 and we retrieve 8, 9, 10
 func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
@@ -16,7 +20,7 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 		return
 	}
 
-	routineKey := "epoch=" + fmt.Sprintf("%d", epoch)
+	routineKey := fmt.Sprintf("%s%d", epochProcesserTag, epoch)
 	s.processerBook.Acquire(routineKey) // resgiter we are about to process metrics for epoch
 
 	// Retrieve states to process metrics

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -27,12 +27,12 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 
 	// this state may never be downloaded if it is below initSlot
 	if epoch >= 2 && epoch-2 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
-		prevState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch) - 2)
+		prevState = s.downloadCache.StateHistory.Wait(EpochTo[uint64](epoch) - 2)
 	}
 	if epoch >= 1 && epoch-1 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
-		currentState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch) - 1)
+		currentState = s.downloadCache.StateHistory.Wait(EpochTo[uint64](epoch) - 1)
 	}
-	nextState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch))
+	nextState = s.downloadCache.StateHistory.Wait(EpochTo[uint64](epoch))
 
 	bundle, err := metrics.StateMetricsByForkVersion(nextState, currentState, prevState, s.cli.Api)
 	if err != nil {

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -21,15 +21,15 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 
 	// Retrieve states to process metrics
 
-	prevState := spec.AgnosticState{}
-	currentState := spec.AgnosticState{}
-	nextState := spec.AgnosticState{}
+	prevState := &spec.AgnosticState{}
+	currentState := &spec.AgnosticState{}
+	nextState := &spec.AgnosticState{}
 
 	// this state may never be downloaded if it is below initSlot
-	if epoch-2 >= 0 && epoch-2 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
+	if epoch >= 2 && epoch-2 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
 		prevState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch) - 2)
 	}
-	if epoch-1 >= 0 && epoch-1 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
+	if epoch >= 1 && epoch-1 >= phase0.Epoch(s.initSlot/spec.SlotsPerEpoch) {
 		currentState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch) - 1)
 	}
 	nextState = s.queue.StateHistory.Wait(EpochTo[uint64](epoch))

--- a/pkg/analyzer/prometheus_metrics.go
+++ b/pkg/analyzer/prometheus_metrics.go
@@ -104,7 +104,7 @@ func (p *ChainAnalyzer) getStateHistoryLength() *metrics.IndvMetrics {
 	}
 
 	updateFn := func() (interface{}, error) {
-		numberStates := len(p.queue.StateHistory.GetKeyList())
+		numberStates := len(p.downloadCache.StateHistory.GetKeyList())
 		StateQueueLength.Set(float64(numberStates))
 		return numberStates, nil
 	}
@@ -130,7 +130,7 @@ func (p *ChainAnalyzer) getBlockHistoryLength() *metrics.IndvMetrics {
 	}
 
 	updateFn := func() (interface{}, error) {
-		numberBlocks := len(p.queue.BlockHistory.GetKeyList())
+		numberBlocks := len(p.downloadCache.BlockHistory.GetKeyList())
 		BlockQueueLength.Set(float64(numberBlocks))
 		return numberBlocks, nil
 	}

--- a/pkg/analyzer/queue.go
+++ b/pkg/analyzer/queue.go
@@ -39,6 +39,7 @@ func (s *Queue) AddNewState(newState spec.AgnosticState) {
 	newState.AddBlocks(blockList)
 
 	s.StateHistory.Set(EpochTo[uint64](newState.Epoch), newState)
+	log.Tracef("state at slot %d successfully added to the queue", newState.Slot)
 }
 
 func (s *Queue) AddNewBlock(block spec.AgnosticBlock) {
@@ -46,6 +47,7 @@ func (s *Queue) AddNewBlock(block spec.AgnosticBlock) {
 	keys := s.BlockHistory.GetKeyList()
 
 	s.BlockHistory.Set(SlotTo[uint64](block.Slot), block)
+	log.Tracef("block at slot %d successfully added to the queue", block.Slot)
 
 	for _, key := range keys {
 		if key >= uint64(block.Slot) { // if there is any key greater than the current evaluated block

--- a/pkg/analyzer/queue.go
+++ b/pkg/analyzer/queue.go
@@ -32,7 +32,7 @@ func (s *Queue) AddNewState(newState spec.AgnosticState) {
 	for i := epochStartSlot; i <= epochEndSlot; i++ {
 		block := s.BlockHistory.Wait(SlotTo[uint64](i))
 
-		blockList = append(blockList, block)
+		blockList = append(blockList, *block)
 	}
 
 	// the 32 blocks were retrieved

--- a/pkg/analyzer/queue.go
+++ b/pkg/analyzer/queue.go
@@ -7,7 +7,7 @@ import (
 	"github.com/migalabs/goteth/pkg/spec"
 )
 
-type Queue struct {
+type ChainCache struct {
 	StateHistory *AgnosticMap[spec.AgnosticState]
 	BlockHistory *AgnosticMap[spec.AgnosticBlock] // Here we will store stateroots from the blocks
 
@@ -16,14 +16,14 @@ type Queue struct {
 	LatestFinalized spec.AgnosticBlock
 }
 
-func NewQueue() Queue {
-	return Queue{
+func NewQueue() ChainCache {
+	return ChainCache{
 		StateHistory: NewAgnosticMap[spec.AgnosticState](),
 		BlockHistory: NewAgnosticMap[spec.AgnosticBlock](),
 	}
 }
 
-func (s *Queue) AddNewState(newState spec.AgnosticState) {
+func (s *ChainCache) AddNewState(newState spec.AgnosticState) {
 
 	blockList := make([]spec.AgnosticBlock, 0)
 	epochStartSlot := phase0.Slot(newState.Epoch * spec.SlotsPerEpoch)
@@ -42,7 +42,7 @@ func (s *Queue) AddNewState(newState spec.AgnosticState) {
 	log.Tracef("state at slot %d successfully added to the queue", newState.Slot)
 }
 
-func (s *Queue) AddNewBlock(block spec.AgnosticBlock) {
+func (s *ChainCache) AddNewBlock(block spec.AgnosticBlock) {
 
 	keys := s.BlockHistory.GetKeyList()
 
@@ -71,7 +71,7 @@ func (s *Queue) AddNewBlock(block spec.AgnosticBlock) {
 // 	}
 // }
 
-func (s *Queue) CleanQueue(maxSlot phase0.Slot) {
+func (s *ChainCache) CleanQueue(maxSlot phase0.Slot) {
 
 	stateKeys := s.StateHistory.GetKeyList()
 	keys := s.BlockHistory.GetKeyList()

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -49,7 +49,7 @@ func (s *ChainAnalyzer) runHead() {
 	log.Info("launching head routine")
 	nextSlotDownload := s.fillToHead()
 
-	s.queue.BlockHistory.Wait(SlotTo[uint64](nextSlotDownload))
+	s.downloadCache.BlockHistory.Wait(SlotTo[uint64](nextSlotDownload))
 	// do not continue until fill is done
 
 	log.Infof("Switch to head mode: following chain head")
@@ -160,7 +160,7 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 		}
 		if len(ticker.C) > 0 { // every ticker, clean queue
 			<-ticker.C
-			s.queue.CleanQueue(s.queue.HeadBlock.Slot - (5 * spec.SlotsPerEpoch))
+			s.downloadCache.CleanQueue(s.downloadCache.HeadBlock.Slot - (5 * spec.SlotsPerEpoch))
 		}
 
 		if s.processerBook.NumFreePages() == 0 {

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -154,7 +154,8 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 
 	log.Infof("Switch to historical mode: %d - %d", init, end)
 
-	for i := init; i <= end; i++ {
+	i := init
+	for i <= end {
 		if s.stop {
 			log.Info("sudden shutdown detected, block downloader routine")
 			return
@@ -181,8 +182,10 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 			log.Debugf("hit limit of concurrent processers")
 			limitTicker := time.NewTicker(utils.RoutineFlushTimeout)
 			<-limitTicker.C // if rate limit, wait for ticker
+			continue
 		}
 		s.downloadTaskChan <- i
+		i += 1
 
 	}
 	log.Infof("historical mode: all download tasks sent")

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -137,8 +137,8 @@ func (s *ChainAnalyzer) fillToHead() phase0.Slot {
 		nextSlotDownload = nextSlotDownload - (epochsToFinalizedTentative * spec.SlotsPerEpoch) // 2 epochs before
 
 	}
-
-	s.initSlot = nextSlotDownload
+	nextSlotDownload = nextSlotDownload / spec.SlotsPerEpoch * spec.SlotsPerEpoch
+	s.initSlot = nextSlotDownload / spec.SlotsPerEpoch * spec.SlotsPerEpoch
 
 	log.Infof("filling to head...")
 	s.wgMainRoutine.Add(1) // add because historical will defer it

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -166,7 +166,7 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 		}
 
 		if s.processerBook.NumFreePages() == 0 {
-			log.Warnf("hit limit of concurrent processers")
+			log.Debugf("hit limit of concurrent processers")
 			limitTicker := time.NewTicker(utils.RoutineFlushTimeout)
 			<-limitTicker.C // if rate limit, wait for ticker
 		}

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -26,7 +26,7 @@ downloadRoutine:
 		case downloadSlot := <-s.downloadTaskChan: // wait for new head event
 			log.Tracef("received new download signal: %d", downloadSlot)
 
-			go s.DownloadBlock(phase0.Slot(downloadSlot))
+			go s.DownloadBlockCotrolled(phase0.Slot(downloadSlot))
 			go s.ProcessBlock(downloadSlot)
 
 			// if epoch boundary, download state

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -153,9 +153,7 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 
 	log.Infof("Switch to historical mode: %d - %d", init, end)
 
-	i := init
-
-	for i <= end {
+	for i := init; i <= end; i++ {
 		if s.stop {
 			log.Info("sudden shutdown detected, block downloader routine")
 			return
@@ -171,7 +169,6 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 			<-limitTicker.C // if rate limit, wait for ticker
 		}
 		s.downloadTaskChan <- i
-		i += 1
 
 	}
 	log.Infof("historical mode: all download tasks sent")

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -82,7 +82,7 @@ func (s *ChainAnalyzer) runHead() {
 			s.dbClient.Persist(db.ChepointTypeFromCheckpoint(newFinalCheckpoint))
 			finalizedSlot := phase0.Slot(newFinalCheckpoint.Epoch * spec.SlotsPerEpoch)
 
-			go s.queue.CleanQueue(finalizedSlot - (2 * spec.SlotsPerEpoch))
+			go s.AdvanceFinalized(finalizedSlot - (2 * spec.SlotsPerEpoch))
 
 		// case newReorg := <-s.eventsObj.ReorgChan:
 		// 	s.dbClient.Persist(db.ReorgTypeFromReorg(newReorg))

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/migalabs/goteth/pkg/clientapi"
 	"github.com/migalabs/goteth/pkg/db"
 	"github.com/migalabs/goteth/pkg/spec"
+	"github.com/migalabs/goteth/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,7 +18,7 @@ const (
 	minBlockReqTime            = 100 * time.Millisecond // max 10 queries per second, dont spam beacon node
 	minStateReqTime            = 1 * time.Second        // max 1 query per second, dont spam beacon node
 	epochsToFinalizedTentative = 3                      // usually, 2 full epochs before the head it is finalized
-	waitMaxTimeout             = 60 * time.Second
+
 )
 
 var (
@@ -120,7 +121,7 @@ func (m *AgnosticMap[T]) Wait(key uint64) T {
 		return value
 	}
 
-	ticker := time.NewTicker(waitMaxTimeout)
+	ticker := time.NewTicker(utils.WaitMaxTimeout)
 
 	// if there is no value yet, subscribe to any new values for this key
 	ch := make(chan T)

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -111,14 +111,14 @@ func (m *AgnosticMap[T]) Set(key uint64, value T) {
 	delete(m.subs, key)
 }
 
-func (m *AgnosticMap[T]) Wait(key uint64) T {
+func (m *AgnosticMap[T]) Wait(key uint64) *T {
 	m.Lock()
 	// Unlock cannot be deferred so we can unblock Set() while waiting
 
 	value, ok := m.m[key]
 	if ok {
 		m.Unlock()
-		return value
+		return &value
 	}
 
 	ticker := time.NewTicker(utils.WaitMaxTimeout)
@@ -132,9 +132,9 @@ func (m *AgnosticMap[T]) Wait(key uint64) T {
 	select {
 	case <-ticker.C:
 		log.Fatalf("Waiting for too long for %T %d...", *new(T), key)
-		return item
+		return &item
 	case item = <-ch:
-		return item
+		return &item
 	}
 }
 

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/migalabs/goteth/pkg/clientapi"
 	"github.com/migalabs/goteth/pkg/db"
 	"github.com/migalabs/goteth/pkg/spec"
-	"github.com/migalabs/goteth/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -122,7 +121,7 @@ func (m *AgnosticMap[T]) Wait(key uint64) *T {
 		return value
 	}
 
-	ticker := time.NewTicker(utils.WaitMaxTimeout)
+	ticker := time.NewTicker(dataWaitInterval)
 
 	// if there is no value yet, subscribe to any new values for this key
 	ch := make(chan *T)

--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -30,17 +30,19 @@ type APIClient struct {
 	ELApi   *ethclient.Client // Execution Node
 	Metrics db.DBMetrics
 
-	apiBook   *utils.RoutineBook // Book to track what is being downloaded through the CL API
-	elApiBook *utils.RoutineBook // Book to track what is being downloaded through the EL API
+	statesBook *utils.RoutineBook // Book to track what is being downloaded through the CL API: states
+	blocksBook *utils.RoutineBook // Book to track what is being downloaded through the CL API: blocks
+	elApiBook  *utils.RoutineBook // Book to track what is being downloaded through the EL API
 }
 
 func NewAPIClient(ctx context.Context, bnEndpoint string, options ...APIClientOption) (*APIClient, error) {
 	log.Debugf("generating http client at %s", bnEndpoint)
 
 	apiService := &APIClient{
-		ctx:       ctx,
-		apiBook:   utils.NewRoutineBook(maxParallelConns, "api-cli"),
-		elApiBook: utils.NewRoutineBook(maxParallelConns, "api-cli"),
+		ctx:        ctx,
+		statesBook: utils.NewRoutineBook(1, "api-cli"),
+		blocksBook: utils.NewRoutineBook(1, "api-cli"),
+		elApiBook:  utils.NewRoutineBook(maxParallelConns, "api-cli"),
 	}
 
 	bnCli, err := http.New(
@@ -93,5 +95,5 @@ func WithDBMetrics(metrics db.DBMetrics) APIClientOption {
 
 func (s APIClient) ActiveReqNum() int {
 
-	return s.apiBook.ActivePages() + s.elApiBook.ActivePages()
+	return s.blocksBook.ActivePages() + s.elApiBook.ActivePages()
 }

--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -39,8 +39,8 @@ func NewAPIClient(ctx context.Context, bnEndpoint string, options ...APIClientOp
 
 	apiService := &APIClient{
 		ctx:       ctx,
-		apiBook:   utils.NewRoutineBook(maxParallelConns),
-		elApiBook: utils.NewRoutineBook(maxParallelConns),
+		apiBook:   utils.NewRoutineBook(maxParallelConns, "api-cli"),
+		elApiBook: utils.NewRoutineBook(maxParallelConns, "api-cli"),
 	}
 
 	bnCli, err := http.New(

--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -32,7 +32,7 @@ type APIClient struct {
 
 	statesBook *utils.RoutineBook // Book to track what is being downloaded through the CL API: states
 	blocksBook *utils.RoutineBook // Book to track what is being downloaded through the CL API: blocks
-	elApiBook  *utils.RoutineBook // Book to track what is being downloaded through the EL API
+	txBook     *utils.RoutineBook // Book to track what is being downloaded through the EL API
 }
 
 func NewAPIClient(ctx context.Context, bnEndpoint string, options ...APIClientOption) (*APIClient, error) {
@@ -42,7 +42,7 @@ func NewAPIClient(ctx context.Context, bnEndpoint string, options ...APIClientOp
 		ctx:        ctx,
 		statesBook: utils.NewRoutineBook(1, "api-cli-states"),
 		blocksBook: utils.NewRoutineBook(1, "api-cli-blocks"),
-		elApiBook:  utils.NewRoutineBook(maxParallelConns, "api-cli-tx"),
+		txBook:     utils.NewRoutineBook(maxParallelConns, "api-cli-tx"),
 	}
 
 	bnCli, err := http.New(
@@ -95,5 +95,5 @@ func WithDBMetrics(metrics db.DBMetrics) APIClientOption {
 
 func (s APIClient) ActiveReqNum() int {
 
-	return s.blocksBook.ActivePages() + s.elApiBook.ActivePages()
+	return s.blocksBook.ActivePages() + s.statesBook.ActivePages() + s.txBook.ActivePages()
 }

--- a/pkg/clientapi/api_requester.go
+++ b/pkg/clientapi/api_requester.go
@@ -40,9 +40,9 @@ func NewAPIClient(ctx context.Context, bnEndpoint string, options ...APIClientOp
 
 	apiService := &APIClient{
 		ctx:        ctx,
-		statesBook: utils.NewRoutineBook(1, "api-cli"),
-		blocksBook: utils.NewRoutineBook(1, "api-cli"),
-		elApiBook:  utils.NewRoutineBook(maxParallelConns, "api-cli"),
+		statesBook: utils.NewRoutineBook(1, "api-cli-states"),
+		blocksBook: utils.NewRoutineBook(1, "api-cli-blocks"),
+		elApiBook:  utils.NewRoutineBook(maxParallelConns, "api-cli-tx"),
 	}
 
 	bnCli, err := http.New(

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -17,14 +17,12 @@ import (
 	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
-var (
-	asset = "block"
-)
-
 func (s *APIClient) RequestBeaconBlock(slot phase0.Slot) (local_spec.AgnosticBlock, error) {
 	routineKey := "slot=" + fmt.Sprintf("%d", slot)
 	s.blocksBook.Acquire(routineKey)
 	defer s.blocksBook.FreePage(routineKey)
+
+	log.Debugf("downloading block at slot %d", slot)
 
 	startTime := time.Now()
 	err := errors.New("first attempt")

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -23,8 +23,8 @@ var (
 
 func (s *APIClient) RequestBeaconBlock(slot phase0.Slot) (local_spec.AgnosticBlock, error) {
 	routineKey := "slot=" + fmt.Sprintf("%d", slot)
-	s.apiBook.Acquire(routineKey)
-	defer s.apiBook.FreePage(routineKey)
+	s.blocksBook.Acquire(routineKey)
+	defer s.blocksBook.FreePage(routineKey)
 
 	startTime := time.Now()
 	err := errors.New("first attempt")

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -153,8 +153,8 @@ func (s *APIClient) RequestExecutionBlockByHash(hash common.Hash) (*types.Block,
 	}
 
 	routineKey := "block=" + hash.String()
-	s.elApiBook.Acquire(routineKey)
-	defer s.elApiBook.FreePage(routineKey)
+	s.txBook.Acquire(routineKey)
+	defer s.txBook.FreePage(routineKey)
 
 	block, err := s.ELApi.BlockByHash(s.ctx, hash)
 	if err != nil {

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -17,8 +17,12 @@ import (
 	bitfield "github.com/prysmaticlabs/go-bitfield"
 )
 
+var (
+	slotKeyTag string = "slot="
+)
+
 func (s *APIClient) RequestBeaconBlock(slot phase0.Slot) (local_spec.AgnosticBlock, error) {
-	routineKey := "slot=" + fmt.Sprintf("%d", slot)
+	routineKey := fmt.Sprintf("%s%d", slotKeyTag, slot)
 	s.blocksBook.Acquire(routineKey)
 	defer s.blocksBook.FreePage(routineKey)
 

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -15,8 +15,8 @@ import (
 func (s *APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticState, error) {
 
 	routineKey := "state=" + fmt.Sprintf("%d", slot)
-	s.apiBook.Acquire(routineKey)
-	defer s.apiBook.FreePage(routineKey)
+	s.statesBook.Acquire(routineKey)
+	defer s.statesBook.FreePage(routineKey)
 
 	startTime := time.Now()
 

--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -12,9 +12,13 @@ import (
 	"github.com/migalabs/goteth/pkg/utils"
 )
 
+var (
+	stateKeyTag string = "state="
+)
+
 func (s *APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticState, error) {
 
-	routineKey := "state=" + fmt.Sprintf("%d", slot)
+	routineKey := fmt.Sprintf("%s%d", stateKeyTag, slot)
 	s.statesBook.Acquire(routineKey)
 	defer s.statesBook.FreePage(routineKey)
 

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -18,8 +18,8 @@ import (
 func (client *APIClient) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
 
 	routineKey := "txreceipt=" + txHash.String()
-	client.elApiBook.Acquire(routineKey)
-	defer client.elApiBook.FreePage(routineKey)
+	client.txBook.Acquire(routineKey)
+	defer client.txBook.FreePage(routineKey)
 
 	receipt, err := client.ELApi.TransactionReceipt(client.ctx, txHash)
 	return receipt, err

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -17,9 +17,9 @@ import (
 // GetReceipt retrieves receipt for the given transaction hash
 func (client *APIClient) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
 
-	// routineKey := "txreceipt=" + txHash.String()
-	// client.elApiBook.Acquire(routineKey)
-	// defer client.elApiBook.FreePage(routineKey)
+	routineKey := "txreceipt=" + txHash.String()
+	client.elApiBook.Acquire(routineKey)
+	defer client.elApiBook.FreePage(routineKey)
 
 	receipt, err := client.ELApi.TransactionReceipt(client.ctx, txHash)
 	return receipt, err

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -14,10 +14,14 @@ import (
 	"github.com/migalabs/goteth/pkg/utils"
 )
 
+var (
+	txKeyTag string = "txreceipt="
+)
+
 // GetReceipt retrieves receipt for the given transaction hash
 func (client *APIClient) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
 
-	routineKey := "txreceipt=" + txHash.String()
+	routineKey := txKeyTag + txHash.String()
 	client.txBook.Acquire(routineKey)
 	defer client.txBook.FreePage(routineKey)
 

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -2,12 +2,16 @@ package clientapi
 
 import (
 	"encoding/hex"
+	"errors"
+	"syscall"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/migalabs/goteth/pkg/spec"
+	"github.com/migalabs/goteth/pkg/utils"
 )
 
 // GetReceipt retrieves receipt for the given transaction hash
@@ -46,15 +50,30 @@ func (s *APIClient) RequestTransactionDetails(iTx bellatrix.Transaction,
 	contractAddress := *&common.Address{}
 
 	if s.ELApi != nil {
-		receipt, err := s.GetReceipt(parsedTx.Hash())
+
+		var receipt *types.Receipt
+		err := errors.New("first attempt")
+
+		attempts := 0
+		for err != nil && attempts < maxRetries {
+			receipt, err = s.GetReceipt(parsedTx.Hash())
+
+			if errors.Is(err, syscall.ECONNRESET) {
+				ticker := time.NewTicker(utils.RoutineFlushTimeout)
+				log.Warnf("retrying transaction request: %s", parsedTx.Hash().String())
+				<-ticker.C
+			}
+			attempts += 1
+
+		}
 
 		if err != nil {
+
 			log.Fatalf("unable to retrieve transaction receipt for hash %x: %s", parsedTx.Hash(), err.Error())
-		} else {
-			gasUsed = receipt.GasUsed
-			gasPrice = receipt.EffectiveGasPrice.Uint64()
-			contractAddress = receipt.ContractAddress
 		}
+		gasUsed = receipt.GasUsed
+		gasPrice = receipt.EffectiveGasPrice.Uint64()
+		contractAddress = receipt.ContractAddress
 
 	}
 

--- a/pkg/db/block_metrics.go
+++ b/pkg/db/block_metrics.go
@@ -61,7 +61,7 @@ var (
 
 	DropBlocksQuery = `
 		DELETE FROM t_block_metrics
-		WHERE f_slot >= $1;
+		WHERE f_slot = $1;
 `
 )
 
@@ -130,4 +130,9 @@ func DropBlocks(slot BlockDropType) (string, []interface{}) {
 	resultArgs := make([]interface{}, 0)
 	resultArgs = append(resultArgs, slot)
 	return DropBlocksQuery, resultArgs
+}
+
+func (s *PostgresDBService) DeleteBlockMetrics(slot phase0.Slot) {
+	s.SingleQuery(DropBlocksQuery, slot)
+	s.SingleQuery(DropTransactionsQuery, slot)
 }

--- a/pkg/db/proposer_duties.go
+++ b/pkg/db/proposer_duties.go
@@ -25,7 +25,7 @@ var (
 
 	DropProposerDutiesQuery = `
 	DELETE FROM t_proposer_duties
-	WHERE f_proposer_slot/32 >= $1;
+	WHERE f_proposer_slot/32 = $1;
 `
 )
 

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -243,3 +243,12 @@ type Model interface { // simply to enforce a Model interface
 	// For now we simply support insert operations
 	Type() spec.ModelType // whether insert is activated for this model
 }
+
+func (p *PostgresDBService) SingleQuery(query string, args ...interface{}) error {
+	rows, err := p.psqlPool.Query(p.ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("error executing query %s: %s", query, err.Error())
+	}
+	rows.Close()
+	return nil
+}

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -15,7 +15,7 @@ var (
 
 	DropTransactionsQuery = `
 		DELETE FROM t_transactions
-		WHERE f_slot >= $1;
+		WHERE f_slot = $1;
 `
 )
 

--- a/pkg/metrics/service.go
+++ b/pkg/metrics/service.go
@@ -17,7 +17,7 @@ var (
 	// TODO: Just hardcoded, move to config
 	EndpointUrl string = "metrics"
 
-	MetricLoopInterval time.Duration = 15 * time.Second
+	MetricLoopInterval time.Duration = 5 * time.Second
 )
 
 type PrometheusMetrics struct {

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -11,9 +11,9 @@ import (
 )
 
 type StateMetricsBase struct {
-	PrevState    local_spec.AgnosticState
-	CurrentState local_spec.AgnosticState
-	NextState    local_spec.AgnosticState
+	PrevState    *local_spec.AgnosticState
+	CurrentState *local_spec.AgnosticState
+	NextState    *local_spec.AgnosticState
 }
 
 func (p StateMetricsBase) EpochReward(valIdx phase0.ValidatorIndex) int64 {
@@ -33,7 +33,11 @@ type StateMetrics interface {
 	// https://notes.ethereum.org/@vbuterin/Sys3GLJbD#Epoch-processing
 }
 
-func StateMetricsByForkVersion(nextBstate local_spec.AgnosticState, bstate local_spec.AgnosticState, prevBstate local_spec.AgnosticState, iApi *http.Service) (StateMetrics, error) {
+func StateMetricsByForkVersion(
+	nextBstate *local_spec.AgnosticState,
+	bstate *local_spec.AgnosticState,
+	prevBstate *local_spec.AgnosticState,
+	iApi *http.Service) (StateMetrics, error) {
 	switch nextBstate.Version { // rewards are written at nextState epoch
 
 	case spec.DataVersionPhase0:

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -12,7 +12,10 @@ type AltairMetrics struct {
 	baseMetrics StateMetricsBase
 }
 
-func NewAltairMetrics(nextBstate spec.AgnosticState, bstate spec.AgnosticState, prevBstate spec.AgnosticState) AltairMetrics {
+func NewAltairMetrics(
+	nextBstate *spec.AgnosticState,
+	bstate *spec.AgnosticState,
+	prevBstate *spec.AgnosticState) AltairMetrics {
 
 	altairObj := AltairMetrics{}
 	altairObj.baseMetrics.CurrentState = bstate

--- a/pkg/spec/metrics/state_phase0.go
+++ b/pkg/spec/metrics/state_phase0.go
@@ -14,7 +14,7 @@ type Phase0Metrics struct {
 	baseMetrics StateMetricsBase
 }
 
-func NewPhase0Metrics(nextBstate spec.AgnosticState, currentState spec.AgnosticState, prevState spec.AgnosticState) Phase0Metrics {
+func NewPhase0Metrics(nextBstate *spec.AgnosticState, currentState *spec.AgnosticState, prevState *spec.AgnosticState) Phase0Metrics {
 
 	phase0Obj := Phase0Metrics{}
 	phase0Obj.baseMetrics.NextState = nextBstate

--- a/pkg/utils/book.go
+++ b/pkg/utils/book.go
@@ -14,9 +14,10 @@ type RoutineBook struct {
 	pages         map[string]string
 	freeSpaceChan chan struct{}
 	size          int64
+	bookTag       string
 }
 
-func NewRoutineBook(size int) *RoutineBook {
+func NewRoutineBook(size int, tag string) *RoutineBook {
 
 	r := &RoutineBook{
 		pages:         make(map[string]string, size), // contains a list of keys identifying routines
@@ -39,7 +40,7 @@ func (r *RoutineBook) Acquire(key string) {
 	ticker := time.NewTicker(WaitMaxTimeout)
 	select {
 	case <-ticker.C:
-		log.Fatalf("Waiting for too long to acquire page %s...", key)
+		log.WithField("bookTag", r.bookTag).Fatalf("Waiting for too long to acquire page %s...", key)
 	case <-r.freeSpaceChan:
 		r.Set(key, "active")
 	}

--- a/pkg/utils/book.go
+++ b/pkg/utils/book.go
@@ -130,7 +130,7 @@ func (r *RoutineBook) getCurrentKeys() *metrics.IndvMetrics {
 		return keyList, nil
 	}
 	currentKeys, err := metrics.NewIndvMetrics(
-		r.bookTag+"current_keys",
+		r.bookTag+"-current_keys",
 		initFn,
 		updateFn,
 	)

--- a/pkg/utils/book.go
+++ b/pkg/utils/book.go
@@ -2,11 +2,11 @@ package utils
 
 import (
 	"sync"
+	"time"
 )
 
 var (
 	emptyKey = ""
-	nullPos  = -1
 )
 
 type RoutineBook struct {
@@ -36,8 +36,13 @@ func (r *RoutineBook) Init() {
 
 func (r *RoutineBook) Acquire(key string) {
 
-	<-r.freeSpaceChan
-	r.Set(key, "active")
+	ticker := time.NewTicker(WaitMaxTimeout)
+	select {
+	case <-ticker.C:
+		log.Fatalf("Waiting for too long to acquire page %s...", key)
+	case <-r.freeSpaceChan:
+		r.Set(key, "active")
+	}
 
 }
 

--- a/pkg/utils/book.go
+++ b/pkg/utils/book.go
@@ -38,7 +38,7 @@ func (r *RoutineBook) Init() {
 		ticker := time.NewTicker(5 * RoutineFlushTimeout)
 
 		for range ticker.C {
-			log.WithField("book=", r.bookTag).Warnf("states book: %+v", r.GetKeys())
+			log.Warnf("%s book: %+v", r.bookTag, r.GetKeys())
 		}
 	}()
 

--- a/pkg/utils/book.go
+++ b/pkg/utils/book.go
@@ -38,7 +38,7 @@ func (r *RoutineBook) Init() {
 		ticker := time.NewTicker(5 * RoutineFlushTimeout)
 
 		for range ticker.C {
-			log.Warnf("%s book: %+v", r.bookTag, r.GetKeys())
+			log.Infof("%s book: %+v", r.bookTag, r.GetKeys())
 		}
 	}()
 

--- a/pkg/utils/book.go
+++ b/pkg/utils/book.go
@@ -37,7 +37,6 @@ func (r *RoutineBook) Init() {
 	for i := 0; i < int(r.size); i++ {
 		r.freeSpaceChan <- struct{}{}
 	}
-
 }
 
 func (r *RoutineBook) Acquire(key string) {
@@ -61,6 +60,16 @@ func (r *RoutineBook) FreePage(key string) {
 		delete(r.pages, key)
 		r.freeSpaceChan <- struct{}{}
 	}
+
+}
+
+func (r *RoutineBook) CheckPageActive(key string) bool {
+	r.Lock()
+
+	_, ok := r.pages[key]
+
+	r.Unlock()
+	return ok
 
 }
 

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -4,4 +4,5 @@ import "time"
 
 const (
 	RoutineFlushTimeout = time.Duration(1 * time.Second)
+	WaitMaxTimeout      = 120 * time.Second
 )


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
The first iteration of the whole refactor was to download data asynchronously.
However, we now need to add the orphan detection by checking blocks and states in the background, when the finalized event arrives

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
When a new finalized event is received, roots must be verified until 2 epochs before the finalized slot.
We will maintain 2 epochs before just in case a reorg happens right after the finalized slot (we will need prevState and currentState). Remember our system works with three states.


# Tasks
<!-- Checklist of tasks to do -->
- [x] Detect finalized event
- [x] Launch goroutine to check roots
- [x] If root is not the same as in the history, redownload and rewrite metrics
- [x] Store finalized event in the database    

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->
```
goteth-experimental-goteth-1  | time="2023-10-26T11:09:10Z" level=info msg="New event: epoch 238265, state root: 0x49b5506f744fa82fefd7306151a3aa925979f5a396499b4aede3536a30c42b23" module=Events routine=checkpoint-event
goteth-experimental-goteth-1  | time="2023-10-26T11:09:10Z" level=warning msg="state root for block (slot=7624410) incorrect, redownload" module=analyzer
goteth-experimental-goteth-1  | time="2023-10-26T11:09:10Z" level=warning msg="the beacon block at slot 7624410 does not exist, missing block" module=api-cli
goteth-experimental-goteth-1  | time="2023-10-26T11:09:11Z" level=warning msg="state root for block (slot=7624414) incorrect, redownload" module=analyzer
goteth-experimental-goteth-1  | time="2023-10-26T11:09:11Z" level=warning msg="the beacon block at slot 7624414 does not exist, missing block" module=api-cli
goteth-experimental-goteth-1  | time="2023-10-26T11:09:11Z" level=info msg="checked states until slot 7624416, epoch 238263" module=analyzer```

