### PR TITLE
Blob events: keep all events without overwriting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     network_mode: 'host'
                 
   clickhouse:
-    image: clickhouse/clickhouse-server:23.12-alpine
+    image: clickhouse/clickhouse-server:24
     user: "$UID:$GID"
     hostname: clickhouse
     environment:

--- a/pkg/db/blob_events.go
+++ b/pkg/db/blob_events.go
@@ -10,7 +10,8 @@ var (
 	insertBlobSideCarsEventsQuery = `
 	INSERT INTO %s (
 		f_arrival_timestamp_ms,
-		f_blob_hash)
+		f_blob_hash,
+		f_slot)
 		VALUES`
 )
 
@@ -19,12 +20,14 @@ func blobSidecarsEventInput(blobSidecarsEvents []spec.BlobSideCarEventWraper) pr
 	var (
 		f_arrival_timestamp_ms proto.ColUInt64
 		f_blob_hash            proto.ColStr
+		f_slot                 proto.ColUInt64
 	)
 
 	for _, blobSidecar := range blobSidecarsEvents {
 
 		f_arrival_timestamp_ms.Append(uint64(blobSidecar.Timestamp.UnixMilli()))
 		f_blob_hash.Append(blobSidecar.BlobSidecarEvent.VersionedHash.String())
+		f_slot.Append(uint64(blobSidecar.BlobSidecarEvent.Slot))
 
 	}
 
@@ -32,6 +35,7 @@ func blobSidecarsEventInput(blobSidecarsEvents []spec.BlobSideCarEventWraper) pr
 
 		{Name: "f_arrival_timestamp_ms", Data: f_arrival_timestamp_ms},
 		{Name: "f_blob_hash", Data: f_blob_hash},
+		{Name: "f_slot", Data: f_slot},
 	}
 }
 

--- a/pkg/db/migrations/000006_blob_events_per_slot.up.sql
+++ b/pkg/db/migrations/000006_blob_events_per_slot.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS t_blob_sidecars_events_copy(
+	f_arrival_timestamp_ms UInt64,
+	f_blob_hash TEXT DEFAULT '',
+	f_slot UInt64)
+	ENGINE = ReplacingMergeTree()
+	ORDER BY (f_arrival_timestamp_ms, f_blob_hash, f_slot);
+
+INSERT INTO t_blob_sidecars_events_copy(f_arrival_timestamp_ms, f_blob_hash)
+	SELECT *
+	FROM t_blob_sidecars_events;
+
+DROP TABLE t_blob_sidecars_events;
+RENAME TABLE t_blob_sidecars_events_copy TO t_blob_sidecars_events;


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
Since we enabled to track of blobs inside GotEth, we have found a small bug where if the same blob is received from the beacon node, it overwrites any existing row in the `t_blob_sidecars_events` table with the same hash.
As this is an events table, we want it not to overwrite any row.

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
We need to recreate the table, but this time all columns are part of the primary key, which disables automatically disables de overwrite of rows. For it to be overwritten, the row must be exactly the same, in which case there is no need to have the same row duplicated

This bug was identified because we saw very large blob_delays, which indicates that the same `blob_hash` is being reused in the future
![image](https://github.com/migalabs/goteth/assets/18716811/395af7ba-b702-4450-a41d-e077330030c0)
With the applied fix, this issue should not happen anymore

# Tasks
<!-- Checklist of tasks to do -->
- [x] Recreate table with the new primary key
- [x] Copy existing values to new table
- [x] Drop old table and rename the new table
- [x] Add slot column (prefilled with 0 during copy)    

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->
![image](https://github.com/migalabs/goteth/assets/18716811/26b188e9-684e-435a-b9b0-641b298b3141)


