### PR TITLE
Also check proposer index as proposed can be false

### DIFF
--- a/pkg/db/pools_summary.go
+++ b/pkg/db/pools_summary.go
@@ -22,7 +22,7 @@ var (
 				COUNT(CASE WHEN f_missing_head = TRUE THEN 1 ELSE null END) as count_missing_head,
 				COUNT(*) as count_expected_attestations,
 				SUM(CASE WHEN t_proposer_duties.f_proposed = TRUE THEN 1 ELSE 0 END) as proposed_blocks_performance,
-				SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE THEN 1 ELSE 0 END) as missed_blocks_performance,
+				SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE and t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx THEN 1 ELSE 0 END) as missed_blocks_performance,
 				count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals,
 				AVG(f_inclusion_delay) as avg_inclusion_delay
 			FROM t_validator_rewards_summary


### PR DESCRIPTION
# Motivation
<!-- Why are we developing this new code. Is the refactor needed, is the feature getting more data... -->
There is an issue that generates wrong metrics about the missed blocks for a pool.
This PR addresses the given issues and fixes the number.
_Related links:_
 
# Description
<!-- How are we approaching to solve the problem or deploy the new code -->
<!-- What new structures will be added or what major changes will be applied -->
The issue is that when joining two tables, Clickhouse treats Nulls as default values.
For example, it a join does not match a row, Clickhouse fils the missing values with default (0 for int, false for bool).
Therefore, the given query was counting rows on false when these were null.

# Tasks
<!-- Checklist of tasks to do -->
- [ ] 

# Proof of Success 
<!-- Here we may add any logs proving that we achieved what we expected or even diagrams that might be useful to understand the code -->

