### PR TITLE
Fix wrong epoch timestamp column

### DIFF
--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -45,7 +45,6 @@ var (
 func epochsInput(epochs []spec.Epoch) proto.Input {
 	// one object per column
 	var (
-		f_timestamp                   proto.ColUInt64
 		f_epoch                       proto.ColUInt64
 		f_slot                        proto.ColUInt64
 		f_num_att                     proto.ColUInt64
@@ -57,6 +56,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		f_missing_source              proto.ColUInt64
 		f_missing_target              proto.ColUInt64
 		f_missing_head                proto.ColUInt64
+		f_timestamp                   proto.ColUInt64
 		f_num_slashed_vals            proto.ColUInt64
 		f_num_active_vals             proto.ColUInt64
 		f_num_exited_vals             proto.ColUInt64
@@ -64,7 +64,6 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 	)
 
 	for _, epoch := range epochs {
-		f_timestamp.Append(uint64(epoch.Timestamp))
 		f_epoch.Append(uint64(epoch.Epoch))
 		f_slot.Append(uint64(epoch.Slot))
 		f_num_att.Append(uint64(epoch.NumAttestations))
@@ -76,6 +75,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		f_missing_source.Append(uint64(epoch.MissingSource))
 		f_missing_target.Append(uint64(epoch.MissingTarget))
 		f_missing_head.Append(uint64(epoch.MissingHead))
+		f_timestamp.Append(uint64(epoch.Timestamp))
 		f_num_slashed_vals.Append(uint64(epoch.NumSlashedVals))
 		f_num_active_vals.Append(uint64(epoch.NumActiveVals))
 		f_num_exited_vals.Append(uint64(epoch.NumExitedVals))
@@ -84,8 +84,6 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 	}
 
 	return proto.Input{
-
-		{Name: "f_timestamp", Data: f_timestamp},
 		{Name: "f_epoch", Data: f_epoch},
 		{Name: "f_slot", Data: f_slot},
 		{Name: "f_num_att", Data: f_num_att},
@@ -97,6 +95,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		{Name: "f_missing_source", Data: f_missing_source},
 		{Name: "f_missing_target", Data: f_missing_target},
 		{Name: "f_missing_head", Data: f_missing_head},
+		{Name: "f_timestamp", Data: f_timestamp},
 		{Name: "f_num_slashed_vals", Data: f_num_slashed_vals},
 		{Name: "f_num_active_vals", Data: f_num_active_vals},
 		{Name: "f_num_exited_vals", Data: f_num_exited_vals},

--- a/pkg/db/migrations/000001_init_schema.up.sql
+++ b/pkg/db/migrations/000001_init_schema.up.sql
@@ -56,7 +56,6 @@ CREATE TABLE IF NOT EXISTS t_orphans(
 	ORDER BY (f_slot);
 
 CREATE TABLE IF NOT EXISTS t_epoch_metrics_summary(
-	f_timestamp UInt64,
 	f_epoch UInt64,
 	f_slot UInt64,
 	f_num_att UInt64,
@@ -68,6 +67,7 @@ CREATE TABLE IF NOT EXISTS t_epoch_metrics_summary(
 	f_missing_source UInt64, 
 	f_missing_target UInt64,
 	f_missing_head UInt64,
+	f_timestamp UInt64,
 	f_num_slashed_vals UInt64 DEFAULT 0,
 	f_num_active_vals UInt64 DEFAULT 0,
 	f_num_exited_vals UInt64 DEFAULT 0,
@@ -122,13 +122,13 @@ CREATE TABLE IF NOT EXISTS t_transactions(
     f_value Float,
     f_nonce UInt64,
     f_to TEXT DEFAULT '',
-	f_from TEXT DEFAULT '',
-	f_contract_address TEXT DEFAULT '',
-    f_hash TEXT,
-    f_size UInt64,
+	f_hash TEXT,
+	f_size UInt64,
 	f_slot UInt64,
 	f_el_block_number UInt64,
-	f_timestamp UInt64)
+	f_timestamp UInt64,
+	f_from TEXT DEFAULT '',
+	f_contract_address TEXT DEFAULT '')
 	ENGINE = ReplacingMergeTree()
 	ORDER BY (f_slot, f_el_block_number, f_hash);
 


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
After the migration from PostgreSQL to Clickhouse we realized some columns were not ordered, and behaviour when migrating had changed. These changes should fix the issue, which allows to migrate the database properly.
_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
Alter the order of the columns, which is relevant when migrating the database.

# Tasks
<!-- Checklist of tasks to do -->
- [ ] 

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

