### PR TITLE
Fix validator last status persisting wrong val idx

### DIFF
--- a/pkg/db/validator_last_status.go
+++ b/pkg/db/validator_last_status.go
@@ -29,6 +29,7 @@ var (
 func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 	// one object per column
 	var (
+		f_val_idx          proto.ColUInt64
 		f_epoch            proto.ColUInt64
 		f_balance_eth      proto.ColFloat32
 		f_status           proto.ColUInt8
@@ -41,6 +42,7 @@ func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 
 	for _, status := range validatorStatuses {
 
+		f_val_idx.Append(uint64(status.ValIdx))
 		f_epoch.Append(uint64(status.Epoch))
 		f_balance_eth.Append(status.BalanceToEth())
 		f_status.Append(uint8(status.CurrentStatus))
@@ -53,6 +55,7 @@ func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 
 	return proto.Input{
 
+		{Name: "f_val_idx", Data: f_val_idx},
 		{Name: "f_epoch", Data: f_epoch},
 		{Name: "f_balance_eth", Data: f_balance_eth},
 		{Name: "f_status", Data: f_status},


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
We have recently detected a minor bug related to the `validator_last_status` table.
The validator index was always 0.
_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
The validator index was not being persisted and, therefore, the default was being applied.
With this pull request, the error should be fixed and the database should be automatically updated, as this table is refreshed every epoch.
# Tasks
<!-- Checklist of tasks to do -->
- [x] Persist the validator index 

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->
![image](https://github.com/migalabs/goteth/assets/18716811/a94805ed-2e33-4075-b1a9-080b53460397)

