### PR TITLE
add attesting balance per flags in epochs table

### DIFF
--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -19,6 +19,9 @@ var (
 		f_num_vals,
 		f_total_balance_eth,
 		f_att_effective_balance_eth,
+		f_source_att_effective_balance_eth,
+		f_target_att_effective_balance_eth,
+		f_head_att_effective_balance_eth,
 		f_total_effective_balance_eth,
 		f_missing_source,
 		f_missing_target,
@@ -45,22 +48,25 @@ var (
 func epochsInput(epochs []spec.Epoch) proto.Input {
 	// one object per column
 	var (
-		f_epoch                       proto.ColUInt64
-		f_slot                        proto.ColUInt64
-		f_num_att                     proto.ColUInt64
-		f_num_att_vals                proto.ColUInt64
-		f_num_vals                    proto.ColUInt64
-		f_total_balance_eth           proto.ColFloat32
-		f_att_effective_balance_eth   proto.ColFloat32
-		f_total_effective_balance_eth proto.ColFloat32
-		f_missing_source              proto.ColUInt64
-		f_missing_target              proto.ColUInt64
-		f_missing_head                proto.ColUInt64
-		f_timestamp                   proto.ColUInt64
-		f_num_slashed_vals            proto.ColUInt64
-		f_num_active_vals             proto.ColUInt64
-		f_num_exited_vals             proto.ColUInt64
-		f_num_in_activation_vals      proto.ColUInt64
+		f_epoch                            proto.ColUInt64
+		f_slot                             proto.ColUInt64
+		f_num_att                          proto.ColUInt64
+		f_num_att_vals                     proto.ColUInt64
+		f_num_vals                         proto.ColUInt64
+		f_total_balance_eth                proto.ColFloat32
+		f_att_effective_balance_eth        proto.ColUInt64
+		f_source_att_effective_balance_eth proto.ColUInt64
+		f_target_att_effective_balance_eth proto.ColUInt64
+		f_head_att_effective_balance_eth   proto.ColUInt64
+		f_total_effective_balance_eth      proto.ColUInt64
+		f_missing_source                   proto.ColUInt64
+		f_missing_target                   proto.ColUInt64
+		f_missing_head                     proto.ColUInt64
+		f_timestamp                        proto.ColUInt64
+		f_num_slashed_vals                 proto.ColUInt64
+		f_num_active_vals                  proto.ColUInt64
+		f_num_exited_vals                  proto.ColUInt64
+		f_num_in_activation_vals           proto.ColUInt64
 	)
 
 	for _, epoch := range epochs {
@@ -70,8 +76,11 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		f_num_att_vals.Append(uint64(epoch.NumAttValidators))
 		f_num_vals.Append(uint64(epoch.NumValidators))
 		f_total_balance_eth.Append(float32(epoch.TotalBalance))
-		f_att_effective_balance_eth.Append(float32(epoch.AttEffectiveBalance))
-		f_total_effective_balance_eth.Append(float32(epoch.TotalEffectiveBalance))
+		f_att_effective_balance_eth.Append(uint64(epoch.AttEffectiveBalance))
+		f_source_att_effective_balance_eth.Append(uint64(epoch.SourceAttEffectiveBalance))
+		f_target_att_effective_balance_eth.Append(uint64(epoch.TargetAttEffectiveBalance))
+		f_head_att_effective_balance_eth.Append(uint64(epoch.HeadAttEffectiveBalance))
+		f_total_effective_balance_eth.Append(uint64(epoch.TotalEffectiveBalance))
 		f_missing_source.Append(uint64(epoch.MissingSource))
 		f_missing_target.Append(uint64(epoch.MissingTarget))
 		f_missing_head.Append(uint64(epoch.MissingHead))
@@ -91,6 +100,9 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		{Name: "f_num_vals", Data: f_num_vals},
 		{Name: "f_total_balance_eth", Data: f_total_balance_eth},
 		{Name: "f_att_effective_balance_eth", Data: f_att_effective_balance_eth},
+		{Name: "f_source_att_effective_balance_eth", Data: f_source_att_effective_balance_eth},
+		{Name: "f_target_att_effective_balance_eth", Data: f_target_att_effective_balance_eth},
+		{Name: "f_head_att_effective_balance_eth", Data: f_head_att_effective_balance_eth},
 		{Name: "f_total_effective_balance_eth", Data: f_total_effective_balance_eth},
 		{Name: "f_missing_source", Data: f_missing_source},
 		{Name: "f_missing_target", Data: f_missing_target},

--- a/pkg/db/migrations/000007_att_balance_per_flag.down.sql
+++ b/pkg/db/migrations/000007_att_balance_per_flag.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_head_att_effective_balance_eth;
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_target_att_effective_balance_eth;
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_source_att_effective_balance_eth;

--- a/pkg/db/migrations/000007_att_balance_per_flag.up.sql
+++ b/pkg/db/migrations/000007_att_balance_per_flag.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE t_epoch_metrics_summary ADD COLUMN f_head_att_effective_balance_eth UInt64 AFTER f_att_effective_balance_eth;
+ALTER TABLE t_epoch_metrics_summary ADD COLUMN f_target_att_effective_balance_eth UInt64 AFTER f_att_effective_balance_eth;
+ALTER TABLE t_epoch_metrics_summary ADD COLUMN f_source_att_effective_balance_eth UInt64 AFTER f_att_effective_balance_eth;
+
+ALTER TABLE t_epoch_metrics_summary MODIFY COLUMN f_att_effective_balance_eth UInt64;
+ALTER TABLE t_epoch_metrics_summary MODIFY COLUMN f_total_effective_balance_eth UInt64;

--- a/pkg/spec/epoch.go
+++ b/pkg/spec/epoch.go
@@ -6,22 +6,25 @@ import (
 
 // TODO: review
 type Epoch struct {
-	Epoch                 phase0.Epoch
-	Slot                  phase0.Slot
-	NumAttestations       int
-	NumAttValidators      int
-	NumValidators         int
-	TotalBalance          float32
-	AttEffectiveBalance   float32
-	TotalEffectiveBalance float32
-	MissingSource         int
-	MissingTarget         int
-	MissingHead           int
-	Timestamp             int64
-	NumSlashedVals        int
-	NumActiveVals         int
-	NumExitedVals         int
-	NumInActivationVals   int
+	Epoch                     phase0.Epoch
+	Slot                      phase0.Slot
+	NumAttestations           int
+	NumAttValidators          int
+	NumValidators             int
+	TotalBalance              float32
+	AttEffectiveBalance       phase0.Gwei
+	SourceAttEffectiveBalance phase0.Gwei
+	TargetAttEffectiveBalance phase0.Gwei
+	HeadAttEffectiveBalance   phase0.Gwei
+	TotalEffectiveBalance     phase0.Gwei
+	MissingSource             int
+	MissingTarget             int
+	MissingHead               int
+	Timestamp                 int64
+	NumSlashedVals            int
+	NumActiveVals             int
+	NumExitedVals             int
+	NumInActivationVals       int
 }
 
 func (f Epoch) Type() ModelType {

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -78,21 +78,24 @@ func StateMetricsByForkVersion(
 func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
 
 	return local_spec.Epoch{
-		Epoch:                 s.CurrentState.Epoch,
-		Slot:                  s.CurrentState.Slot,
-		NumAttestations:       len(s.NextState.PrevAttestations),
-		NumAttValidators:      int(countTrue(s.CurrentNumAttestingVals)),
-		NumValidators:         len(s.CurrentState.Validators),
-		TotalBalance:          float32(s.CurrentState.TotalActiveRealBalance) / float32(local_spec.EffectiveBalanceInc),
-		AttEffectiveBalance:   float32(s.NextState.AttestingBalance[altair.TimelyTargetFlagIndex]) / float32(local_spec.EffectiveBalanceInc), // as per BEaconcha.in
-		TotalEffectiveBalance: float32(s.CurrentState.TotalActiveBalance) / float32(local_spec.EffectiveBalanceInc),
-		MissingSource:         int(s.NextState.GetMissingFlagCount(int(altair.TimelySourceFlagIndex))),
-		MissingTarget:         int(s.NextState.GetMissingFlagCount(int(altair.TimelyTargetFlagIndex))),
-		MissingHead:           int(s.NextState.GetMissingFlagCount(int(altair.TimelyHeadFlagIndex))),
-		Timestamp:             int64(s.CurrentState.GenesisTimestamp + uint64(s.CurrentState.Epoch)*local_spec.SlotsPerEpoch*local_spec.SlotSeconds),
-		NumSlashedVals:        int(s.CurrentState.NumSlashedVals),
-		NumActiveVals:         int(s.CurrentState.NumActiveVals),
-		NumExitedVals:         int(s.CurrentState.NumExitedVals),
-		NumInActivationVals:   int(s.CurrentState.NumQueuedVals),
+		Epoch:                     s.CurrentState.Epoch,
+		Slot:                      s.CurrentState.Slot,
+		NumAttestations:           len(s.NextState.PrevAttestations),
+		NumAttValidators:          int(countTrue(s.CurrentNumAttestingVals)),
+		NumValidators:             len(s.CurrentState.Validators),
+		TotalBalance:              float32(s.CurrentState.TotalActiveRealBalance) / float32(local_spec.EffectiveBalanceInc),
+		AttEffectiveBalance:       s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc, // as per BEaconcha.in
+		SourceAttEffectiveBalance: s.NextState.AttestingBalance[local_spec.AttSourceFlagIndex] / local_spec.EffectiveBalanceInc, // as per BEaconcha.in
+		TargetAttEffectiveBalance: s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc, // as per BEaconcha.in
+		HeadAttEffectiveBalance:   s.NextState.AttestingBalance[local_spec.AttHeadFlagIndex] / local_spec.EffectiveBalanceInc,   // as per BEaconcha.in
+		TotalEffectiveBalance:     s.CurrentState.TotalActiveBalance / local_spec.EffectiveBalanceInc,
+		MissingSource:             int(s.NextState.GetMissingFlagCount(int(altair.TimelySourceFlagIndex))),
+		MissingTarget:             int(s.NextState.GetMissingFlagCount(int(altair.TimelyTargetFlagIndex))),
+		MissingHead:               int(s.NextState.GetMissingFlagCount(int(altair.TimelyHeadFlagIndex))),
+		Timestamp:                 int64(s.CurrentState.GenesisTimestamp + uint64(s.CurrentState.Epoch)*local_spec.SlotsPerEpoch*local_spec.SlotSeconds),
+		NumSlashedVals:            int(s.CurrentState.NumSlashedVals),
+		NumActiveVals:             int(s.CurrentState.NumActiveVals),
+		NumExitedVals:             int(s.CurrentState.NumExitedVals),
+		NumInActivationVals:       int(s.CurrentState.NumQueuedVals),
 	}
 }

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -84,10 +84,10 @@ func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
 		NumAttValidators:          int(countTrue(s.CurrentNumAttestingVals)),
 		NumValidators:             len(s.CurrentState.Validators),
 		TotalBalance:              float32(s.CurrentState.TotalActiveRealBalance) / float32(local_spec.EffectiveBalanceInc),
-		AttEffectiveBalance:       s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc, // as per BEaconcha.in
-		SourceAttEffectiveBalance: s.NextState.AttestingBalance[local_spec.AttSourceFlagIndex] / local_spec.EffectiveBalanceInc, // as per BEaconcha.in
-		TargetAttEffectiveBalance: s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc, // as per BEaconcha.in
-		HeadAttEffectiveBalance:   s.NextState.AttestingBalance[local_spec.AttHeadFlagIndex] / local_spec.EffectiveBalanceInc,   // as per BEaconcha.in
+		AttEffectiveBalance:       s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc,
+		SourceAttEffectiveBalance: s.NextState.AttestingBalance[local_spec.AttSourceFlagIndex] / local_spec.EffectiveBalanceInc,
+		TargetAttEffectiveBalance: s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc,
+		HeadAttEffectiveBalance:   s.NextState.AttestingBalance[local_spec.AttHeadFlagIndex] / local_spec.EffectiveBalanceInc,
 		TotalEffectiveBalance:     s.CurrentState.TotalActiveBalance / local_spec.EffectiveBalanceInc,
 		MissingSource:             int(s.NextState.GetMissingFlagCount(int(altair.TimelySourceFlagIndex))),
 		MissingTarget:             int(s.NextState.GetMissingFlagCount(int(altair.TimelyTargetFlagIndex))),

--- a/tests/db_epoch_metrics_test.py
+++ b/tests/db_epoch_metrics_test.py
@@ -13,6 +13,21 @@ class CheckIntegrityOfDB(dbtest.DBintegrityTest):
         """
         df = self.db.get_df_from_sql_query(sql_query)
         self.assertNoRows(df)
+    
+    def test_att_balance_less_than_total(self):
+        """ Some attesting balance is greater than the total effective balance in the epoch"""
+        sql_query = """
+        SELECT *
+        FROM t_epoch_metrics_summary
+        WHERE (
+            	f_att_effective_balance_eth > f_total_effective_balance_eth or
+				f_source_att_effective_balance_eth > f_total_effective_balance_eth or 
+                f_target_att_effective_balance_eth > f_total_effective_balance_eth or
+                f_head_att_effective_balance_eth > f_total_effective_balance_eth
+        )
+        """
+        df = self.db.get_df_from_sql_query(sql_query)
+        self.assertNoRows(df)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
In order to calculate the reward a validator obtains, it is needed to calculate the attesting balance vs the active effective balance, which adjust the rewards depending on the participation. We aim to store these values, which we already have in memory but will formulas easier with a cheap storage cost.

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
We need to store three additional columns in the `t_epoch_metrics_summary` table.
Each column represents the sum of effective balances of the validators that achieved the given flag.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Change the column format to UInt64, these are all effective balances sum
- [x] Store the three additional columns  

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

![image](https://github.com/migalabs/goteth/assets/18716811/abdbba05-f423-4199-abd0-6cca7b916114)
