### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "go-relay-client"]
 	path = go-relay-client
-	url = git@github.com:migalabs/go-relay-client.git
+	url = https://github.com/migalabs/go-relay-client.git
+	


### PR DESCRIPTION
# Motivation
Attempting to clone `goteth` with https will result in an error because the `go-relay-client` submodule is configured with ssh.
# Description
Changed the `go-relay-client` configuration in `.gitmodules` to use https instead of ssh.


