### PR TITLE
fix bug when init_slot less than 32

### DIFF
--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -50,6 +50,9 @@ func (s *ChainAnalyzer) WaitForPrevState(slot phase0.Slot) {
 	// check if state two epochs before is available
 	// the idea is that blocks are too fast to download, wait for states as well
 
+	if slot < spec.SlotsPerEpoch*2 {
+		return
+	}
 	prevStateEpoch := slot/spec.SlotsPerEpoch - 2              // epoch to check if state downloaded
 	prevStateSlot := (prevStateEpoch+1)*spec.SlotsPerEpoch - 1 // slot at which the check state was downloaded
 

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -177,10 +177,11 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 			if i >= finalizedSlot.Slot {
 				// keep 2 epochs before finalized, needed to calculate epoch metrics
 				s.AdvanceFinalized(finalizedSlot.Slot - spec.SlotsPerEpoch*5) // includes check and clean
-			} else {
+			} else if i > (5 * spec.SlotsPerEpoch) {
 				// keep 5 epochs before current downloading slot, need 3 at least for epoch metrics
 				// magic number, 2 extra if processer takes long
-				s.downloadCache.CleanUpTo(i - (5 * spec.SlotsPerEpoch)) // only clean, no check, keep
+				cleanUpToSlot := i - (5 * spec.SlotsPerEpoch)
+				s.downloadCache.CleanUpTo(cleanUpToSlot) // only clean, no check, keep
 			}
 		}
 


### PR DESCRIPTION
# Description
When running in historical mode with init_slot being <32, there was an underflow which made the script get stuck. This was fixed in this PR.

```
time="2024-07-03T15:37:49Z" level=debug msg="slot 0 waiting for state at slot 18446744073709551583 (epoch 18446744073709551614) to be downloaded or processed..." module=analyzer
```

Closes #121

