### PR TITLE
Attestation max reward: take into account missed blocks

### DIFF
--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -35,6 +35,9 @@ const (
 
 var (
 	ParticipatingFlagsWeight = [3]int{TimelySourceWeight, TimelyTargetWeight, TimelyHeadWeight}
+	AttSourceFlagIndex       = 0
+	AttTargetFlagIndex       = 1
+	AttHeadFlagIndex         = 2
 )
 
 type ModelType int8

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -241,6 +241,9 @@ func (p AltairMetrics) GetMaxAttestationReward(valIdx phase0.ValidatorIndex) pha
 
 		for i := range p.baseMetrics.CurrentState.AttestingBalance {
 
+			if !p.isFlagPossible(valIdx, i) { // consider if the attester could have achieved the flag
+				continue
+			}
 			// apply formula
 			attestingBalanceInc := p.baseMetrics.CurrentState.AttestingBalance[i] / spec.EffectiveBalanceInc
 
@@ -373,4 +376,32 @@ func (p AltairMetrics) GetParticipationFlags(attestation phase0.Attestation, inc
 	}
 
 	return result
+}
+
+func (p AltairMetrics) isFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int) bool {
+	attSlot := p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx]
+	maxInclusionDelay := 0
+
+	switch flagIndex {
+	case local_spec.AttSourceFlagIndex:
+		maxInclusionDelay = int(math.Sqrt(local_spec.SlotsPerEpoch))
+	case local_spec.AttTargetFlagIndex:
+		maxInclusionDelay = local_spec.SlotsPerEpoch
+	case local_spec.AttHeadFlagIndex:
+		maxInclusionDelay = 1
+	}
+
+	for slot := attSlot; slot <= (attSlot + phase0.Slot(maxInclusionDelay)); slot++ {
+		slotInEpoch := slot % local_spec.SlotsPerEpoch
+		block := p.baseMetrics.PrevState.Blocks[slotInEpoch]
+		if slot >= phase0.Slot(p.baseMetrics.CurrentState.Epoch*local_spec.SlotsPerEpoch) {
+			block = p.baseMetrics.CurrentState.Blocks[slotInEpoch]
+		}
+
+		if block.Proposed == true { // if there was a block proposed inside the inclusion window
+			return true
+		}
+	}
+	return false
+
 }

--- a/pkg/spec/metrics/state_phase0.go
+++ b/pkg/spec/metrics/state_phase0.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 
 	"github.com/attestantio/go-eth2-client/spec/altair"
@@ -138,11 +139,12 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (local_spec.Va
 	// only consider attestations rewards in case the validator was active in the previous epoch
 	baseReward := p.GetBaseReward(p.baseMetrics.CurrentState.Validators[valIdx].EffectiveBalance)
 	voteReward := phase0.Gwei(0)
-	proposerReward := phase0.Gwei(0)
+	proposerManualReward := phase0.Gwei(0)
 	proposerSlot := phase0.Slot(0)
 	maxReward := phase0.Gwei(0)
 	inclusionDelayReward := phase0.Gwei(0)
-	attSlot := p.baseMetrics.CurrentState.EpochStructs.ValidatorAttSlot[valIdx]
+	attSlot := p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx]
+	minRealInlusionDelay := p.getMinInclusionDelayPossible(attSlot)
 
 	for i := range p.baseMetrics.CurrentState.CorrectFlags {
 
@@ -155,12 +157,12 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (local_spec.Va
 		voteReward += singleReward / (p.baseMetrics.CurrentState.TotalActiveBalance / local_spec.EffectiveBalanceInc)
 	}
 
-	proposerReward = baseReward / local_spec.ProposerRewardQuotient
+	proposerReward := baseReward / local_spec.ProposerRewardQuotient
 	inclusionDelayReward = baseReward - proposerReward
-	inclusionDelayReward /= phase0.Gwei(p.getMissedSlotsAfter(attSlot)) // correct based on missed slots after block
+	inclusionDelayReward /= phase0.Gwei(minRealInlusionDelay) // correct based on missed slots after block
 
-	_, proposerSlot = p.GetMaxProposerReward(valIdx, baseReward)
-	maxReward = voteReward + inclusionDelayReward + proposerReward // this was already calculated, keep using the manual reward
+	proposerManualReward, proposerSlot = p.GetMaxProposerReward(valIdx, baseReward)
+	maxReward = voteReward + inclusionDelayReward + proposerManualReward // this was already calculated, keep using the manual reward
 
 	proposerApiReward := phase0.Gwei(0)
 
@@ -168,6 +170,11 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (local_spec.Va
 		if block.Proposed && block.ProposerIndex == valIdx {
 			proposerApiReward = phase0.Gwei(block.Reward.Data.Total)
 		}
+	}
+
+	if minRealInlusionDelay > 1 {
+		calculatedInclusionDelay := p.baseMetrics.InclusionDelays[valIdx]
+		fmt.Println(calculatedInclusionDelay)
 	}
 
 	result := local_spec.ValidatorRewards{
@@ -178,14 +185,14 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (local_spec.Va
 		MaxReward:            maxReward,
 		AttestationReward:    voteReward + inclusionDelayReward,
 		SyncCommitteeReward:  0,
-		AttSlot:              p.baseMetrics.CurrentState.EpochStructs.ValidatorAttSlot[valIdx],
+		AttSlot:              attSlot,
 		MissingSource:        false,
 		MissingTarget:        false,
 		MissingHead:          false,
 		Status:               p.baseMetrics.NextState.GetValStatus(valIdx),
 		BaseReward:           baseReward,
 		ProposerSlot:         proposerSlot,
-		ProposerManualReward: int64(proposerReward),
+		ProposerManualReward: int64(proposerManualReward),
 		ProposerApiReward:    int64(proposerApiReward),
 		InSyncCommittee:      false,
 		InclusionDelay:       p.baseMetrics.InclusionDelays[valIdx],
@@ -242,7 +249,7 @@ func (p Phase0Metrics) GetBaseReward(valEffectiveBalance phase0.Gwei) phase0.Gwe
 	return baseReward
 }
 
-func (p Phase0Metrics) getMissedSlotsAfter(slot phase0.Slot) int {
+func (p Phase0Metrics) getMinInclusionDelayPossible(slot phase0.Slot) int {
 
 	result := 1
 	for slot := slot + 1; slot <= (slot + phase0.Slot(local_spec.SlotsPerEpoch)); slot++ {


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
GotEth can calculate the maximum reward regarding attestation, sync committee, and proposer duties.
Duties are known and rewards can be calculated based on the epoch statistics and the validator effective balance.
This max reward should represent the maximum reward a validator could have achieved by executing its duties correctly.

However, some duties are dependent on other validators, like attesting. A validator could send its duties in time, but if the next block was missed, that attestation would never be included in the next slot. This implies not getting any rewards from the `head_flag`.

We aim to also consider this, as from an attester's perspective, its maximum reward is immediately downgraded.

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->

We calculate the maximum attestation reward by simulating the validator to achieve all three attestation flags.
However, we must first consider whether the validator can achieve them (from an inclusion delay perspective). 
This is, calculating the first proposed block after the one being attested.
For example, the maximum inclusion delay to achieve the `source_flag` is 5. If there are no blocks proposed in the next 5 slots to the slot being attested, this flag is not achievable from an attester's perspective.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Create a function that calculates the number of missed slots after a given slot (minimum possible inclusion delay)
- [x] Get which slot a validator attests to and calculate the minimum possible inclusion delay
- [x] Based on the result, simulate achieving a flag or not
- [x] Apply the formula to all forks

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

## Phase0 (in Mainnet)

The validator 31 had to attest to slot 100090, but the next slot was missed. The maximum reward was adjusted
![image](https://github.com/migalabs/goteth/assets/18716811/2f57c61b-feca-4fe7-b3b4-c12ac040cb82)
https://beaconcha.in/slot/1000091

## Deneb (in Holesky)
The validator 409611 had to attest to slot 1165516, but the next slot was missed. The maximum reward was adjusted
![image](https://github.com/migalabs/goteth/assets/18716811/429353c1-19a8-4161-a110-7d61db7664f7)
https://holesky.beaconcha.in/slot/1165517
