### PR TITLE
Fix/capella blocks download crashing

### DIFF
--- a/pkg/spec/block.go
+++ b/pkg/spec/block.go
@@ -252,7 +252,7 @@ func NewCapellaBlock(block spec.VersionedSignedBeaconBlock) AgnosticBlock {
 			GasLimit:      block.Capella.Message.Body.ExecutionPayload.GasLimit,
 			GasUsed:       block.Capella.Message.Body.ExecutionPayload.GasUsed,
 			Timestamp:     block.Capella.Message.Body.ExecutionPayload.Timestamp,
-			BaseFeePerGas: binary.BigEndian.Uint64(block.Bellatrix.Message.Body.ExecutionPayload.BaseFeePerGas[:]),
+			BaseFeePerGas: binary.BigEndian.Uint64(block.Capella.Message.Body.ExecutionPayload.BaseFeePerGas[:]),
 			BlockHash:     block.Capella.Message.Body.ExecutionPayload.BlockHash,
 			Transactions:  block.Capella.Message.Body.ExecutionPayload.Transactions,
 			BlockNumber:   block.Capella.Message.Body.ExecutionPayload.BlockNumber,


### PR DESCRIPTION
# Description
Fixed bug introduced in #114 in which Capella blocks weren't downloaded and crashed goteth.

Closes #128 