### PR TITLE
Request Txs and Blobs in bulk

### DIFF
--- a/pkg/analyzer/chain_cache.go
+++ b/pkg/analyzer/chain_cache.go
@@ -8,8 +8,9 @@ import (
 )
 
 type ChainCache struct {
-	StateHistory *AgnosticMap[spec.AgnosticState]
-	BlockHistory *AgnosticMap[spec.AgnosticBlock] // Here we will store stateroots from the blocks
+	StateHistory       *AgnosticMap[spec.AgnosticState]
+	BlockHistory       *AgnosticMap[spec.AgnosticBlock] // Here we will store stateroots from the blocks
+	BlobSidecarHistory *AgnosticMap[spec.BlobSidecarsInSlot]
 
 	sync.Mutex
 	HeadBlock       *spec.AgnosticBlock
@@ -18,8 +19,9 @@ type ChainCache struct {
 
 func NewQueue() ChainCache {
 	return ChainCache{
-		StateHistory: NewAgnosticMap[spec.AgnosticState](),
-		BlockHistory: NewAgnosticMap[spec.AgnosticBlock](),
+		StateHistory:       NewAgnosticMap[spec.AgnosticState](),
+		BlockHistory:       NewAgnosticMap[spec.AgnosticBlock](),
+		BlobSidecarHistory: NewAgnosticMap[spec.BlobSidecarsInSlot](),
 	}
 }
 
@@ -59,6 +61,14 @@ func (s *ChainCache) AddNewBlock(block *spec.AgnosticBlock) {
 	s.Lock()
 	s.HeadBlock = block
 	s.Unlock()
+
+}
+
+func (s *ChainCache) AddNewBlobSidecarsInSlot(blobs *spec.BlobSidecarsInSlot) {
+
+	s.BlobSidecarHistory.Set(SlotTo[uint64](blobs.Slot), blobs) // create space for blobs
+
+	log.Tracef("blob sidecar at slot %d successfully added to the queue", blobs.Slot)
 
 }
 

--- a/pkg/analyzer/chain_cache.go
+++ b/pkg/analyzer/chain_cache.go
@@ -8,9 +8,8 @@ import (
 )
 
 type ChainCache struct {
-	StateHistory       *AgnosticMap[spec.AgnosticState]
-	BlockHistory       *AgnosticMap[spec.AgnosticBlock] // Here we will store stateroots from the blocks
-	BlobSidecarHistory *AgnosticMap[spec.BlobSidecarsInSlot]
+	StateHistory *AgnosticMap[spec.AgnosticState]
+	BlockHistory *AgnosticMap[spec.AgnosticBlock] // Here we will store stateroots from the blocks
 
 	sync.Mutex
 	HeadBlock       *spec.AgnosticBlock
@@ -19,9 +18,8 @@ type ChainCache struct {
 
 func NewQueue() ChainCache {
 	return ChainCache{
-		StateHistory:       NewAgnosticMap[spec.AgnosticState](),
-		BlockHistory:       NewAgnosticMap[spec.AgnosticBlock](),
-		BlobSidecarHistory: NewAgnosticMap[spec.BlobSidecarsInSlot](),
+		StateHistory: NewAgnosticMap[spec.AgnosticState](),
+		BlockHistory: NewAgnosticMap[spec.AgnosticBlock](),
 	}
 }
 
@@ -61,14 +59,6 @@ func (s *ChainCache) AddNewBlock(block *spec.AgnosticBlock) {
 	s.Lock()
 	s.HeadBlock = block
 	s.Unlock()
-
-}
-
-func (s *ChainCache) AddNewBlobSidecarsInSlot(blobs *spec.BlobSidecarsInSlot) {
-
-	s.BlobSidecarHistory.Set(SlotTo[uint64](blobs.Slot), blobs) // create space for blobs
-
-	log.Tracef("blob sidecar at slot %d successfully added to the queue", blobs.Slot)
 
 }
 

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -49,21 +49,12 @@ func (s *ChainAnalyzer) ProcessBlock(slot phase0.Slot) {
 
 func (s *ChainAnalyzer) processTransactions(block *spec.AgnosticBlock) {
 
-	var transactions []spec.AgnosticTransaction
-	for idx, tx := range block.ExecutionPayload.Transactions {
-		detailedTx, err := s.cli.RequestTransactionDetails(
-			tx,
-			block.Slot,
-			block.ExecutionPayload.BlockNumber,
-			block.ExecutionPayload.Timestamp)
-		if err != nil {
-			log.Errorf("could not request transaction details in slot %d for transaction %d: %s", block.Slot, idx, err)
-		}
-
-		transactions = append(transactions, *detailedTx)
+	txs, err := s.cli.GetBlockTransactions(*block)
+	if err != nil {
+		log.Errorf("error getting slot %d transactions: %s", block.Slot, err.Error())
 	}
-	log.Tracef("persisting transaction metrics: slot %d", block.Slot)
-	err := s.dbClient.PersistTransactions(transactions)
+
+	err = s.dbClient.PersistTransactions(txs)
 	if err != nil {
 		log.Errorf("error persisting transactions: %s", err.Error())
 	}

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -93,9 +93,13 @@ func (s *ChainAnalyzer) runHead() {
 		case newBlobSidecarEvent := <-s.eventsObj.BlobSidecarChan:
 
 			go func() {
-				blobList := s.downloadCache.BlobSidecarHistory.Wait(uint64(newBlobSidecarEvent.BlobSidecarEvent.Slot))
+				slot := newBlobSidecarEvent.BlobSidecarEvent.Slot
+				blobList := s.downloadCache.BlobSidecarHistory.Wait(uint64(slot))
+				block := s.downloadCache.BlockHistory.Wait(uint64(slot))
+
 				agnosticBlob := blobList.BlobSidecars[int(newBlobSidecarEvent.BlobSidecarEvent.Index)]
 				agnosticBlob.AddEventData(newBlobSidecarEvent)
+				agnosticBlob.GetTxHash(block.ExecutionPayload.AgnosticTransactions)
 
 				s.dbClient.PersistBlobSidecars([]spec.AgnosticBlobSidecar{*agnosticBlob})
 			}()

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -91,18 +91,7 @@ func (s *ChainAnalyzer) runHead() {
 			go s.HandleReorg(newReorg)
 
 		case newBlobSidecarEvent := <-s.eventsObj.BlobSidecarChan:
-
-			go func() {
-				slot := newBlobSidecarEvent.BlobSidecarEvent.Slot
-				blobList := s.downloadCache.BlobSidecarHistory.Wait(uint64(slot))
-				block := s.downloadCache.BlockHistory.Wait(uint64(slot))
-
-				agnosticBlob := blobList.BlobSidecars[int(newBlobSidecarEvent.BlobSidecarEvent.Index)]
-				agnosticBlob.AddEventData(newBlobSidecarEvent)
-				agnosticBlob.GetTxHash(block.ExecutionPayload.AgnosticTransactions)
-
-				s.dbClient.PersistBlobSidecars([]spec.AgnosticBlobSidecar{*agnosticBlob})
-			}()
+			s.dbClient.PersistBlobSidecarsEvents([]spec.BlobSideCarEventWraper{newBlobSidecarEvent})
 
 		case <-s.ctx.Done():
 			log.Info("context has died, closing block requester routine")

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -37,12 +37,10 @@ func EpochTo[T uint64 | int64 | int](epoch phase0.Epoch) T {
 // --- Map ---
 
 type AgnosticMapOption[T spec.AgnosticBlock |
-	spec.AgnosticState |
-	spec.BlobSidecarsInSlot] func(*AgnosticMap[T])
+	spec.AgnosticState] func(*AgnosticMap[T])
 
 type AgnosticMap[T spec.AgnosticBlock |
-	spec.AgnosticState |
-	spec.BlobSidecarsInSlot] struct {
+	spec.AgnosticState] struct {
 	sync.Mutex
 	// both spec.Slot and spec.Epoch are uint64
 	m    map[uint64]*T
@@ -53,8 +51,7 @@ type AgnosticMap[T spec.AgnosticBlock |
 }
 
 func NewAgnosticMap[T spec.AgnosticBlock |
-	spec.AgnosticState |
-	spec.BlobSidecarsInSlot](opts ...AgnosticMapOption[T]) *AgnosticMap[T] {
+	spec.AgnosticState](opts ...AgnosticMapOption[T]) *AgnosticMap[T] {
 	// init by default with empty functions
 	emptyF := func(_ *T) {}
 	agnosticMap := &AgnosticMap[T]{
@@ -72,16 +69,14 @@ func NewAgnosticMap[T spec.AgnosticBlock |
 }
 
 func WithSetCollisionF[T spec.AgnosticBlock |
-	spec.AgnosticState |
-	spec.BlobSidecarsInSlot](f func(*T)) AgnosticMapOption[T] {
+	spec.AgnosticState](f func(*T)) AgnosticMapOption[T] {
 	return func(m *AgnosticMap[T]) {
 		m.setCollisionF = f
 	}
 }
 
 func WithDeleteF[T spec.AgnosticBlock |
-	spec.AgnosticState |
-	spec.BlobSidecarsInSlot](f func(*T)) AgnosticMapOption[T] {
+	spec.AgnosticState](f func(*T)) AgnosticMapOption[T] {
 	return func(m *AgnosticMap[T]) {
 		m.deleteF = f
 	}

--- a/pkg/analyzer/utils.go
+++ b/pkg/analyzer/utils.go
@@ -36,9 +36,13 @@ func EpochTo[T uint64 | int64 | int](epoch phase0.Epoch) T {
 
 // --- Map ---
 
-type AgnosticMapOption[T spec.AgnosticBlock | spec.AgnosticState] func(*AgnosticMap[T])
+type AgnosticMapOption[T spec.AgnosticBlock |
+	spec.AgnosticState |
+	spec.BlobSidecarsInSlot] func(*AgnosticMap[T])
 
-type AgnosticMap[T spec.AgnosticBlock | spec.AgnosticState] struct {
+type AgnosticMap[T spec.AgnosticBlock |
+	spec.AgnosticState |
+	spec.BlobSidecarsInSlot] struct {
 	sync.Mutex
 	// both spec.Slot and spec.Epoch are uint64
 	m    map[uint64]*T
@@ -48,7 +52,9 @@ type AgnosticMap[T spec.AgnosticBlock | spec.AgnosticState] struct {
 	deleteF       func(*T) // extra code we want to run when deleting a key from the map
 }
 
-func NewAgnosticMap[T spec.AgnosticBlock | spec.AgnosticState](opts ...AgnosticMapOption[T]) *AgnosticMap[T] {
+func NewAgnosticMap[T spec.AgnosticBlock |
+	spec.AgnosticState |
+	spec.BlobSidecarsInSlot](opts ...AgnosticMapOption[T]) *AgnosticMap[T] {
 	// init by default with empty functions
 	emptyF := func(_ *T) {}
 	agnosticMap := &AgnosticMap[T]{
@@ -65,13 +71,17 @@ func NewAgnosticMap[T spec.AgnosticBlock | spec.AgnosticState](opts ...AgnosticM
 	return agnosticMap
 }
 
-func WithSetCollisionF[T spec.AgnosticBlock | spec.AgnosticState](f func(*T)) AgnosticMapOption[T] {
+func WithSetCollisionF[T spec.AgnosticBlock |
+	spec.AgnosticState |
+	spec.BlobSidecarsInSlot](f func(*T)) AgnosticMapOption[T] {
 	return func(m *AgnosticMap[T]) {
 		m.setCollisionF = f
 	}
 }
 
-func WithDeleteF[T spec.AgnosticBlock | spec.AgnosticState](f func(*T)) AgnosticMapOption[T] {
+func WithDeleteF[T spec.AgnosticBlock |
+	spec.AgnosticState |
+	spec.BlobSidecarsInSlot](f func(*T)) AgnosticMapOption[T] {
 	return func(m *AgnosticMap[T]) {
 		m.deleteF = f
 	}

--- a/pkg/clientapi/blob.go
+++ b/pkg/clientapi/blob.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/migalabs/goteth/pkg/spec"
 	local_spec "github.com/migalabs/goteth/pkg/spec"
 )
 
-func (s *APIClient) RequestBlobSidecars(slot phase0.Slot, txs []spec.AgnosticTransaction) ([]*local_spec.AgnosticBlobSidecar, error) {
+func (s *APIClient) RequestBlobSidecars(slot phase0.Slot) ([]*local_spec.AgnosticBlobSidecar, error) {
 
 	agnosticBlobs := make([]*local_spec.AgnosticBlobSidecar, 0)
 

--- a/pkg/clientapi/blob.go
+++ b/pkg/clientapi/blob.go
@@ -1,0 +1,39 @@
+package clientapi
+
+import (
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/migalabs/goteth/pkg/spec"
+	local_spec "github.com/migalabs/goteth/pkg/spec"
+)
+
+func (s *APIClient) RequestBlobSidecars(slot phase0.Slot, txs []spec.AgnosticTransaction) ([]*local_spec.AgnosticBlobSidecar, error) {
+
+	agnosticBlobs := make([]*local_spec.AgnosticBlobSidecar, 0)
+
+	blobsResp, err := s.Api.BlobSidecars(s.ctx, &api.BlobSidecarsOpts{
+		Block: fmt.Sprintf("%d", slot),
+	})
+
+	if err != nil {
+		if response404(err.Error()) {
+			return agnosticBlobs, nil
+		}
+		return nil, fmt.Errorf("could not retrieve blob sidecars for slot %d: %s", slot, err)
+	}
+
+	blobs := blobsResp.Data
+
+	for _, item := range blobs {
+		agnosticBlob, err := local_spec.NewAgnosticBlobFromAPI(slot, *item)
+
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve blob sidecars for slot %d: %s", slot, err)
+		}
+		agnosticBlobs = append(agnosticBlobs, agnosticBlob)
+
+	}
+	return agnosticBlobs, nil
+}

--- a/pkg/clientapi/blob_test.go
+++ b/pkg/clientapi/blob_test.go
@@ -1,0 +1,29 @@
+package clientapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/migalabs/goteth/pkg/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash
+func TestBlobHash(t *testing.T) {
+
+	cli, err := NewAPIClient(context.Background(), "http://localhost:5052")
+	if err != nil {
+		return
+	}
+	blobs, err := cli.RequestBlobSidecars(1167743)
+
+	for _, blob := range blobs {
+		if blob.Index == 1 {
+			realHash := "0x011ee86e83951989dcf96af5c3aeae51ecd15575f8c0003cb5a275945322e98d"
+			versionedHash := spec.KZGCommitmentToVersionedHash(blob.KZGCommitment)
+
+			assert.Equal(t, realHash, versionedHash)
+
+		}
+	}
+}

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -86,7 +86,6 @@ func (s *APIClient) RequestBeaconBlock(slot phase0.Slot) (*local_spec.AgnosticBl
 
 		customBlock.Reward = reward
 	}
-	// s.RequestBlockBlobs(slot)
 	log.Infof("block at slot %d downloaded in %f seconds", slot, time.Since(startTime).Seconds())
 
 	return &customBlock, nil
@@ -204,28 +203,4 @@ func (s *APIClient) RequestCurrentHead() phase0.Slot {
 	}
 
 	return head.Data.Header.Message.Slot
-}
-
-func (s *APIClient) RequestBlockBlobs(slot phase0.Slot) error {
-	blobsResp, err := s.Api.BlobSidecars(s.ctx, &api.BlobSidecarsOpts{
-		Block: fmt.Sprintf("%d", slot),
-	})
-
-	if err != nil {
-		return fmt.Errorf("could not retrieve blob sidecars for slot %d: %s", slot, err)
-	}
-
-	blobs := blobsResp.Data
-
-	for _, item := range blobs {
-		agnosticBlob, err := local_spec.NewAgnosticBlobFromAPI(*item)
-
-		if err != nil {
-			return fmt.Errorf("could not retrieve blob sidecars for slot %d: %s", slot, err)
-		}
-
-		log.Infof("%+v", agnosticBlob)
-
-	}
-	return nil
 }

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -70,7 +70,7 @@ func (s *APIClient) RequestBeaconBlock(slot phase0.Slot) (*local_spec.AgnosticBl
 	// shows error inside function if ELApi is not defined
 	block, err := s.RequestExecutionBlockByHash(common.Hash(customBlock.ExecutionPayload.BlockHash))
 	if err != nil {
-		log.Error("cannot request block by hash: %s", err)
+		log.Errorf("cannot request block by hash: %s", err)
 	}
 	if block != nil {
 		customBlock.ExecutionPayload.PayloadSize = uint32(block.Size())

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -86,6 +86,7 @@ func (s *APIClient) RequestBeaconBlock(slot phase0.Slot) (*local_spec.AgnosticBl
 
 		customBlock.Reward = reward
 	}
+	// s.RequestBlockBlobs(slot)
 	log.Infof("block at slot %d downloaded in %f seconds", slot, time.Since(startTime).Seconds())
 
 	return &customBlock, nil
@@ -203,4 +204,28 @@ func (s *APIClient) RequestCurrentHead() phase0.Slot {
 	}
 
 	return head.Data.Header.Message.Slot
+}
+
+func (s *APIClient) RequestBlockBlobs(slot phase0.Slot) error {
+	blobsResp, err := s.Api.BlobSidecars(s.ctx, &api.BlobSidecarsOpts{
+		Block: fmt.Sprintf("%d", slot),
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not retrieve blob sidecars for slot %d: %s", slot, err)
+	}
+
+	blobs := blobsResp.Data
+
+	for _, item := range blobs {
+		agnosticBlob, err := local_spec.NewAgnosticBlobFromAPI(*item)
+
+		if err != nil {
+			return fmt.Errorf("could not retrieve blob sidecars for slot %d: %s", slot, err)
+		}
+
+		log.Infof("%+v", agnosticBlob)
+
+	}
+	return nil
 }

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -9,6 +9,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/migalabs/goteth/pkg/spec"
 	"github.com/migalabs/goteth/pkg/utils"
 )
@@ -17,72 +18,30 @@ var (
 	txKeyTag string = "txreceipt="
 )
 
-// GetReceipt retrieves receipt for the given transaction hash
-func (client *APIClient) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
+func (client *APIClient) ParseSingleTx(
+	parsedTx types.Transaction,
+	receipt *types.Receipt,
+	slot phase0.Slot,
+	blockNumber uint64,
+	timestamp uint64) (spec.AgnosticTransaction, error) {
 
-	routineKey := txKeyTag + txHash.String()
-	client.txBook.Acquire(routineKey)
-	defer client.txBook.FreePage(routineKey)
-
-	receipt, err := client.ELApi.TransactionReceipt(client.ctx, txHash)
-	return receipt, err
-}
-
-// convert transactions from byte sequences to Transaction object
-func (s *APIClient) RequestTransactionDetails(iTx bellatrix.Transaction,
-	iSlot phase0.Slot,
-	iBlockNumber uint64,
-	iTimestamp uint64) (*spec.AgnosticTransaction, error) {
-	// starTime := time.Now()
-	if s.ELApi == nil {
-		log.Warn("EL endpoint not provided. The gas price read from the CL may not be the effective gas price.")
-	}
-	var parsedTx = &types.Transaction{}
-	if err := parsedTx.UnmarshalBinary(iTx); err != nil {
-		log.Warnf("unable to unmarshal transaction: %s", err)
-		return &spec.AgnosticTransaction{}, err
-	}
-	from, err := types.Sender(types.LatestSignerForChainID(parsedTx.ChainId()), parsedTx)
+	from, err := types.Sender(types.LatestSignerForChainID(parsedTx.ChainId()), &parsedTx)
 	if err != nil {
 		log.Warnf("unable to retrieve sender address from transaction: %s", err)
-		return &spec.AgnosticTransaction{}, err
+		return spec.AgnosticTransaction{}, err
 	}
 
 	gasUsed := parsedTx.Gas()
 	gasPrice := parsedTx.GasPrice().Uint64()
-	contractAddress := *&common.Address{}
+	contractAddress := common.Address{}
 
-	if s.ELApi != nil {
-
-		var receipt *types.Receipt
-		err := errors.New("first attempt")
-
-		attempts := 0
-		for err != nil && attempts < maxRetries {
-			receipt, err = s.GetReceipt(parsedTx.Hash())
-
-			if err != nil {
-				ticker := time.NewTicker(utils.RoutineFlushTimeout)
-				log.Warnf("retrying transaction request: %s", parsedTx.Hash().String())
-				<-ticker.C
-			}
-			attempts += 1
-
-		}
-
-		if err != nil {
-
-			log.Errorf("unable to retrieve transaction receipt for hash %x: %s", parsedTx.Hash(), err.Error())
-		}
+	if receipt != nil {
 		gasUsed = receipt.GasUsed
 		gasPrice = receipt.EffectiveGasPrice.Uint64()
 		contractAddress = receipt.ContractAddress
-
 	}
 
-	//log.Infof("transaction details took %f seconds", time.Since(starTime).Seconds())
-
-	return &spec.AgnosticTransaction{
+	return spec.AgnosticTransaction{
 		TxType:          parsedTx.Type(),
 		ChainId:         uint8(parsedTx.ChainId().Uint64()),
 		Data:            hex.EncodeToString(parsedTx.Data()),
@@ -96,9 +55,96 @@ func (s *APIClient) RequestTransactionDetails(iTx bellatrix.Transaction,
 		From:            from,
 		Hash:            phase0.Hash32(parsedTx.Hash()),
 		Size:            parsedTx.Size(),
-		Slot:            iSlot,
-		BlockNumber:     iBlockNumber,
-		Timestamp:       iTimestamp,
+		Slot:            slot,
+		BlockNumber:     blockNumber,
+		Timestamp:       timestamp,
 		ContractAddress: contractAddress,
 	}, nil
+
+}
+
+func (client *APIClient) GetBlockTransactions(block spec.AgnosticBlock) ([]spec.AgnosticTransaction, error) {
+	agnosticTxs := make([]spec.AgnosticTransaction, 0)
+	blockNumber := rpc.BlockNumber(block.ExecutionPayload.BlockNumber)
+	receipts, err := client.ELApi.BlockReceipts(client.ctx, rpc.BlockNumberOrHashWithNumber(blockNumber))
+	if err != nil {
+		return nil, err
+	}
+
+	txs := make([]bellatrix.Transaction, len(block.ExecutionPayload.Transactions))
+	copy(txs, block.ExecutionPayload.Transactions)
+
+	// match receipts and transactions
+
+	for _, tx := range txs {
+		var parsedTx = &types.Transaction{}
+		if err := parsedTx.UnmarshalBinary(tx); err != nil {
+			return nil, err
+		}
+		for _, receipt := range receipts {
+			if receipt.TxHash.String() == parsedTx.Hash().String() {
+				// we found a match
+				agnosticTx, err := client.ParseSingleTx(
+					*parsedTx,
+					receipt,
+					block.Slot,
+					block.ExecutionPayload.BlockNumber,
+					block.ExecutionPayload.Timestamp)
+				if err != nil {
+					return nil, err
+				}
+				agnosticTxs = append(agnosticTxs, agnosticTx)
+				break
+			}
+		}
+	}
+	return agnosticTxs, nil
+}
+
+// convert transactions from byte sequences to Transaction object
+func (s *APIClient) RequestTransactionDetails(iTx bellatrix.Transaction,
+	iSlot phase0.Slot,
+	iBlockNumber uint64,
+	iTimestamp uint64) (*spec.AgnosticTransaction, error) {
+
+	var parsedTx = &types.Transaction{}
+	if err := parsedTx.UnmarshalBinary(iTx); err != nil {
+		log.Warnf("unable to unmarshal transaction: %s", err)
+		return nil, err
+	}
+
+	var receipt *types.Receipt
+	err := errors.New("first attempt")
+
+	if s.ELApi == nil {
+		log.Warn("EL endpoint not provided. The gas price read from the CL may not be the effective gas price.")
+		attempts := 0
+		for err != nil && attempts < maxRetries {
+			receipt, err = s.ELApi.TransactionReceipt(s.ctx, parsedTx.Hash())
+
+			if err != nil {
+				ticker := time.NewTicker(utils.RoutineFlushTimeout)
+				log.Warnf("retrying transaction request: %s", parsedTx.Hash().String())
+				<-ticker.C
+			}
+			attempts += 1
+
+		}
+		if err != nil {
+			log.Errorf("could not retrieve the receipt for tx %s: %s", parsedTx.Hash().String(), err)
+		}
+	}
+
+	agnosticTx, err := s.ParseSingleTx(
+		*parsedTx,
+		receipt,
+		iSlot,
+		iBlockNumber,
+		iTimestamp)
+
+	if err != nil {
+		return nil, err
+	}
+	return &agnosticTx, nil
+
 }

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -34,11 +34,22 @@ func (client *APIClient) ParseSingleTx(
 	gasUsed := parsedTx.Gas()
 	gasPrice := parsedTx.GasPrice().Uint64()
 	contractAddress := common.Address{}
+	blobGasUsed := uint64(0)
+	blobGasPrice := uint64(0)
+	blobGasLimit := uint64(0)
+	blobGasFeeCap := uint64(0)
 
 	if receipt != nil {
 		gasUsed = receipt.GasUsed
 		gasPrice = receipt.EffectiveGasPrice.Uint64()
 		contractAddress = receipt.ContractAddress
+	}
+
+	if parsedTx.Type() == blobTxType {
+		blobGasUsed = receipt.BlobGasUsed
+		blobGasPrice = receipt.BlobGasPrice.Uint64()
+		blobGasLimit = parsedTx.BlobGas()
+		blobGasFeeCap = parsedTx.BlobGasFeeCap().Uint64()
 	}
 
 	return spec.AgnosticTransaction{
@@ -59,8 +70,10 @@ func (client *APIClient) ParseSingleTx(
 		BlockNumber:     blockNumber,
 		Timestamp:       timestamp,
 		ContractAddress: contractAddress,
-		BlobGasLimit:    parsedTx.BlobGas(),
-		BlobGasFeeCap:   parsedTx.BlobGasFeeCap(),
+		BlobGasUsed:     blobGasUsed,
+		BlobGasPrice:    blobGasPrice,
+		BlobGasLimit:    blobGasLimit,
+		BlobGasFeeCap:   blobGasFeeCap,
 		BlobHashes:      parsedTx.BlobHashes(),
 	}, nil
 

--- a/pkg/clientapi/transaction.go
+++ b/pkg/clientapi/transaction.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	txKeyTag string = "txreceipt="
+	blobTxType uint8 = 3
 )
 
 func (client *APIClient) ParseSingleTx(
@@ -59,6 +59,9 @@ func (client *APIClient) ParseSingleTx(
 		BlockNumber:     blockNumber,
 		Timestamp:       timestamp,
 		ContractAddress: contractAddress,
+		BlobGasLimit:    parsedTx.BlobGas(),
+		BlobGasFeeCap:   parsedTx.BlobGasFeeCap(),
+		BlobHashes:      parsedTx.BlobHashes(),
 	}, nil
 
 }

--- a/pkg/db/blob_events.go
+++ b/pkg/db/blob_events.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+var (
+	blobEventsTable               = "t_blob_sidecars_events"
+	insertBlobSideCarsEventsQuery = `
+	INSERT INTO %s (
+		f_arrival_timestamp_ms,
+		f_blob_hash)
+		VALUES`
+)
+
+func blobSidecarsEventInput(blobSidecarsEvents []spec.BlobSideCarEventWraper) proto.Input {
+	// one object per column
+	var (
+		f_arrival_timestamp_ms proto.ColUInt64
+		f_blob_hash            proto.ColStr
+	)
+
+	for _, blobSidecar := range blobSidecarsEvents {
+
+		f_arrival_timestamp_ms.Append(uint64(blobSidecar.Timestamp.UnixMilli()))
+		f_blob_hash.Append(blobSidecar.BlobSidecarEvent.VersionedHash.String())
+
+	}
+
+	return proto.Input{
+
+		{Name: "f_arrival_timestamp_ms", Data: f_arrival_timestamp_ms},
+		{Name: "f_blob_hash", Data: f_blob_hash},
+	}
+}
+
+func (p *DBService) PersistBlobSidecarsEvents(data []spec.BlobSideCarEventWraper) error {
+	persistObj := PersistableObject[spec.BlobSideCarEventWraper]{
+		input: blobSidecarsEventInput,
+		table: blobEventsTable,
+		query: insertBlobSideCarsEventsQuery,
+	}
+
+	for _, item := range data {
+		persistObj.Append(item)
+	}
+
+	err := p.Persist(persistObj.ExportPersist())
+	if err != nil {
+		log.Errorf("error persisting blob events: %s", err.Error())
+	}
+	return err
+}

--- a/pkg/db/blob_metrics.go
+++ b/pkg/db/blob_metrics.go
@@ -11,6 +11,7 @@ var (
 	INSERT INTO %s (
 		f_arrival_timestamp_ms,
 		f_blob_hash,
+		f_tx_hash,
 		f_slot,
 		f_index,
 		f_kzg_commitment,
@@ -29,6 +30,7 @@ func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {
 	var (
 		f_arrival_timestamp_ms proto.ColUInt64
 		f_blob_hash            proto.ColStr
+		f_tx_hash              proto.ColStr
 		f_slot                 proto.ColUInt64
 		f_index                proto.ColUInt8
 		f_kzg_commitment       proto.ColStr
@@ -39,6 +41,7 @@ func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {
 
 		f_arrival_timestamp_ms.Append(uint64(blobSidecar.ArrivalTimestamp.UnixMilli()))
 		f_blob_hash.Append(blobSidecar.BlobHash.String())
+		f_tx_hash.Append(blobSidecar.TxHash.String())
 		f_slot.Append(uint64(blobSidecar.Slot))
 		f_index.Append(uint8(blobSidecar.Index))
 		f_kzg_commitment.Append(blobSidecar.KZGCommitment.String())
@@ -50,6 +53,7 @@ func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {
 
 		{Name: "f_arrival_timestamp_ms", Data: f_arrival_timestamp_ms},
 		{Name: "f_blob_hash", Data: f_blob_hash},
+		{Name: "f_tx_hash", Data: f_tx_hash},
 		{Name: "f_slot", Data: f_slot},
 		{Name: "f_index", Data: f_index},
 		{Name: "f_kzg_commitment", Data: f_kzg_commitment},
@@ -74,50 +78,3 @@ func (p *DBService) PersistBlobSidecars(data []spec.AgnosticBlobSidecar) error {
 	}
 	return err
 }
-
-// func (s *DBService) DeleteBlockMetrics(slot phase0.Slot) error {
-
-// 	err := s.Delete(DeletableObject{
-// 		query: deleteBlockQuery,
-// 		table: blocksTable,
-// 		args:  []any{slot},
-// 	})
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	err = s.Delete(DeletableObject{
-// 		query: deleteTransactionsQuery,
-// 		table: transactionsTable,
-// 		args:  []any{slot},
-// 	})
-// 	if err != nil {
-// 		return err
-// 	}
-// 	err = s.Delete(DeletableObject{
-// 		query: deleteWithdrawalsQuery,
-// 		table: withdrawalsTable,
-// 		args:  []any{slot},
-// 	})
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return nil
-// }
-
-// func (p *DBService) RetrieveLastSlot() (phase0.Slot, error) {
-
-// 	var dest []struct {
-// 		F_slot uint64 `ch:"f_slot"`
-// 	}
-
-// 	err := p.highSelect(
-// 		fmt.Sprintf(selectLastSlotQuery, blocksTable),
-// 		&dest)
-
-// 	if len(dest) > 0 {
-// 		return phase0.Slot(dest[0].F_slot), err
-// 	}
-// 	return 0, err
-
-// }

--- a/pkg/db/blob_metrics.go
+++ b/pkg/db/blob_metrics.go
@@ -17,11 +17,11 @@ var (
 		f_kzg_proof)
 		VALUES`
 
-//	deleteBlockQuery = `
-//		DELETE FROM %s
-//		WHERE f_slot = $1;
-//
-// `
+	deleteBlobsQuery = `
+		DELETE FROM %s
+		WHERE f_slot = $1;
+
+`
 )
 
 func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {

--- a/pkg/db/blob_metrics.go
+++ b/pkg/db/blob_metrics.go
@@ -14,7 +14,8 @@ var (
 		f_slot,
 		f_index,
 		f_kzg_commitment,
-		f_kzg_proof)
+		f_kzg_proof,
+		f_ending_0s)
 		VALUES`
 
 	deleteBlobsQuery = `
@@ -33,6 +34,7 @@ func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {
 		f_index          proto.ColUInt8
 		f_kzg_commitment proto.ColStr
 		f_kzg_proof      proto.ColStr
+		f_ending_0s      proto.ColUInt64
 	)
 
 	for _, blobSidecar := range blobSidecars {
@@ -43,6 +45,7 @@ func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {
 		f_index.Append(uint8(blobSidecar.Index))
 		f_kzg_commitment.Append(blobSidecar.KZGCommitment.String())
 		f_kzg_proof.Append(blobSidecar.KZGProof.String())
+		f_ending_0s.Append(uint64(blobSidecar.BlobEnding0s))
 
 	}
 
@@ -54,6 +57,7 @@ func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {
 		{Name: "f_index", Data: f_index},
 		{Name: "f_kzg_commitment", Data: f_kzg_commitment},
 		{Name: "f_kzg_proof", Data: f_kzg_proof},
+		{Name: "f_ending_0s", Data: f_ending_0s},
 	}
 }
 

--- a/pkg/db/blob_metrics.go
+++ b/pkg/db/blob_metrics.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+var (
+	blobsTable              = "t_blob_sidecars"
+	insertBlobSidecarsQuery = `
+	INSERT INTO %s (
+		f_arrival_timestamp_ms,
+		f_blob_hash,
+		f_slot,
+		f_index,
+		f_kzg_commitment,
+		f_kzg_proof)
+		VALUES`
+
+//	deleteBlockQuery = `
+//		DELETE FROM %s
+//		WHERE f_slot = $1;
+//
+// `
+)
+
+func blobSidecarsInput(blobSidecars []spec.AgnosticBlobSidecar) proto.Input {
+	// one object per column
+	var (
+		f_arrival_timestamp_ms proto.ColUInt64
+		f_blob_hash            proto.ColStr
+		f_slot                 proto.ColUInt64
+		f_index                proto.ColUInt8
+		f_kzg_commitment       proto.ColStr
+		f_kzg_proof            proto.ColStr
+	)
+
+	for _, blobSidecar := range blobSidecars {
+
+		f_arrival_timestamp_ms.Append(uint64(blobSidecar.ArrivalTimestamp.UnixMilli()))
+		f_blob_hash.Append(blobSidecar.BlobHash.String())
+		f_slot.Append(uint64(blobSidecar.Slot))
+		f_index.Append(uint8(blobSidecar.Index))
+		f_kzg_commitment.Append(blobSidecar.KZGCommitment.String())
+		f_kzg_proof.Append(blobSidecar.KZGProof.String())
+
+	}
+
+	return proto.Input{
+
+		{Name: "f_arrival_timestamp_ms", Data: f_arrival_timestamp_ms},
+		{Name: "f_blob_hash", Data: f_blob_hash},
+		{Name: "f_slot", Data: f_slot},
+		{Name: "f_index", Data: f_index},
+		{Name: "f_kzg_commitment", Data: f_kzg_commitment},
+		{Name: "f_kzg_proof", Data: f_kzg_proof},
+	}
+}
+
+func (p *DBService) PersistBlobSidecars(data []spec.AgnosticBlobSidecar) error {
+	persistObj := PersistableObject[spec.AgnosticBlobSidecar]{
+		input: blobSidecarsInput,
+		table: blobsTable,
+		query: insertBlobSidecarsQuery,
+	}
+
+	for _, item := range data {
+		persistObj.Append(item)
+	}
+
+	err := p.Persist(persistObj.ExportPersist())
+	if err != nil {
+		log.Errorf("error persisting blobs: %s", err.Error())
+	}
+	return err
+}
+
+// func (s *DBService) DeleteBlockMetrics(slot phase0.Slot) error {
+
+// 	err := s.Delete(DeletableObject{
+// 		query: deleteBlockQuery,
+// 		table: blocksTable,
+// 		args:  []any{slot},
+// 	})
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	err = s.Delete(DeletableObject{
+// 		query: deleteTransactionsQuery,
+// 		table: transactionsTable,
+// 		args:  []any{slot},
+// 	})
+// 	if err != nil {
+// 		return err
+// 	}
+// 	err = s.Delete(DeletableObject{
+// 		query: deleteWithdrawalsQuery,
+// 		table: withdrawalsTable,
+// 		args:  []any{slot},
+// 	})
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
+
+// func (p *DBService) RetrieveLastSlot() (phase0.Slot, error) {
+
+// 	var dest []struct {
+// 		F_slot uint64 `ch:"f_slot"`
+// 	}
+
+// 	err := p.highSelect(
+// 		fmt.Sprintf(selectLastSlotQuery, blocksTable),
+// 		&dest)
+
+// 	if len(dest) > 0 {
+// 		return phase0.Slot(dest[0].F_slot), err
+// 	}
+// 	return 0, err
+
+// }

--- a/pkg/db/block_metrics.go
+++ b/pkg/db/block_metrics.go
@@ -171,6 +171,14 @@ func (s *DBService) DeleteBlockMetrics(slot phase0.Slot) error {
 	if err != nil {
 		return err
 	}
+	err = s.Delete(DeletableObject{
+		query: deleteBlobsQuery,
+		table: blobsTable,
+		args:  []any{slot},
+	})
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/db/migrations/000003_add_blob_sidecars.down.sql
+++ b/pkg/db/migrations/000003_add_blob_sidecars.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS t_blob_sidecars;

--- a/pkg/db/migrations/000003_add_blob_sidecars.down.sql
+++ b/pkg/db/migrations/000003_add_blob_sidecars.down.sql
@@ -1,1 +1,6 @@
 DROP TABLE IF EXISTS t_blob_sidecars;
+
+ALTER TABLE t_transactions DROP COLUMN f_blob_gas_used;
+ALTER TABLE t_transactions DROP COLUMN f_blob_gas_price;
+ALTER TABLE t_transactions DROP COLUMN f_blob_gas_limit;
+ALTER TABLE t_transactions DROP COLUMN f_blob_gas_fee_cap;

--- a/pkg/db/migrations/000003_add_blob_sidecars.down.sql
+++ b/pkg/db/migrations/000003_add_blob_sidecars.down.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS t_blob_sidecars;
+DROP TABLE IF EXISTS t_blob_sidecars_events;
 
 ALTER TABLE t_transactions DROP COLUMN f_blob_gas_used;
 ALTER TABLE t_transactions DROP COLUMN f_blob_gas_price;

--- a/pkg/db/migrations/000003_add_blob_sidecars.up.sql
+++ b/pkg/db/migrations/000003_add_blob_sidecars.up.sql
@@ -1,5 +1,4 @@
 CREATE TABLE IF NOT EXISTS t_blob_sidecars(
-	f_arrival_timestamp_ms UInt64,
 	f_blob_hash TEXT DEFAULT '',
 	f_tx_hash TEXT DEFAULT '',
 	f_slot UInt64,
@@ -8,6 +7,12 @@ CREATE TABLE IF NOT EXISTS t_blob_sidecars(
 	f_kzg_proof TEXT DEFAULT '')
 	ENGINE = ReplacingMergeTree()
 	ORDER BY (f_slot, f_index);
+
+CREATE TABLE IF NOT EXISTS t_blob_sidecars_events(
+	f_arrival_timestamp_ms UInt64,
+	f_blob_hash TEXT DEFAULT '')
+	ENGINE = ReplacingMergeTree()
+	ORDER BY (f_blob_hash);
 
 ALTER TABLE t_transactions ADD COLUMN f_blob_gas_used UInt64;
 ALTER TABLE t_transactions ADD COLUMN f_blob_gas_price UInt64;

--- a/pkg/db/migrations/000003_add_blob_sidecars.up.sql
+++ b/pkg/db/migrations/000003_add_blob_sidecars.up.sql
@@ -1,9 +1,15 @@
 CREATE TABLE IF NOT EXISTS t_blob_sidecars(
 	f_arrival_timestamp_ms UInt64,
 	f_blob_hash TEXT DEFAULT '',
+	f_tx_hash TEXT DEFAULT '',
 	f_slot UInt64,
 	f_index UInt8,
 	f_kzg_commitment TEXT DEFAULT '',
 	f_kzg_proof TEXT DEFAULT '')
 	ENGINE = ReplacingMergeTree()
 	ORDER BY (f_slot, f_index);
+
+ALTER TABLE t_transactions ADD COLUMN f_blob_gas_used UInt64;
+ALTER TABLE t_transactions ADD COLUMN f_blob_gas_price UInt64;
+ALTER TABLE t_transactions ADD COLUMN f_blob_gas_limit UInt64;
+ALTER TABLE t_transactions ADD COLUMN f_blob_gas_fee_cap UInt64;

--- a/pkg/db/migrations/000003_add_blob_sidecars.up.sql
+++ b/pkg/db/migrations/000003_add_blob_sidecars.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS t_blob_sidecars(
+	f_arrival_timestamp_ms UInt64,
+	f_blob_hash TEXT DEFAULT '',
+	f_slot UInt64,
+	f_index UInt8,
+	f_kzg_commitment TEXT DEFAULT '',
+	f_kzg_proof TEXT DEFAULT '')
+	ENGINE = ReplacingMergeTree()
+	ORDER BY (f_slot, f_index);

--- a/pkg/db/migrations/000003_add_blob_sidecars.up.sql
+++ b/pkg/db/migrations/000003_add_blob_sidecars.up.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS t_blob_sidecars(
 	f_slot UInt64,
 	f_index UInt8,
 	f_kzg_commitment TEXT DEFAULT '',
-	f_kzg_proof TEXT DEFAULT '')
+	f_kzg_proof TEXT DEFAULT '',
+	f_ending_0s UInt64)
 	ENGINE = ReplacingMergeTree()
 	ORDER BY (f_slot, f_index);
 

--- a/pkg/db/prometheus_metrics.go
+++ b/pkg/db/prometheus_metrics.go
@@ -76,6 +76,7 @@ func (r *DBService) initMonitorMetrics() {
 
 	tablesArr := []string{
 		blobsTable,
+		blobEventsTable,
 		blocksTable,
 		epochsTable,
 		finalizedTable,

--- a/pkg/db/prometheus_metrics.go
+++ b/pkg/db/prometheus_metrics.go
@@ -75,6 +75,7 @@ var (
 func (r *DBService) initMonitorMetrics() {
 
 	tablesArr := []string{
+		blobsTable,
 		blocksTable,
 		epochsTable,
 		finalizedTable,

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -142,7 +142,8 @@ type PersistableObject[
 		spec.ValidatorLastStatus |
 		spec.ValidatorRewards |
 		spec.Withdrawal |
-		HeadEvent] struct {
+		HeadEvent |
+		spec.AgnosticBlobSidecar] struct {
 	table string
 	query string
 	data  []T

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -143,7 +143,8 @@ type PersistableObject[
 		spec.ValidatorRewards |
 		spec.Withdrawal |
 		HeadEvent |
-		spec.AgnosticBlobSidecar] struct {
+		spec.AgnosticBlobSidecar |
+		spec.BlobSideCarEventWraper] struct {
 	table string
 	query string
 	data  []T

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -9,8 +9,26 @@ var (
 	transactionsTable       = "t_transactions"
 	insertTransactionsQuery = `
 		INSERT INTO %s(
-			f_tx_type, f_chain_id, f_data, f_gas, f_gas_price, f_gas_tip_cap, f_gas_fee_cap, f_value, f_nonce, f_to, f_hash,
-								f_size, f_slot, f_el_block_number, f_timestamp, f_from, f_contract_address)
+			f_tx_type, 
+			f_chain_id, 
+			f_data, f_gas, 
+			f_gas_price, 
+			f_gas_tip_cap, 
+			f_gas_fee_cap, 
+			f_value, 
+			f_nonce, 
+			f_to, 
+			f_hash,
+			f_size, 
+			f_slot, 
+			f_el_block_number, 
+			f_timestamp, 
+			f_from, 
+			f_contract_address,
+			f_blob_gas_used,
+			f_blob_gas_price,
+			f_blob_gas_limit,
+			f_blob_gas_fee_cap)
 		VALUES`
 
 	deleteTransactionsQuery = `
@@ -39,6 +57,10 @@ func transactionsInput(transactions []spec.AgnosticTransaction) proto.Input {
 		f_timestamp        proto.ColUInt64
 		f_from             proto.ColStr
 		f_contract_address proto.ColStr
+		f_blob_gas_used    proto.ColUInt64
+		f_blob_gas_price   proto.ColUInt64
+		f_blob_gas_limit   proto.ColUInt64
+		f_blob_gas_fee_cap proto.ColUInt64
 	)
 
 	for _, transaction := range transactions {
@@ -65,6 +87,11 @@ func transactionsInput(transactions []spec.AgnosticTransaction) proto.Input {
 		f_timestamp.Append(uint64(transaction.Timestamp))
 		f_from.Append(transaction.From.String())
 		f_contract_address.Append(transaction.ContractAddress.String())
+
+		f_blob_gas_used.Append(transaction.BlobGasUsed)
+		f_blob_gas_price.Append(transaction.BlobGasPrice)
+		f_blob_gas_limit.Append(transaction.BlobGasLimit)
+		f_blob_gas_fee_cap.Append(transaction.BlobGasFeeCap)
 	}
 
 	return proto.Input{
@@ -86,6 +113,10 @@ func transactionsInput(transactions []spec.AgnosticTransaction) proto.Input {
 		{Name: "f_timestamp", Data: f_timestamp},
 		{Name: "f_from", Data: f_from},
 		{Name: "f_contract_address", Data: f_contract_address},
+		{Name: "f_blob_gas_used", Data: f_blob_gas_used},
+		{Name: "f_blob_gas_price", Data: f_blob_gas_price},
+		{Name: "f_blob_gas_limit", Data: f_blob_gas_limit},
+		{Name: "f_blob_gas_fee_cap", Data: f_blob_gas_fee_cap},
 	}
 }
 

--- a/pkg/events/blobs.go
+++ b/pkg/events/blobs.go
@@ -1,0 +1,31 @@
+package events
+
+import (
+	"time"
+
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+func (e *Events) SubscribeToBlobSidecarsEvents() {
+	// subscribe to head event
+	err := e.cli.Api.Events(e.ctx, []string{"blob_sidecar"}, e.HandleBlobSidecarEvent) // every reorg
+	if err != nil {
+		log.Panicf("failed to subscribe to blob_sidecar events: %s", err)
+	}
+	log.Infof("subscribed to blob_sidecar events")
+}
+
+func (e *Events) HandleBlobSidecarEvent(event *api.Event) {
+	timestamp := time.Now()
+	if event.Data == nil {
+		return
+	}
+
+	data := spec.BlobSideCarEventWraper{
+		Timestamp:        timestamp,
+		BlobSidecarEvent: *event.Data.(*api.BlobSidecarEvent),
+	}
+
+	e.BlobSidecarChan <- data
+}

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -6,6 +6,7 @@ import (
 	api "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/migalabs/goteth/pkg/clientapi"
 	"github.com/migalabs/goteth/pkg/db"
+	"github.com/migalabs/goteth/pkg/spec"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,6 +25,7 @@ type Events struct {
 	SubscribedFinalized bool
 	FinalizedChan       chan api.FinalizedCheckpointEvent
 	ReorgChan           chan api.ChainReorgEvent
+	BlobSidecarChan     chan spec.BlobSideCarEventWraper
 }
 
 func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
@@ -35,5 +37,6 @@ func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 		SubscribedFinalized: false,
 		FinalizedChan:       make(chan api.FinalizedCheckpointEvent),
 		ReorgChan:           make(chan api.ChainReorgEvent),
+		BlobSidecarChan:     make(chan spec.BlobSideCarEventWraper),
 	}
 }

--- a/pkg/spec/blob.go
+++ b/pkg/spec/blob.go
@@ -1,0 +1,65 @@
+package spec
+
+import (
+	"time"
+
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	maxBlobsPerBlock int = 6
+)
+
+type AgnosticBlobSidecar struct {
+	ArrivalTimestamp            time.Time
+	Slot                        phase0.Slot
+	BlobHash                    common.Hash
+	Blob                        deneb.Blob
+	Index                       deneb.BlobIndex
+	KZGCommitment               deneb.KZGCommitment
+	KZGProof                    deneb.KZGProof
+	SignedBlockHeader           *phase0.SignedBeaconBlockHeader
+	KZGCommitmentInclusionProof deneb.KZGCommitmentInclusionProof
+}
+
+func NewAgnosticBlobFromAPI(slot phase0.Slot, blob deneb.BlobSidecar) (*AgnosticBlobSidecar, error) {
+
+	return &AgnosticBlobSidecar{
+		Slot:                        slot,
+		Index:                       blob.Index,
+		Blob:                        blob.Blob,
+		KZGCommitment:               blob.KZGCommitment,
+		KZGProof:                    blob.KZGProof,
+		SignedBlockHeader:           blob.SignedBlockHeader,
+		KZGCommitmentInclusionProof: blob.KZGCommitmentInclusionProof,
+	}, nil
+}
+
+func (b *AgnosticBlobSidecar) AddEventData(blobSidecarEvent BlobSideCarEventWraper) {
+	b.BlobHash = common.Hash(blobSidecarEvent.BlobSidecarEvent.VersionedHash)
+	b.ArrivalTimestamp = blobSidecarEvent.Timestamp
+}
+
+type BlobSideCarEventWraper struct {
+	Timestamp        time.Time
+	BlobSidecarEvent api.BlobSidecarEvent
+}
+
+type BlobSidecarsInSlot struct {
+	Slot         phase0.Slot
+	BlobSidecars map[int]*AgnosticBlobSidecar
+}
+
+func NewBlobSidecarsInSlot(slot phase0.Slot) *BlobSidecarsInSlot {
+	return &BlobSidecarsInSlot{
+		Slot:         slot,
+		BlobSidecars: make(map[int]*AgnosticBlobSidecar, maxBlobsPerBlock),
+	}
+}
+
+func (b *BlobSidecarsInSlot) AddNewBlobSidecar(blobSidecar *AgnosticBlobSidecar) {
+	b.BlobSidecars[int(blobSidecar.Index)] = blobSidecar
+}

--- a/pkg/spec/blob.go
+++ b/pkg/spec/blob.go
@@ -10,6 +10,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/migalabs/goteth/pkg/utils"
 )
 
 const (
@@ -21,10 +22,11 @@ var (
 )
 
 type AgnosticBlobSidecar struct {
-	Slot                        phase0.Slot
-	TxHash                      common.Hash
-	BlobHash                    string
-	Blob                        deneb.Blob
+	Slot                        phase0.Slot // slot the blob belongs to
+	TxHash                      common.Hash // has of the transactions that references this blob in this slot
+	BlobHash                    string      // versioned blob hash
+	Blob                        deneb.Blob  // the blob itself
+	BlobEnding0s                int         // amount of consecutive 0s at the end of the blob
 	Index                       deneb.BlobIndex
 	KZGCommitment               deneb.KZGCommitment
 	KZGProof                    deneb.KZGProof
@@ -43,6 +45,7 @@ func NewAgnosticBlobFromAPI(slot phase0.Slot, blob deneb.BlobSidecar) (*Agnostic
 		KZGProof:                    blob.KZGProof,
 		SignedBlockHeader:           blob.SignedBlockHeader,
 		KZGCommitmentInclusionProof: blob.KZGCommitmentInclusionProof,
+		BlobEnding0s:                utils.CountConsecutiveEnding0(blob.Blob[:]),
 	}, nil
 }
 

--- a/pkg/spec/blob.go
+++ b/pkg/spec/blob.go
@@ -16,6 +16,7 @@ const (
 type AgnosticBlobSidecar struct {
 	ArrivalTimestamp            time.Time
 	Slot                        phase0.Slot
+	TxHash                      common.Hash
 	BlobHash                    common.Hash
 	Blob                        deneb.Blob
 	Index                       deneb.BlobIndex
@@ -41,6 +42,22 @@ func NewAgnosticBlobFromAPI(slot phase0.Slot, blob deneb.BlobSidecar) (*Agnostic
 func (b *AgnosticBlobSidecar) AddEventData(blobSidecarEvent BlobSideCarEventWraper) {
 	b.BlobHash = common.Hash(blobSidecarEvent.BlobSidecarEvent.VersionedHash)
 	b.ArrivalTimestamp = blobSidecarEvent.Timestamp
+}
+
+func (b *AgnosticBlobSidecar) GetTxHash(txs []AgnosticTransaction) {
+
+	for _, tx := range txs {
+		if len(tx.BlobHashes) == 0 {
+			continue // this tx does not reference any blobs
+		}
+
+		for _, txBlobHash := range tx.BlobHashes {
+			if txBlobHash == b.BlobHash {
+				// we found it
+				b.TxHash = common.Hash(tx.Hash)
+			}
+		}
+	}
 }
 
 type BlobSideCarEventWraper struct {

--- a/pkg/spec/block.go
+++ b/pkg/spec/block.go
@@ -39,16 +39,17 @@ type AgnosticBlock struct {
 
 // This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs
 type AgnosticExecutionPayload struct {
-	FeeRecipient  bellatrix.ExecutionAddress
-	GasLimit      uint64
-	GasUsed       uint64
-	Timestamp     uint64
-	BaseFeePerGas [32]byte
-	BlockHash     phase0.Hash32
-	Transactions  []bellatrix.Transaction
-	BlockNumber   uint64
-	Withdrawals   []*capella.Withdrawal
-	PayloadSize   uint32
+	FeeRecipient         bellatrix.ExecutionAddress
+	GasLimit             uint64
+	GasUsed              uint64
+	Timestamp            uint64
+	BaseFeePerGas        [32]byte
+	BlockHash            phase0.Hash32
+	Transactions         []bellatrix.Transaction
+	AgnosticTransactions []AgnosticTransaction
+	BlockNumber          uint64
+	Withdrawals          []*capella.Withdrawal
+	PayloadSize          uint32
 }
 
 func (f AgnosticBlock) Type() ModelType {

--- a/pkg/spec/transactions.go
+++ b/pkg/spec/transactions.go
@@ -27,9 +27,9 @@ type AgnosticTransaction struct {
 
 	// Blobs
 	BlobHashes    []common.Hash
-	BlobGasUsed   uint64
-	BlobGasPrice  uint64
-	BlobGasLimit  uint64
+	BlobGasUsed   uint64 // amount of gas used
+	BlobGasPrice  uint64 // price per unit of gas used => Wei
+	BlobGasLimit  uint64 // maximum gas allowed
 	BlobGasFeeCap uint64
 }
 

--- a/pkg/spec/transactions.go
+++ b/pkg/spec/transactions.go
@@ -1,6 +1,8 @@
 package spec
 
 import (
+	"math/big"
+
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -24,6 +26,13 @@ type AgnosticTransaction struct {
 	BlockNumber     uint64          // the number of the block where this transaction was added
 	Timestamp       uint64          // timestamp of the block to which this transaction belongs
 	ContractAddress common.Address  // address of the smart contract associated with this transaction
+
+	// Blobs
+	BlobHashes    []common.Hash
+	BlobGasUsed   uint64
+	BlobGasPrice  *big.Int
+	BlobGasLimit  uint64
+	BlobGasFeeCap *big.Int
 }
 
 func (txs AgnosticTransaction) Type() ModelType {

--- a/pkg/spec/transactions.go
+++ b/pkg/spec/transactions.go
@@ -1,8 +1,6 @@
 package spec
 
 import (
-	"math/big"
-
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -30,9 +28,9 @@ type AgnosticTransaction struct {
 	// Blobs
 	BlobHashes    []common.Hash
 	BlobGasUsed   uint64
-	BlobGasPrice  *big.Int
+	BlobGasPrice  uint64
 	BlobGasLimit  uint64
-	BlobGasFeeCap *big.Int
+	BlobGasFeeCap uint64
 }
 
 func (txs AgnosticTransaction) Type() ModelType {

--- a/pkg/utils/bytes.go
+++ b/pkg/utils/bytes.go
@@ -1,0 +1,18 @@
+package utils
+
+func CountConsecutiveEnding0(s []byte) int {
+
+	phraseLen := len(s)
+	count := 0
+
+	for i := phraseLen - 1; i >= 0; i-- {
+		singleByte := s[i]
+		if singleByte == 0 {
+			count += 1
+		} else {
+			break
+		}
+	}
+
+	return count
+}

--- a/tests/db_blobs_test.py
+++ b/tests/db_blobs_test.py
@@ -29,6 +29,18 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
 		"""
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)
+    
+    def test_no_blobs_on_missed_slot(self):
+        """ Test that there are no blobs when the slot is missed """
+        sql_query = """
+			select *
+			from t_block_metrics
+			inner join t_blob_sidecars
+			on t_block_metrics.f_slot == t_blob_sidecars.f_slot
+			where f_proposed = false
+		"""
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
 
     
         

--- a/tests/db_blobs_test.py
+++ b/tests/db_blobs_test.py
@@ -1,0 +1,36 @@
+import unittest
+import unit_db_test.testcase as dbtest
+
+class CheckIntegrityOfDB(dbtest.DBintegrityTest):
+    db_config_file = ".env"
+
+    def test_no_blobs_with_tx_type_3(self):
+        """ Test that there are no blobs with tx type != 3 (blob type) """
+        sql_query = """
+        select t_transactions.f_hash
+		from t_transactions
+		inner join t_blob_sidecars
+		on t_transactions.f_hash == t_blob_sidecars.f_tx_hash
+        where f_tx_type != 3
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+        
+    def test_no_more_than_6_blobs_per_block(self):
+        """ Test that there are no more than 6 blobs per slot """
+        sql_query = """
+			select t_transactions.f_slot, count() as number_blobs
+			from t_transactions
+			inner join t_blob_sidecars
+			on t_transactions.f_hash == t_blob_sidecars.f_tx_hash
+			group by t_transactions.f_slot
+			having number_blobs > 6
+			order by t_transactions.f_slot DESC
+		"""
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
+
+    
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
The Beacon API has recently been updated with several new endpoints: 
- `eth_getBlockReceipts` (at the execution node, JSON RPC)
- [blob_sidecar](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlobSidecars) and [blob_sidecar event](https://ethereum.github.io/beacon-APIs/#/Events/eventstream)
Therefore, we aim to first request all transactions in bulk, to reduce the load on the execution layer node, and retrieve blob data, as since the Deneb hard fork some transactions will rely on the blobs.
_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->

First, we will bulk request the transaction from a whole block and then parse each.
After that, we will request and process blob sidecars, which are related to transactions.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Request transactions in bulk (single request per slot)
- [x] Request blob sidecars in bulk (single request per slot)
- [x] Listen to blob sidecars events
- [x] Store blob sidecars and events (with timestamp) in the database
- [x] Store additional blob gas data from transactions of type 3 (blob tx type)
- [x] Elaborate unit testing and database testing 

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

![image](https://github.com/migalabs/goteth/assets/18716811/07d2004b-de71-4abf-b649-732fba849542)

```
ethereum@Ubuntu-2004-focal-64-minimal-hwe:/home/ethereum/goteth-experimental/tests$ python3 -m unittest db_blobs_test.py 
..
----------------------------------------------------------------------
Ran 2 tests in 0.094s

OK
```