### PR TITLE
Set inclusion delay to maxinclusion+1 when there is no attestation

### DIFF
--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -24,7 +24,7 @@ type StateMetricsBase struct {
 	// these are the max rewards calculated by our tool
 	MaxSlashingRewards      map[phase0.ValidatorIndex]phase0.Gwei // for now just proposer as per spec
 	MaxBlockRewards         map[phase0.ValidatorIndex]phase0.Gwei // from including attestation and sync aggregates. In this case, not max reward but the actual reward
-	InclusionDelays         map[phase0.ValidatorIndex]int         // from attestation inclusion delay
+	InclusionDelays         []int                                 // from attestation inclusion delay
 	MaxAttesterRewards      map[phase0.ValidatorIndex]phase0.Gwei // rewards from attesting
 	CurrentNumAttestingVals []bool                                // array that marks whether each validator has attested or not
 }

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -130,7 +130,7 @@ func (p *AltairMetrics) ProcessInclusionDelays() {
 
 	for valIdx, inclusionDelay := range p.baseMetrics.InclusionDelays {
 		if inclusionDelay == 0 {
-			p.baseMetrics.InclusionDelays[valIdx] = p.MaxInclusionDelay(phase0.ValidatorIndex(valIdx)) + 1
+			p.baseMetrics.InclusionDelays[valIdx] = p.maxInclusionDelay(phase0.ValidatorIndex(valIdx)) + 1
 		}
 	}
 }
@@ -165,7 +165,7 @@ func (p AltairMetrics) ProcessAttestations() {
 				continue
 			}
 
-			participationFlags := p.GetParticipationFlags(*attestation, *block)
+			participationFlags := p.getParticipationFlags(*attestation, *block)
 
 			committeIndex := attestation.Data.Index
 
@@ -263,7 +263,7 @@ func (p AltairMetrics) GetMaxFlagIndexDeltas() {
 
 			for i := range p.baseMetrics.CurrentState.AttestingBalance {
 
-				if !p.IsFlagPossible(phase0.ValidatorIndex(valIdx), i) { // consider if the attester could have achieved the flag (inclusion delay wise)
+				if !p.isFlagPossible(phase0.ValidatorIndex(valIdx), i) { // consider if the attester could have achieved the flag (inclusion delay wise)
 					continue
 				}
 				// apply formula
@@ -357,7 +357,7 @@ func (p AltairMetrics) GetInclusionDelay(attestation phase0.Attestation, include
 	return int(includedInBlock.Slot - attestation.Data.Slot)
 }
 
-func (p AltairMetrics) GetParticipationFlags(attestation phase0.Attestation, includedInBlock spec.AgnosticBlock) [3]bool {
+func (p AltairMetrics) getParticipationFlags(attestation phase0.Attestation, includedInBlock spec.AgnosticBlock) [3]bool {
 	var result [3]bool
 
 	justifiedCheckpoint, err := p.GetJustifiedRootfromSlot(attestation.Data.Slot)
@@ -387,7 +387,7 @@ func (p AltairMetrics) GetParticipationFlags(attestation phase0.Attestation, inc
 	return result
 }
 
-func (p AltairMetrics) IsFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int) bool {
+func (p AltairMetrics) isFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int) bool {
 	attSlot := p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx]
 	maxInclusionDelay := 0
 
@@ -418,6 +418,6 @@ func (p AltairMetrics) IsFlagPossible(valIdx phase0.ValidatorIndex, flagIndex in
 
 }
 
-func (p AltairMetrics) MaxInclusionDelay(valIdx phase0.ValidatorIndex) int {
+func (p AltairMetrics) maxInclusionDelay(valIdx phase0.ValidatorIndex) int {
 	return spec.SlotsPerEpoch
 }

--- a/pkg/spec/metrics/state_deneb.go
+++ b/pkg/spec/metrics/state_deneb.go
@@ -82,7 +82,7 @@ func (p DenebMetrics) ProcessAttestations() {
 				continue
 			}
 
-			participationFlags := p.GetParticipationFlags(*attestation, *block)
+			participationFlags := p.getParticipationFlags(*attestation, *block)
 
 			committeIndex := attestation.Data.Index
 
@@ -171,7 +171,7 @@ func (p *DenebMetrics) ProcessInclusionDelays() {
 
 	for valIdx, inclusionDelay := range p.baseMetrics.InclusionDelays {
 		if inclusionDelay == 0 {
-			p.baseMetrics.InclusionDelays[valIdx] = p.MaxInclusionDelay(phase0.ValidatorIndex(valIdx)) + 1
+			p.baseMetrics.InclusionDelays[valIdx] = p.maxInclusionDelay(phase0.ValidatorIndex(valIdx)) + 1
 		}
 	}
 }
@@ -189,7 +189,7 @@ func (p DenebMetrics) GetMaxFlagIndexDeltas() {
 
 			for i := range p.baseMetrics.CurrentState.AttestingBalance {
 
-				if !p.IsFlagPossible(phase0.ValidatorIndex(valIdx), i) { // consider if the attester could have achieved the flag (inclusion delay wise)
+				if !p.isFlagPossible(phase0.ValidatorIndex(valIdx), i) { // consider if the attester could have achieved the flag (inclusion delay wise)
 					continue
 				}
 				// apply formula
@@ -205,7 +205,7 @@ func (p DenebMetrics) GetMaxFlagIndexDeltas() {
 	}
 }
 
-func (p DenebMetrics) GetParticipationFlags(attestation phase0.Attestation, includedInBlock spec.AgnosticBlock) [3]bool {
+func (p DenebMetrics) getParticipationFlags(attestation phase0.Attestation, includedInBlock spec.AgnosticBlock) [3]bool {
 	var result [3]bool
 
 	justifiedCheckpoint, err := p.GetJustifiedRootfromSlot(attestation.Data.Slot)
@@ -243,7 +243,7 @@ func (p DenebMetrics) GetParticipationFlags(attestation phase0.Attestation, incl
 	return result
 }
 
-func (p DenebMetrics) IsFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int) bool {
+func (p DenebMetrics) isFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int) bool {
 	attSlot := p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx]
 	maxInclusionDelay := 0
 
@@ -278,7 +278,7 @@ func (p DenebMetrics) IsFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int
 
 }
 
-func (p DenebMetrics) MaxInclusionDelay(valIdx phase0.ValidatorIndex) int {
+func (p DenebMetrics) maxInclusionDelay(valIdx phase0.ValidatorIndex) int {
 
 	// check attestationSlot in prev epoch
 

--- a/pkg/spec/metrics/state_deneb.go
+++ b/pkg/spec/metrics/state_deneb.go
@@ -284,7 +284,7 @@ func (p DenebMetrics) maxInclusionDelay(valIdx phase0.ValidatorIndex) int {
 
 	slot := p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx]
 
-	slotsUntilEpochEnd := spec.SlotsPerEpoch - (slot % spec.SlotsPerEpoch)
+	slotsUntilEpochEnd := spec.SlotsPerEpoch - (slot % spec.SlotsPerEpoch) - 1
 
 	return spec.SlotsPerEpoch + int(slotsUntilEpochEnd)
 }

--- a/pkg/spec/metrics/state_deneb.go
+++ b/pkg/spec/metrics/state_deneb.go
@@ -62,7 +62,7 @@ func (p DenebMetrics) GetParticipationFlags(attestation phase0.Attestation, incl
 	return result
 }
 
-func (p DenebMetrics) isFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int) bool {
+func (p DenebMetrics) IsFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int) bool {
 	attSlot := p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx]
 	maxInclusionDelay := 0
 
@@ -95,4 +95,15 @@ func (p DenebMetrics) isFlagPossible(valIdx phase0.ValidatorIndex, flagIndex int
 	}
 	return false
 
+}
+
+func (p DenebMetrics) MaxInclusionDelay(valIdx phase0.ValidatorIndex) int {
+
+	// check attestationSlot in prev epoch
+
+	slot := p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx]
+
+	slotsUntilEpochEnd := spec.SlotsPerEpoch - (slot % spec.SlotsPerEpoch)
+
+	return spec.SlotsPerEpoch + int(slotsUntilEpochEnd)
 }

--- a/pkg/spec/metrics/state_deneb.go
+++ b/pkg/spec/metrics/state_deneb.go
@@ -24,6 +24,187 @@ func NewDenebMetrics(
 	return denebObj
 }
 
+func (p *DenebMetrics) InitBundle(nextState *spec.AgnosticState,
+	currentState *spec.AgnosticState,
+	prevState *spec.AgnosticState) {
+	p.baseMetrics.NextState = nextState
+	p.baseMetrics.CurrentState = currentState
+	p.baseMetrics.PrevState = prevState
+	p.baseMetrics.MaxBlockRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	p.baseMetrics.MaxSlashingRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	p.baseMetrics.InclusionDelays = make([]int, len(p.baseMetrics.NextState.Validators))
+	p.baseMetrics.MaxAttesterRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	p.MaxSyncCommitteeRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	p.baseMetrics.CurrentNumAttestingVals = make([]bool, len(currentState.Validators))
+}
+
+func (p *DenebMetrics) PreProcessBundle() {
+
+	if !p.baseMetrics.PrevState.EmptyStateRoot() && !p.baseMetrics.CurrentState.EmptyStateRoot() {
+		// block rewards
+		p.ProcessAttestations()
+		p.ProcessSlashings()
+		p.ProcessSyncAggregates()
+
+		p.GetMaxFlagIndexDeltas()
+		p.ProcessInclusionDelays()
+		p.GetMaxSyncComReward()
+	}
+}
+
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#modified-process_attestation
+func (p DenebMetrics) ProcessAttestations() {
+
+	if p.baseMetrics.CurrentState.Blocks == nil { // only process attestations when CurrentState available
+		return
+	}
+
+	currentEpochParticipation := make([][]bool, len(p.baseMetrics.CurrentState.Validators))
+	nextEpochParticipation := make([][]bool, len(p.baseMetrics.NextState.Validators))
+
+	blockList := p.baseMetrics.CurrentState.Blocks
+	blockList = append(
+		blockList,
+		p.baseMetrics.NextState.Blocks...)
+
+	for _, block := range blockList {
+
+		for _, attestation := range block.Attestations {
+
+			attReward := phase0.Gwei(0)
+			slot := attestation.Data.Slot
+			epochParticipation := nextEpochParticipation
+			if slotInEpoch(slot, p.baseMetrics.CurrentState.Epoch) {
+				epochParticipation = currentEpochParticipation
+			}
+
+			if slot < phase0.Slot(p.baseMetrics.CurrentState.Epoch)*spec.SlotsPerEpoch {
+				continue
+			}
+
+			participationFlags := p.GetParticipationFlags(*attestation, *block)
+
+			committeIndex := attestation.Data.Index
+
+			attestingIndices := attestation.AggregationBits.BitIndices()
+
+			for _, idx := range attestingIndices {
+				block.VotesIncluded += 1
+
+				valIdx, err := p.GetValidatorFromCommitteeIndex(slot, committeIndex, idx)
+				if err != nil {
+					log.Fatalf("error processing attestations at block %d: %s", block.Slot, err)
+				}
+				if epochParticipation[valIdx] == nil {
+					epochParticipation[valIdx] = make([]bool, len(spec.ParticipatingFlagsWeight))
+				}
+
+				if slotInEpoch(slot, p.baseMetrics.CurrentState.Epoch) {
+					p.baseMetrics.CurrentNumAttestingVals[valIdx] = true
+				}
+
+				// we are only counting rewards at NextState
+				attesterBaseReward := p.GetBaseReward(valIdx, p.baseMetrics.NextState.Validators[valIdx].EffectiveBalance, p.baseMetrics.NextState.TotalActiveBalance)
+
+				new := false
+				if participationFlags[spec.AttSourceFlagIndex] && !epochParticipation[valIdx][spec.AttSourceFlagIndex] { // source
+					attReward += attesterBaseReward * spec.TimelySourceWeight
+					epochParticipation[valIdx][spec.AttSourceFlagIndex] = true
+					new = true
+				}
+				if participationFlags[spec.AttTargetFlagIndex] && !epochParticipation[valIdx][spec.AttTargetFlagIndex] { // target
+					attReward += attesterBaseReward * spec.TimelyTargetWeight
+					epochParticipation[valIdx][spec.AttTargetFlagIndex] = true
+					new = true
+				}
+				if participationFlags[spec.AttHeadFlagIndex] && !epochParticipation[valIdx][spec.AttHeadFlagIndex] { // head
+					attReward += attesterBaseReward * spec.TimelyHeadWeight
+					epochParticipation[valIdx][spec.AttHeadFlagIndex] = true
+					new = true
+				}
+				if new {
+					block.NewVotesIncluded += 1
+				}
+			}
+
+			// only process rewards for blocks in NextState
+			if block.Slot >= phase0.Slot(p.baseMetrics.NextState.Epoch)*spec.SlotsPerEpoch {
+				denominator := phase0.Gwei((spec.WeightDenominator - spec.ProposerWeight) * spec.WeightDenominator / spec.ProposerWeight)
+				attReward = attReward / denominator
+
+				p.baseMetrics.MaxBlockRewards[block.ProposerIndex] += attReward
+				block.ManualReward += attReward
+			}
+
+		}
+
+	}
+}
+
+func (p *DenebMetrics) ProcessInclusionDelays() {
+	for _, block := range append(p.baseMetrics.PrevState.Blocks, p.baseMetrics.CurrentState.Blocks...) {
+		// we assume the blocks are in order asc
+		for _, attestation := range block.Attestations {
+			attSlot := attestation.Data.Slot
+			// Calculate inclusion delays only for attestations corresponding to slots from the previous epoch
+			attSlotNotInPrevEpoch := attSlot < phase0.Slot(p.baseMetrics.PrevState.Epoch)*spec.SlotsPerEpoch || attSlot >= phase0.Slot(p.baseMetrics.CurrentState.Epoch)*spec.SlotsPerEpoch
+			if attSlotNotInPrevEpoch {
+				continue
+			}
+			inclusionDelay := p.GetInclusionDelay(*attestation, *block)
+			committeIndex := attestation.Data.Index
+
+			attestingIndices := attestation.AggregationBits.BitIndices()
+
+			for _, idx := range attestingIndices {
+				valIdx, err := p.GetValidatorFromCommitteeIndex(attSlot, committeIndex, idx)
+				if err != nil {
+					log.Fatalf("error processing attestations at block %d: %s", block.Slot, err)
+				}
+
+				if p.baseMetrics.InclusionDelays[valIdx] == 0 {
+					p.baseMetrics.InclusionDelays[valIdx] = inclusionDelay
+				}
+			}
+		}
+	}
+
+	for valIdx, inclusionDelay := range p.baseMetrics.InclusionDelays {
+		if inclusionDelay == 0 {
+			p.baseMetrics.InclusionDelays[valIdx] = p.MaxInclusionDelay(phase0.ValidatorIndex(valIdx)) + 1
+		}
+	}
+}
+
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#get_flag_index_deltas
+func (p DenebMetrics) GetMaxFlagIndexDeltas() {
+
+	for valIdx, validator := range p.baseMetrics.NextState.Validators {
+		maxFlagsReward := phase0.Gwei(0)
+		// the maxReward would be each flag_index_weight * base_reward * (attesting_balance_inc / total_active_balance_inc) / WEIGHT_DENOMINATOR
+
+		if spec.IsActive(*validator, phase0.Epoch(p.baseMetrics.PrevState.Epoch)) {
+			baseReward := p.GetBaseReward(phase0.ValidatorIndex(valIdx), p.baseMetrics.CurrentState.Validators[valIdx].EffectiveBalance, p.baseMetrics.CurrentState.TotalActiveBalance)
+			// only consider flag Index rewards if the validator was active in the previous epoch
+
+			for i := range p.baseMetrics.CurrentState.AttestingBalance {
+
+				if !p.IsFlagPossible(phase0.ValidatorIndex(valIdx), i) { // consider if the attester could have achieved the flag (inclusion delay wise)
+					continue
+				}
+				// apply formula
+				attestingBalanceInc := p.baseMetrics.CurrentState.AttestingBalance[i] / spec.EffectiveBalanceInc
+
+				flagReward := phase0.Gwei(spec.ParticipatingFlagsWeight[i]) * baseReward * attestingBalanceInc
+				flagReward = flagReward / ((phase0.Gwei(p.baseMetrics.CurrentState.TotalActiveBalance / spec.EffectiveBalanceInc)) * phase0.Gwei(spec.WeightDenominator))
+				maxFlagsReward += flagReward
+			}
+		}
+
+		p.baseMetrics.MaxAttesterRewards[phase0.ValidatorIndex(valIdx)] += maxFlagsReward
+	}
+}
+
 func (p DenebMetrics) GetParticipationFlags(attestation phase0.Attestation, includedInBlock spec.AgnosticBlock) [3]bool {
 	var result [3]bool
 

--- a/pkg/spec/metrics/state_phase0.go
+++ b/pkg/spec/metrics/state_phase0.go
@@ -32,7 +32,7 @@ func (p *Phase0Metrics) InitBundle(nextState *spec.AgnosticState,
 	p.baseMetrics.PrevState = prevState
 	p.baseMetrics.MaxBlockRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	p.baseMetrics.MaxSlashingRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
-	p.baseMetrics.InclusionDelays = make(map[phase0.ValidatorIndex]int)
+	p.baseMetrics.InclusionDelays = make([]int, len(p.baseMetrics.NextState.Validators))
 	p.baseMetrics.MaxAttesterRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	p.baseMetrics.CurrentNumAttestingVals = make([]bool, len(currentState.Validators))
 }
@@ -107,6 +107,12 @@ func (p *Phase0Metrics) GetInclusionDelayDeltas() {
 					p.baseMetrics.CurrentState.AttestingBalance[spec.AttHeadFlagIndex] += p.baseMetrics.CurrentState.Validators[attestingValIdx].EffectiveBalance
 				}
 			}
+		}
+	}
+
+	for valIdx, inclusionDelay := range p.baseMetrics.InclusionDelays {
+		if inclusionDelay == 0 {
+			p.baseMetrics.InclusionDelays[valIdx] = spec.SlotsPerEpoch + 1
 		}
 	}
 }


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
We have recently introduced the inclusion delay metric, which indicates the amount of slots it took to include a validator's attestation.
However, when there is no attestation sent, this metric defaults to 0. In result, the `t_pool_summary` has averages of inclusion delays under 1, which is not correct. 
We have a dilemma whether to consider only inclusion delay when there was an attestation included or to default the 0s to the maximum inclusion delay (32 until Deneb).

## Update
In the end, we will set the inclusion delay to the maximum possible + 1. This metric should penalize a validator for not getting the attestation included in any block.

_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
When no attestation was recorded for a given validator, we must calculate the maximum possible inclusion delay (pre-deneb, this is always 32) and sum 1.

# Tasks
<!-- Checklist of tasks to do -->
- [x] Calculate the maximum inclusion delay for a given validator (since Deneb, this is until the end of the next epoch)
- [x] When no attestation was recorded for a given validator, calculate the maximum inclusion delay and add 1.
- [x] Set the inclusion delay in the database accordingly  

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

![image](https://github.com/migalabs/goteth/assets/18716811/f7496681-752e-4fb5-8485-3342aa6ce24f)
