### PR TITLE
Feature/store headevent arrival timestamp

### DIFF
--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -66,11 +66,13 @@ func (s *ChainAnalyzer) runHead() {
 	for {
 		select {
 
-		case headSlot := <-s.eventsObj.HeadChan: // wait for new head event
+		case headEvent := <-s.eventsObj.HeadChan: // wait for new head event
 			// make the block query
-			log.Tracef("received new head signal: %d", headSlot)
+			log.Tracef("received new head signal: %d", headEvent.Slot)
+			timestamp := time.Now().Unix()
 
-			for nextSlotDownload <= headSlot {
+			s.dbClient.Persist(db.HeadEventTypeFromHeadEvent(headEvent, timestamp))
+			for nextSlotDownload <= headEvent.Slot {
 
 				if s.processerBook.NumFreePages() > 0 {
 					s.downloadTaskChan <- nextSlotDownload

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -66,13 +66,11 @@ func (s *ChainAnalyzer) runHead() {
 	for {
 		select {
 
-		case headEvent := <-s.eventsObj.HeadChan: // wait for new head event
+		case event := <-s.eventsObj.HeadChan: // wait for new head event
 			// make the block query
-			log.Tracef("received new head signal: %d", headEvent.Slot)
-			timestamp := time.Now().Unix()
-
-			s.dbClient.Persist(db.HeadEventTypeFromHeadEvent(headEvent, timestamp))
-			for nextSlotDownload <= headEvent.Slot {
+			log.Tracef("received new head signal: %d", event.HeadEvent.Slot)
+			s.dbClient.Persist(event)
+			for nextSlotDownload <= event.HeadEvent.Slot {
 
 				if s.processerBook.NumFreePages() > 0 {
 					s.downloadTaskChan <- nextSlotDownload

--- a/pkg/db/head_events.go
+++ b/pkg/db/head_events.go
@@ -1,0 +1,70 @@
+package db
+
+/*
+
+This file together with the model, has all the needed methods to interact with the epoch_metrics table of the database
+
+*/
+
+import (
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+// Postgres intregration variables
+var (
+	UpsertHeadEvent = `
+	INSERT INTO t_head_events (
+		f_slot,
+		f_block,
+		f_state,
+		f_epoch_transition,
+		f_current_duty_dependent_root,
+		f_previous_duty_dependent_root,
+		f_arrival_timestamp)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT ON CONSTRAINT PK_Block
+		DO 
+			UPDATE SET
+				f_slot = excluded.f_slot, 
+				f_block = excluded.f_block,
+				f_state = excluded.f_state,
+				f_epoch_transition = excluded.f_epoch_transition,
+				f_current_duty_dependent_root = excluded.f_current_duty_dependent_root,
+				f_previous_duty_dependent_root = excluded.f_previous_duty_dependent_root,
+				f_arrival_timestamp = excluded.f_arrival_timestamp;
+	`
+)
+
+func insertHeadEvent(inputHeadEvent api.HeadEvent, arrivalTimestamp int64) (string, []interface{}) {
+	resultArgs := make([]interface{}, 0)
+	resultArgs = append(resultArgs, inputHeadEvent.Slot)
+	resultArgs = append(resultArgs, inputHeadEvent.Block)
+	resultArgs = append(resultArgs, inputHeadEvent.State)
+	resultArgs = append(resultArgs, inputHeadEvent.EpochTransition)
+	resultArgs = append(resultArgs, inputHeadEvent.CurrentDutyDependentRoot)
+	resultArgs = append(resultArgs, inputHeadEvent.PreviousDutyDependentRoot)
+	resultArgs = append(resultArgs, arrivalTimestamp)
+	return UpsertHeadEvent, resultArgs
+}
+
+func HeadEventOperation(inputHeadEvent HeadEventType) (string, []interface{}) {
+	q, args := insertHeadEvent(inputHeadEvent.HeadEvent, inputHeadEvent.ArrivalTimestamp)
+	return q, args
+}
+
+type HeadEventType struct {
+	HeadEvent        api.HeadEvent
+	ArrivalTimestamp int64
+}
+
+func (s HeadEventType) Type() spec.ModelType {
+	return spec.HeadEventModel
+}
+
+func HeadEventTypeFromHeadEvent(input api.HeadEvent, arrivalTimestamp int64) HeadEventType {
+	return HeadEventType{
+		HeadEvent:        input,
+		ArrivalTimestamp: arrivalTimestamp,
+	}
+}

--- a/pkg/db/migrations/000034_add_head_events_table.down.sql
+++ b/pkg/db/migrations/000034_add_head_events_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS t_head_events;

--- a/pkg/db/migrations/000034_add_head_events_table.up.sql
+++ b/pkg/db/migrations/000034_add_head_events_table.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS t_head_events(
+	f_slot INT,
+    f_block TEXT,
+    f_state TEXT,
+    f_epoch_transition BOOLEAN,
+    f_current_duty_dependent_root TEXT,
+    f_previous_duty_dependent_root TEXT,
+	f_arrival_timestamp BIGINT,
+	CONSTRAINT PK_Block PRIMARY KEY (f_block));

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -199,6 +199,10 @@ func (p *PostgresDBService) runWriters() {
 						q, args := InsertCheckpoint(task.(CheckpointType))
 						persis.query = q
 						persis.values = append(persis.values, args...)
+					case spec.HeadEventModel:
+						q, args := HeadEventOperation(task.(HeadEventType))
+						persis.query = q
+						persis.values = append(persis.values, args...)
 					default:
 						err = fmt.Errorf("could not figure out the type of write task")
 						wlog.Errorf("could not process incoming task, %s", err)

--- a/pkg/events/head.go
+++ b/pkg/events/head.go
@@ -1,6 +1,10 @@
 package events
 
 import (
+	"time"
+
+	"github.com/migalabs/goteth/pkg/db"
+
 	api "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/migalabs/goteth/pkg/spec"
@@ -16,6 +20,7 @@ func (e Events) SubscribeToHeadEvents() {
 }
 
 func (e *Events) HandleHeadEvent(event *api.Event) {
+	timestamp := time.Now().UnixNano() / 1000000
 	log := log.WithField("routine", "head-event")
 	if event.Data == nil {
 		return
@@ -29,7 +34,7 @@ func (e *Events) HandleHeadEvent(event *api.Event) {
 		(int(headEpoch+1)*spec.EpochSlots)-int(data.Slot))
 
 	select { // only notify if we can
-	case e.HeadChan <- *data:
+	case e.HeadChan <- db.HeadEventTypeFromHeadEvent(*data, timestamp):
 	default:
 	}
 

--- a/pkg/events/head.go
+++ b/pkg/events/head.go
@@ -20,7 +20,6 @@ func (e *Events) HandleHeadEvent(event *api.Event) {
 	if event.Data == nil {
 		return
 	}
-
 	data := event.Data.(*api.HeadEvent) // cast to head event
 	headEpoch := phase0.Epoch(data.Slot) / spec.SlotsPerEpoch
 
@@ -30,7 +29,7 @@ func (e *Events) HandleHeadEvent(event *api.Event) {
 		(int(headEpoch+1)*spec.EpochSlots)-int(data.Slot))
 
 	select { // only notify if we can
-	case e.HeadChan <- data.Slot:
+	case e.HeadChan <- *data:
 	default:
 	}
 

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	api "github.com/attestantio/go-eth2-client/api/v1"
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/migalabs/goteth/pkg/clientapi"
 	"github.com/sirupsen/logrus"
 )
@@ -19,7 +18,7 @@ type Events struct {
 	ctx            context.Context
 	cli            *clientapi.APIClient
 	SubscribedHead bool
-	HeadChan       chan phase0.Slot
+	HeadChan       chan api.HeadEvent
 
 	SubscribedFinalized bool
 	FinalizedChan       chan api.FinalizedCheckpointEvent
@@ -31,7 +30,7 @@ func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 		ctx:                 iCtx,
 		cli:                 iCli,
 		SubscribedHead:      false,
-		HeadChan:            make(chan phase0.Slot),
+		HeadChan:            make(chan api.HeadEvent),
 		SubscribedFinalized: false,
 		FinalizedChan:       make(chan api.FinalizedCheckpointEvent),
 		ReorgChan:           make(chan api.ChainReorgEvent),

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/migalabs/goteth/pkg/clientapi"
+	"github.com/migalabs/goteth/pkg/db"
 	"github.com/sirupsen/logrus"
 )
 
@@ -18,7 +19,7 @@ type Events struct {
 	ctx            context.Context
 	cli            *clientapi.APIClient
 	SubscribedHead bool
-	HeadChan       chan api.HeadEvent
+	HeadChan       chan db.HeadEventType
 
 	SubscribedFinalized bool
 	FinalizedChan       chan api.FinalizedCheckpointEvent
@@ -30,7 +31,7 @@ func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 		ctx:                 iCtx,
 		cli:                 iCli,
 		SubscribedHead:      false,
-		HeadChan:            make(chan api.HeadEvent),
+		HeadChan:            make(chan db.HeadEventType),
 		SubscribedFinalized: false,
 		FinalizedChan:       make(chan api.FinalizedCheckpointEvent),
 		ReorgChan:           make(chan api.ChainReorgEvent),

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -57,6 +57,7 @@ const (
 	TransactionDropModel
 	ReorgModel
 	FinalizedCheckpointModel
+	HeadEventModel
 )
 
 type ValidatorStatus int8

--- a/tests/db_head_events_test.py
+++ b/tests/db_head_events_test.py
@@ -1,0 +1,22 @@
+import unittest
+import unit_db_test.testcase as dbtest
+
+class CheckIntegrityOfDB(dbtest.DBintegrityTest):
+    db_config_file = ".env"
+
+    def test_arrival_timestamp_not_gt_block_timestamp(self):
+        """ On the edge case where the arrival timestamp is not greater than the block timestamp, which is not possible """
+        sql_query = """
+        SELECT *
+        FROM t_head_events
+        JOIN t_block_metrics ON t_head_events.f_slot = t_block_metrics.f_slot
+        WHERE t_head_events.f_arrival_timestamp < t_block_metrics.f_timestamp;
+
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+if __name__ == '__main__':
+    unittest.main()
+
+

--- a/tests/db_head_events_test.py
+++ b/tests/db_head_events_test.py
@@ -10,7 +10,7 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
         SELECT *
         FROM t_head_events
         JOIN t_block_metrics ON t_head_events.f_slot = t_block_metrics.f_slot
-        WHERE t_head_events.f_arrival_timestamp < t_block_metrics.f_timestamp;
+        WHERE t_head_events.f_arrival_timestamp / 1000 < t_block_metrics.f_timestamp;
 
         """
         df = self.db.get_df_from_sql_query(sql_query)


### PR DESCRIPTION
# Motivation
It is important to measure when a new block was received to see if it was a late block that took time to be imported.

_Related links:_

-  [Beacon API](https://ethereum.github.io/beacon-APIs/#/Events/eventstream)


# Description
Right now, we have a timestamp for each block but it represents the timestamp of the slot since genesis. We want to also know the `arrival_timestamp`, which represents the timestamp at which we received the new block through a head event.

This could be done using the `headEvent` timestamp when the tool follows the head, and the timestamp we already have when running historical.

# Tasks
- [x]  Create `t_head_events` table storing the head events data and also the arrival timestamp.(migrations up and down)
- [x]  Insert head event into `t_head_events` on `/pkg/events/head.go` `HandleHeadEvent`.
- [x]  Test that `arrival_timestamp` > `block_timestamp`

# Proof of Success 

![image](https://github.com/migalabs/goteth/assets/45318759/5234dff6-8fbb-4c67-9d73-7489c6a79bad)

