### PR TITLE
Reorgs should consider blocks from the reorg base to the head

### DIFF
--- a/pkg/analyzer/chain_cache.go
+++ b/pkg/analyzer/chain_cache.go
@@ -62,6 +62,12 @@ func (s *ChainCache) AddNewBlock(block *spec.AgnosticBlock) {
 
 }
 
+func (s *ChainCache) GetHeadBlock() spec.AgnosticBlock {
+	s.Lock()
+	defer s.Unlock()
+	return *s.HeadBlock
+}
+
 func (s *ChainCache) CleanUpTo(maxSlot phase0.Slot) {
 
 	stateKeys := s.StateHistory.GetKeyList()


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
Reorgs can be difficult to handle. During our testing phase, we realized that some reorgs were not properly handled.
This PR aims to solve the issue and consider there are many edgy cases to contemplate.
_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
If a reorg of depth 2 hits, we must go 2 blocks back (not slots, this is, proposed blocks) and recheck roots from there onwards until the head of the chain.
On top of that, some edgy cases were not handled properly, which we have solved by redownloading any mismatched block when a new finalized checkpoint hits. This should cover any reorg we have not handled properly.

Closes:
- #103 
- #91 

# Tasks
<!-- Checklist of tasks to do -->
- [x] Consider proposed blocks only when a reorg hits
- [x] Consider checking the roots of the blocks until the current head of the chain
- [x] Recheck block and state roots when a new finalized checkpoint hits   

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

```
goteth_1      | time="2024-02-28T09:20:06Z" level=info msg="New event: slot 1100800, epoch 34400. 32 pending slots for new epoch" module=Events routine=head-event
goteth_1      | time="2024-02-28T09:20:06Z" level=info msg="block at slot 1100800 downloaded in 0.048187 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:17Z" level=info msg="New event: slot 1100801 of depth 1" module=Events routine=reorg-event
goteth_1      | time="2024-02-28T09:20:17Z" level=info msg="New event: slot 1100801, epoch 34400. 31 pending slots for new epoch" module=Events routine=head-event
goteth_1      | time="2024-02-28T09:20:18Z" level=warning msg="the beacon block at slot 1100800 does not exist, missing block" module=api-cli
goteth_1      | time="2024-02-28T09:20:18Z" level=info msg="query: \n\t\tDELETE FROM t_block_metrics\n\t\tWHERE f_slot = $1;\n finished in 0.014361 seconds" module=db
goteth_1      | time="2024-02-28T09:20:18Z" level=info msg="query: \n\t\tDELETE FROM t_transactions\n\t\tWHERE f_slot = $1;\n finished in 0.001870 seconds" module=db
goteth_1      | time="2024-02-28T09:20:18Z" level=info msg="query: \n\t\tDELETE FROM t_withdrawals\n\t\tWHERE f_slot = $1; finished in 0.010410 seconds" module=db
goteth_1      | time="2024-02-28T09:20:18Z" level=info msg="rewriting metrics for slot 1100800" module=analyzer
goteth_1      | time="2024-02-28T09:20:19Z" level=info msg="block at slot 1100799 downloaded in 0.044923 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:19Z" level=info msg="reorg slot 1100799: block roots are the same" module=analyzer
goteth_1      | time="2024-02-28T09:20:21Z" level=info msg="state at slot 1100799 downloaded in 0.913693 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:24Z" level=info msg="New event: slot 1100801 of depth 2" module=Events routine=reorg-event
goteth_1      | time="2024-02-28T09:20:24Z" level=info msg="New event: slot 1100801, epoch 34400. 31 pending slots for new epoch" module=Events routine=head-event
goteth_1      | time="2024-02-28T09:20:25Z" level=info msg="block at slot 1100800 downloaded in 0.038929 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:25Z" level=info msg="query: \n\t\tDELETE FROM t_block_metrics\n\t\tWHERE f_slot = $1;\n finished in 0.017524 seconds" module=db
goteth_1      | time="2024-02-28T09:20:25Z" level=info msg="query: \n\t\tDELETE FROM t_transactions\n\t\tWHERE f_slot = $1;\n finished in 0.002684 seconds" module=db
goteth_1      | time="2024-02-28T09:20:25Z" level=info msg="query: \n\t\tDELETE FROM t_withdrawals\n\t\tWHERE f_slot = $1; finished in 0.009093 seconds" module=db
goteth_1      | time="2024-02-28T09:20:25Z" level=info msg="rewriting metrics for slot 1100800" module=analyzer
goteth_1      | time="2024-02-28T09:20:26Z" level=info msg="New event: slot 1100802, epoch 34400. 30 pending slots for new epoch" module=Events routine=head-event
goteth_1      | time="2024-02-28T09:20:26Z" level=warning msg="the beacon block at slot 1100801 does not exist, missing block" module=api-cli
goteth_1      | time="2024-02-28T09:20:26Z" level=info msg="block at slot 1100802 downloaded in 0.060985 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:26Z" level=info msg="block at slot 1100799 downloaded in 0.049235 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:26Z" level=info msg="reorg slot 1100799: block roots are the same" module=analyzer
goteth_1      | time="2024-02-28T09:20:28Z" level=info msg="state at slot 1100799 downloaded in 0.949652 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:31Z" level=info msg="block at slot 1100798 downloaded in 0.097438 seconds" module=api-cli
goteth_1      | time="2024-02-28T09:20:31Z" level=info msg="reorg slot 1100798: block roots are the same" module=analyzer
```



