### PR TITLE
Add column avg inclusion delay to pools summary

### DIFF
--- a/pkg/db/migrations/000004_add_inclusion_delay_pools.down.sql
+++ b/pkg/db/migrations/000004_add_inclusion_delay_pools.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_pool_summary DROP COLUMN f_avg_inclusion_delay;

--- a/pkg/db/migrations/000004_add_inclusion_delay_pools.down.sql
+++ b/pkg/db/migrations/000004_add_inclusion_delay_pools.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE t_pool_summary DROP COLUMN f_avg_inclusion_delay;
+ALTER TABLE t_pool_summary DROP COLUMN avg_inclusion_delay;

--- a/pkg/db/migrations/000004_add_inclusion_delay_pools.up.sql
+++ b/pkg/db/migrations/000004_add_inclusion_delay_pools.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_pool_summary ADD COLUMN avg_inclusion_delay Float;

--- a/pkg/db/pools_summary.go
+++ b/pkg/db/pools_summary.go
@@ -23,7 +23,8 @@ var (
 				COUNT(*) as count_expected_attestations,
 				SUM(CASE WHEN t_proposer_duties.f_proposed = TRUE THEN 1 ELSE 0 END) as proposed_blocks_performance,
 				SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE THEN 1 ELSE 0 END) as missed_blocks_performance,
-				count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals
+				count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals,
+				AVG(f_inclusion_delay) as avg_inclusion_delay
 			FROM t_validator_rewards_summary
 			LEFT JOIN t_eth2_pubkeys 
 				ON t_validator_rewards_summary.f_val_idx = t_eth2_pubkeys.f_val_idx


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
As we recently added the inclusion delay calculation for each single validator in a specific epoch, it may also be useful to aggregate this data into the pool summaries.

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
It is needed to add a new column to the pool summaries table and calculate the average inclusion delay of the affected validators per pool.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Add a new column in the pool summaries table
- [x] Calculate the average inclusion delay per epoch  

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->
![image](https://github.com/migalabs/goteth/assets/18716811/2785cbab-6d2f-4654-8c47-b0f92805d646)

