### PR TITLE
Feature/got eth validator summary metrics

### DIFF
--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -27,8 +27,13 @@ var (
 		f_total_effective_balance_eth, 
 		f_missing_source, 
 		f_missing_target, 
-		f_missing_head)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		f_missing_head,
+		f_timestamp,
+		f_num_slashed,
+		f_num_active,
+		f_num_exit,
+		f_num_in_activation)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		ON CONFLICT ON CONSTRAINT PK_Epoch
 		DO 
 			UPDATE SET 
@@ -40,7 +45,12 @@ var (
 				f_total_effective_balance_eth = excluded.f_total_effective_balance_eth,
 				f_missing_source = excluded.f_missing_source,
 				f_missing_target = excluded.f_missing_target,
-				f_missing_head = excluded.f_missing_head;
+				f_missing_head = excluded.f_missing_head,
+				f_timestamp = excluded.f_timestamp,
+				f_num_slashed = excluded.f_num_slashed,
+				f_num_active = excluded.f_num_active,
+				f_num_exit = excluded.f_num_exit,
+				f_num_in_activation = excluded.f_num_in_activation;
 	`
 	SelectLastEpoch = `
 		SELECT f_epoch
@@ -67,6 +77,11 @@ func insertEpoch(inputEpoch spec.Epoch) (string, []interface{}) {
 	resultArgs = append(resultArgs, inputEpoch.MissingSource)
 	resultArgs = append(resultArgs, inputEpoch.MissingTarget)
 	resultArgs = append(resultArgs, inputEpoch.MissingHead)
+	resultArgs = append(resultArgs, inputEpoch.Timestamp)
+	resultArgs = append(resultArgs, inputEpoch.NumSlashed)
+	resultArgs = append(resultArgs, inputEpoch.NumActive)
+	resultArgs = append(resultArgs, inputEpoch.NumExit)
+	resultArgs = append(resultArgs, inputEpoch.NumInActivation)
 
 	return UpsertEpoch, resultArgs
 }

--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -29,10 +29,10 @@ var (
 		f_missing_target, 
 		f_missing_head,
 		f_timestamp,
-		f_num_slashed,
-		f_num_active,
-		f_num_exit,
-		f_num_in_activation)
+		f_num_slashed_vals,
+		f_num_active_vals,
+		f_num_exited_vals,
+		f_num_in_activation_vals)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		ON CONFLICT ON CONSTRAINT PK_Epoch
 		DO 
@@ -47,10 +47,10 @@ var (
 				f_missing_target = excluded.f_missing_target,
 				f_missing_head = excluded.f_missing_head,
 				f_timestamp = excluded.f_timestamp,
-				f_num_slashed = excluded.f_num_slashed,
-				f_num_active = excluded.f_num_active,
-				f_num_exit = excluded.f_num_exit,
-				f_num_in_activation = excluded.f_num_in_activation;
+				f_num_slashed_vals = excluded.f_num_slashed_vals,
+				f_num_active_vals = excluded.f_num_active_vals,
+				f_num_exited_vals = excluded.f_num_exited_vals,
+				f_num_in_activation_vals = excluded.f_num_in_activation_vals;
 	`
 	SelectLastEpoch = `
 		SELECT f_epoch
@@ -78,10 +78,10 @@ func insertEpoch(inputEpoch spec.Epoch) (string, []interface{}) {
 	resultArgs = append(resultArgs, inputEpoch.MissingTarget)
 	resultArgs = append(resultArgs, inputEpoch.MissingHead)
 	resultArgs = append(resultArgs, inputEpoch.Timestamp)
-	resultArgs = append(resultArgs, inputEpoch.NumSlashed)
-	resultArgs = append(resultArgs, inputEpoch.NumActive)
-	resultArgs = append(resultArgs, inputEpoch.NumExit)
-	resultArgs = append(resultArgs, inputEpoch.NumInActivation)
+	resultArgs = append(resultArgs, inputEpoch.NumSlashedVals)
+	resultArgs = append(resultArgs, inputEpoch.NumActiveVals)
+	resultArgs = append(resultArgs, inputEpoch.NumExitedVals)
+	resultArgs = append(resultArgs, inputEpoch.NumInActivationVals)
 
 	return UpsertEpoch, resultArgs
 }

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
@@ -1,13 +1,13 @@
 UPDATE t_epoch_metrics_summary
-SET f_num_vals = f_num_active;
+SET f_num_vals = f_num_active_vals;
 
-ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_timestamp;
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_timestamp_vals;
 
-ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_slashed;
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_slashed_vals;
 
-ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_active;
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_active_vals;
 
-ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_exit;
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_exited_vals;
 
-ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_in_activation;
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_in_activation_vals;
 

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
@@ -1,3 +1,6 @@
+UPDATE t_epoch_metrics_summary
+SET f_num_vals = f_num_active;
+
 ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_timestamp;
 
 ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_slashed;
@@ -7,3 +10,4 @@ ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_active;
 ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_exit;
 
 ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_in_activation;
+

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
@@ -1,9 +1,3 @@
--- Drop trigger
-DROP TRIGGER set_default_timestamp ON t_epoch_metrics_summary;
-
--- Drop function
-DROP FUNCTION calculate_default_timestamp();
-
 ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_timestamp;
 
 ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_slashed;

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.down.sql
@@ -1,0 +1,15 @@
+-- Drop trigger
+DROP TRIGGER set_default_timestamp ON t_epoch_metrics_summary;
+
+-- Drop function
+DROP FUNCTION calculate_default_timestamp();
+
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_timestamp;
+
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_slashed;
+
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_active;
+
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_exit;
+
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_in_activation;

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
@@ -14,3 +14,7 @@ ADD COLUMN f_num_exit INTEGER DEFAULT 0;
 
 ALTER TABLE t_epoch_metrics_summary
 ADD COLUMN f_num_in_activation INTEGER DEFAULT 0;
+
+UPDATE t_epoch_metrics_summary
+SET f_num_active = f_num_vals,
+    f_num_vals = 0;

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
@@ -4,17 +4,17 @@ UPDATE t_epoch_metrics_summary
 SET f_timestamp = (SELECT f_genesis_time FROM t_genesis LIMIT 1) + (f_epoch * 32 * 12);
 
 ALTER TABLE t_epoch_metrics_summary
-ADD COLUMN f_num_slashed INTEGER DEFAULT 0;
+ADD COLUMN f_num_slashed_vals INTEGER DEFAULT 0;
 
 ALTER TABLE t_epoch_metrics_summary
-ADD COLUMN f_num_active INTEGER DEFAULT 0;
+ADD COLUMN f_num_active_vals INTEGER DEFAULT 0;
 
 ALTER TABLE t_epoch_metrics_summary
-ADD COLUMN f_num_exit INTEGER DEFAULT 0;
+ADD COLUMN f_num_exited_vals INTEGER DEFAULT 0;
 
 ALTER TABLE t_epoch_metrics_summary
-ADD COLUMN f_num_in_activation INTEGER DEFAULT 0;
+ADD COLUMN f_num_in_activation_vals INTEGER DEFAULT 0;
 
 UPDATE t_epoch_metrics_summary
-SET f_num_active = f_num_vals,
+SET f_num_active_vals = f_num_vals,
     f_num_vals = 0;

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
@@ -1,0 +1,32 @@
+ALTER TABLE t_epoch_metrics_summary ADD COLUMN f_timestamp BIGINT;
+
+CREATE OR REPLACE FUNCTION calculate_default_timestamp()
+  RETURNS TRIGGER AS
+$$
+BEGIN
+  NEW.f_timestamp := (SELECT f_genesis_time FROM t_genesis LIMIT 1) + (NEW.f_epoch * 32 * 12);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+
+CREATE TRIGGER set_default_timestamp
+  BEFORE INSERT ON t_epoch_metrics_summary
+  FOR EACH ROW
+  EXECUTE FUNCTION calculate_default_timestamp();
+
+UPDATE t_epoch_metrics_summary
+SET f_timestamp = (SELECT f_genesis_time FROM t_genesis LIMIT 1) + (f_epoch * 32 * 12);
+
+ALTER TABLE t_epoch_metrics_summary
+ADD COLUMN f_num_slashed INTEGER DEFAULT 0;
+
+ALTER TABLE t_epoch_metrics_summary
+ADD COLUMN f_num_active INTEGER DEFAULT 0;
+
+ALTER TABLE t_epoch_metrics_summary
+ADD COLUMN f_num_exit INTEGER DEFAULT 0;
+
+ALTER TABLE t_epoch_metrics_summary
+ADD COLUMN f_num_in_activation INTEGER DEFAULT 0;

--- a/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
+++ b/pkg/db/migrations/000032_add_epoch_summary_timestamp_and_validator_data.up.sql
@@ -1,21 +1,5 @@
 ALTER TABLE t_epoch_metrics_summary ADD COLUMN f_timestamp BIGINT;
 
-CREATE OR REPLACE FUNCTION calculate_default_timestamp()
-  RETURNS TRIGGER AS
-$$
-BEGIN
-  NEW.f_timestamp := (SELECT f_genesis_time FROM t_genesis LIMIT 1) + (NEW.f_epoch * 32 * 12);
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-
-
-CREATE TRIGGER set_default_timestamp
-  BEFORE INSERT ON t_epoch_metrics_summary
-  FOR EACH ROW
-  EXECUTE FUNCTION calculate_default_timestamp();
-
 UPDATE t_epoch_metrics_summary
 SET f_timestamp = (SELECT f_genesis_time FROM t_genesis LIMIT 1) + (f_epoch * 32 * 12);
 

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -64,4 +64,5 @@ const (
 	ACTIVE_STATUS
 	EXIT_STATUS
 	SLASHED_STATUS
+	NUMBER_OF_STATUS // Add new status before this
 )

--- a/pkg/spec/epoch.go
+++ b/pkg/spec/epoch.go
@@ -17,6 +17,11 @@ type Epoch struct {
 	MissingSource         int
 	MissingTarget         int
 	MissingHead           int
+	Timestamp             int64
+	NumSlashed            int
+	NumActive             int
+	NumExit               int
+	NumInActivation       int
 }
 
 func (f Epoch) Type() ModelType {

--- a/pkg/spec/epoch.go
+++ b/pkg/spec/epoch.go
@@ -18,10 +18,10 @@ type Epoch struct {
 	MissingTarget         int
 	MissingHead           int
 	Timestamp             int64
-	NumSlashed            int
-	NumActive             int
-	NumExit               int
-	NumInActivation       int
+	NumSlashedVals        int
+	NumActiveVals         int
+	NumExitedVals         int
+	NumInActivationVals   int
 }
 
 func (f Epoch) Type() ModelType {

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -74,9 +74,9 @@ func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
 		MissingTarget:         int(s.NextState.GetMissingFlagCount(int(altair.TimelyTargetFlagIndex))),
 		MissingHead:           int(s.NextState.GetMissingFlagCount(int(altair.TimelyHeadFlagIndex))),
 		Timestamp:             int64(s.CurrentState.GenesisTimestamp + uint64(s.CurrentState.Epoch)*local_spec.SlotsPerEpoch*local_spec.SlotSeconds),
-		NumSlashed:            int(s.CurrentState.NumSlashedVals),
-		NumActive:             int(s.CurrentState.NumActiveVals),
-		NumExit:               int(s.CurrentState.NumExitedVals),
-		NumInActivation:       int(s.CurrentState.NumQueuedVals),
+		NumSlashedVals:        int(s.CurrentState.NumSlashedVals),
+		NumActiveVals:         int(s.CurrentState.NumActiveVals),
+		NumExitedVals:         int(s.CurrentState.NumExitedVals),
+		NumInActivationVals:   int(s.CurrentState.NumQueuedVals),
 	}
 }

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -60,16 +60,23 @@ func StateMetricsByForkVersion(
 }
 
 func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
+
 	return local_spec.Epoch{
 		Epoch:                 s.CurrentState.Epoch,
 		Slot:                  s.CurrentState.Slot,
 		NumAttestations:       len(s.NextState.PrevAttestations),
 		NumAttValidators:      int(s.NextState.NumAttestingVals),
-		NumValidators:         int(s.CurrentState.NumActiveVals),
+		NumValidators:         len(s.CurrentState.Validators),
 		TotalBalance:          float32(s.CurrentState.TotalActiveRealBalance) / float32(local_spec.EffectiveBalanceInc),
 		AttEffectiveBalance:   float32(s.NextState.AttestingBalance[altair.TimelyTargetFlagIndex]) / float32(local_spec.EffectiveBalanceInc), // as per BEaconcha.in
 		TotalEffectiveBalance: float32(s.CurrentState.TotalActiveBalance) / float32(local_spec.EffectiveBalanceInc),
 		MissingSource:         int(s.NextState.GetMissingFlagCount(int(altair.TimelySourceFlagIndex))),
 		MissingTarget:         int(s.NextState.GetMissingFlagCount(int(altair.TimelyTargetFlagIndex))),
-		MissingHead:           int(s.NextState.GetMissingFlagCount(int(altair.TimelyHeadFlagIndex)))}
+		MissingHead:           int(s.NextState.GetMissingFlagCount(int(altair.TimelyHeadFlagIndex))),
+		Timestamp:             int64(s.CurrentState.GenesisTimestamp + uint64(s.CurrentState.Epoch)*local_spec.SlotsPerEpoch*local_spec.SlotSeconds),
+		NumSlashed:            int(s.CurrentState.NumSlashedVals),
+		NumActive:             int(s.CurrentState.NumActiveVals),
+		NumExit:               int(s.CurrentState.NumExitedVals),
+		NumInActivation:       int(s.CurrentState.NumQueuedVals),
+	}
 }

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -38,6 +38,7 @@ type AgnosticState struct {
 	SyncCommittee           altair.SyncCommittee              // list of pubkeys in the current sync committe
 	Blocks                  []AgnosticBlock                   // list of blocks in the epoch
 	Withdrawals             []phase0.Gwei                     // one position per validator
+	GenesisTimestamp        uint64                            // genesis timestamp
 }
 
 func GetCustomState(bstate spec.VersionedBeaconState, duties EpochDuties) (AgnosticState, error) {
@@ -323,6 +324,7 @@ func NewPhase0State(bstate spec.VersionedBeaconState, duties EpochDuties) Agnost
 		Slot:             phase0.Slot(bstate.Phase0.Slot),
 		BlockRoots:       bstate.Phase0.BlockRoots,
 		PrevAttestations: bstate.Phase0.PreviousEpochAttestations,
+		GenesisTimestamp: bstate.Phase0.GenesisTime,
 	}
 
 	phase0Obj.Setup()
@@ -335,14 +337,15 @@ func NewPhase0State(bstate spec.VersionedBeaconState, duties EpochDuties) Agnost
 func NewAltairState(bstate spec.VersionedBeaconState, duties EpochDuties) AgnosticState {
 
 	altairObj := AgnosticState{
-		Version:       bstate.Version,
-		Balances:      bstate.Altair.Balances,
-		Validators:    bstate.Altair.Validators,
-		EpochStructs:  duties,
-		Epoch:         phase0.Epoch(bstate.Altair.Slot / SlotsPerEpoch),
-		Slot:          bstate.Altair.Slot,
-		BlockRoots:    bstate.Altair.BlockRoots,
-		SyncCommittee: *bstate.Altair.CurrentSyncCommittee,
+		Version:          bstate.Version,
+		Balances:         bstate.Altair.Balances,
+		Validators:       bstate.Altair.Validators,
+		EpochStructs:     duties,
+		Epoch:            phase0.Epoch(bstate.Altair.Slot / SlotsPerEpoch),
+		Slot:             bstate.Altair.Slot,
+		BlockRoots:       bstate.Altair.BlockRoots,
+		SyncCommittee:    *bstate.Altair.CurrentSyncCommittee,
+		GenesisTimestamp: bstate.Altair.GenesisTime,
 	}
 
 	altairObj.Setup()
@@ -390,14 +393,15 @@ func ProcessAltairAttestations(customState *AgnosticState, participation []altai
 func NewBellatrixState(bstate spec.VersionedBeaconState, duties EpochDuties) AgnosticState {
 
 	bellatrixObj := AgnosticState{
-		Version:       bstate.Version,
-		Balances:      bstate.Bellatrix.Balances,
-		Validators:    bstate.Bellatrix.Validators,
-		EpochStructs:  duties,
-		Epoch:         phase0.Epoch(bstate.Bellatrix.Slot / SlotsPerEpoch),
-		Slot:          bstate.Bellatrix.Slot,
-		BlockRoots:    bstate.Bellatrix.BlockRoots,
-		SyncCommittee: *bstate.Bellatrix.CurrentSyncCommittee,
+		Version:          bstate.Version,
+		Balances:         bstate.Bellatrix.Balances,
+		Validators:       bstate.Bellatrix.Validators,
+		EpochStructs:     duties,
+		Epoch:            phase0.Epoch(bstate.Bellatrix.Slot / SlotsPerEpoch),
+		Slot:             bstate.Bellatrix.Slot,
+		BlockRoots:       bstate.Bellatrix.BlockRoots,
+		SyncCommittee:    *bstate.Bellatrix.CurrentSyncCommittee,
+		GenesisTimestamp: bstate.Bellatrix.GenesisTime,
 	}
 
 	bellatrixObj.Setup()
@@ -411,14 +415,15 @@ func NewBellatrixState(bstate spec.VersionedBeaconState, duties EpochDuties) Agn
 func NewCapellaState(bstate spec.VersionedBeaconState, duties EpochDuties) AgnosticState {
 
 	capellaObj := AgnosticState{
-		Version:       bstate.Version,
-		Balances:      bstate.Capella.Balances,
-		Validators:    bstate.Capella.Validators,
-		EpochStructs:  duties,
-		Epoch:         phase0.Epoch(bstate.Capella.Slot / SlotsPerEpoch),
-		Slot:          bstate.Capella.Slot,
-		BlockRoots:    bstate.Capella.BlockRoots,
-		SyncCommittee: *bstate.Capella.CurrentSyncCommittee,
+		Version:          bstate.Version,
+		Balances:         bstate.Capella.Balances,
+		Validators:       bstate.Capella.Validators,
+		EpochStructs:     duties,
+		Epoch:            phase0.Epoch(bstate.Capella.Slot / SlotsPerEpoch),
+		Slot:             bstate.Capella.Slot,
+		BlockRoots:       bstate.Capella.BlockRoots,
+		SyncCommittee:    *bstate.Capella.CurrentSyncCommittee,
+		GenesisTimestamp: bstate.Capella.GenesisTime,
 	}
 
 	capellaObj.Setup()
@@ -432,14 +437,15 @@ func NewCapellaState(bstate spec.VersionedBeaconState, duties EpochDuties) Agnos
 func NewDenebState(bstate spec.VersionedBeaconState, duties EpochDuties) AgnosticState {
 
 	denebObj := AgnosticState{
-		Version:       bstate.Version,
-		Balances:      bstate.Deneb.Balances,
-		Validators:    bstate.Deneb.Validators,
-		EpochStructs:  duties,
-		Epoch:         phase0.Epoch(bstate.Deneb.Slot / SlotsPerEpoch),
-		Slot:          bstate.Deneb.Slot,
-		BlockRoots:    bstate.Deneb.BlockRoots,
-		SyncCommittee: *bstate.Deneb.CurrentSyncCommittee,
+		Version:          bstate.Version,
+		Balances:         bstate.Deneb.Balances,
+		Validators:       bstate.Deneb.Validators,
+		EpochStructs:     duties,
+		Epoch:            phase0.Epoch(bstate.Deneb.Slot / SlotsPerEpoch),
+		Slot:             bstate.Deneb.Slot,
+		BlockRoots:       bstate.Deneb.BlockRoots,
+		SyncCommittee:    *bstate.Deneb.CurrentSyncCommittee,
+		GenesisTimestamp: bstate.Deneb.GenesisTime,
 	}
 
 	denebObj.Setup()

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -144,7 +144,7 @@ func (p *AgnosticState) GetTotalActiveEffBalance() phase0.Gwei {
 	return p.ValsEffectiveBalance(val_array)
 }
 
-func (p AgnosticState) GetValsStateNums() {
+func (p *AgnosticState) GetValsStateNums() {
 	result := p.GetValsPerStatus()
 	p.NumActiveVals = uint(len(result[ACTIVE_STATUS]))
 	p.NumExitedVals = uint(len(result[EXIT_STATUS]))

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -267,12 +267,12 @@ func (p AgnosticState) GetMissingFlagCount(flagIndex int) uint64 {
 
 func (p AgnosticState) GetValStatus(valIdx phase0.ValidatorIndex) ValidatorStatus {
 
-	if p.Validators[valIdx].ExitEpoch <= phase0.Epoch(p.Epoch) {
-		return EXIT_STATUS
-	}
-
 	if p.Validators[valIdx].Slashed {
 		return SLASHED_STATUS
+	}
+
+	if p.Validators[valIdx].ExitEpoch <= phase0.Epoch(p.Epoch) {
+		return EXIT_STATUS
 	}
 
 	if p.Validators[valIdx].ActivationEpoch <= phase0.Epoch(p.Epoch) {

--- a/tests/db_epoch_metrics_test.py
+++ b/tests/db_epoch_metrics_test.py
@@ -5,11 +5,11 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
     db_config_file = ".env"
 
     def test_num_validators_equals_sum_of_val_states(self):
-        """ Columns f_num_slashed, f_num_active, f_num_exit, f_num_in_activation should sum up to f_num_vals"""
+        """ Columns f_num_slashed_vals, f_num_active_vals, f_num_exited_vals, f_num_in_activation_vals should sum up to f_num_vals"""
         sql_query = """
         SELECT *
         FROM t_epoch_metrics_summary
-        WHERE (f_num_slashed + f_num_active + f_num_exit + f_num_in_activation) != f_num_vals;
+        WHERE (f_num_slashed_vals + f_num_active_vals + f_num_exited_vals + f_num_in_activation_vals) != f_num_vals;
         """
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)

--- a/tests/db_epoch_metrics_test.py
+++ b/tests/db_epoch_metrics_test.py
@@ -1,0 +1,20 @@
+import unittest
+import unit_db_test.testcase as dbtest
+
+class CheckIntegrityOfDB(dbtest.DBintegrityTest):
+    db_config_file = ".env"
+
+    def test_num_validators_equals_sum_of_val_states(self):
+        """ Columns f_num_slashed, f_num_active, f_num_exit, f_num_in_activation should sum up to f_num_vals"""
+        sql_query = """
+        SELECT *
+        FROM t_epoch_metrics_summary
+        WHERE (f_num_slashed + f_num_active + f_num_exit + f_num_in_activation) != f_num_vals;
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/tests/db_transactions_test.py
+++ b/tests/db_transactions_test.py
@@ -32,13 +32,15 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
         self.assertNoRows(df)
 
     def test_number_of_blocks_across_tables(self):
-        """The test ensures that the are the same number of blocks in across the existing tables"""
+        """The test ensures that there are no transactions from missed or 0 transactions blocks"""
         sql_query = """
-        select *
-        from t_transactions
-        inner join t_block_metrics
-        on t_transactions.f_slot = t_block_metrics.f_slot
-        where f_el_transactions = 0 or f_proposed = false
+    	select *
+		from t_block_metrics
+		where f_slot in (
+			select f_slot
+			from t_transactions
+		) and (f_el_transactions = 0 or f_proposed = false)
+		order by f_slot desc
         """
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)

--- a/tests/db_validator_test.py
+++ b/tests/db_validator_test.py
@@ -4,7 +4,7 @@ import unit_db_test.testcase as dbtest
 class CheckIntegrityOfDB(dbtest.DBintegrityTest):
     db_config_file = ".env"
 
-    def test_orphan_blocks_in_block_metrics(self):
+    def test_reward_not_gt_than_max(self):
         """ After the last update to v2.0.0 the rewards must never exceed the f_max_reward """
         sql_query = """
         select *


### PR DESCRIPTION
# Motivation
We aim to have detection and evolution of active, exited and slashed validators. For this, we would like to add a summary of these groups to the epoch metrics table, so we can see how these numbers evolve throughout the chain.
 
# Description

Per EpochTransition, update four variables:

- NumSlashedVals
- NumActiveVals
- NumExitedVals
- NumInActivationVals
- Timestamp (prefill in migration)

# Tasks

- [x]  Add new columns to `t_epoch_metrics_summary` and a timestamp (migrations)
- [x]  Timestamp can be precalculated upon migration. `timestamp` = `genesis_time` + `epoch` * 32 (blocks per epoch) * 12 (seconds per slot)
- [x]  Modify `GetValStatus` to prioritize slashing check before exit
- [x]  Create a new function `GetValsPerStatus` in `pkg>spec>state.go`. The method will not only collect active validators but also slashed, exit and in activation, using  `GetValStatus` from
- [x]  Add new fields in `AgnosticState` struct for filling the new columns (`NumSlashedVals`, `NumExitedVals`, `NumInActivationVals`) .
- [x]  Remove update of `NumActiveVals` in `GetTotalActiveEffBalance`.
- [x]  Create function to update validator state num fields in `Setup`.  Use newly created function `GetValsPerStatus`
- [x]  Add field  `GenesisTimestamp` in `AgnosticState` for calculating epoch timestamp. Bring it in the constructors of Phase0, Altair, Capella y Deneb
- [x]  Change epoch sql query to have 4 new columns + timestamp (Update `Epoch` struct). Also change `ExportToEpoch` func
- [x]  Convert DB column `f_num_vals` into total number of validators instead of active validators.
- [x]  Make tests for the total sum of validators

# Proof of Success 
Capture from script running in Sepolia:
![image](https://github.com/migalabs/goteth/assets/45318759/083fc9a0-5110-4e9b-9458-7309f0552ce4)

