### PR TITLE
change the way we calculate num attestations to use block data

### DIFF
--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -80,7 +80,7 @@ func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
 	return local_spec.Epoch{
 		Epoch:                     s.CurrentState.Epoch,
 		Slot:                      s.CurrentState.Slot,
-		NumAttestations:           len(s.NextState.PrevAttestations),
+		NumAttestations:           s.CurrentState.NumAttestations,
 		NumAttValidators:          int(countTrue(s.CurrentNumAttestingVals)),
 		NumValidators:             len(s.CurrentState.Validators),
 		TotalBalance:              float32(s.CurrentState.TotalActiveRealBalance) / float32(local_spec.EffectiveBalanceInc),

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -25,6 +25,7 @@ type AgnosticState struct {
 	EpochStructs               EpochDuties                  // structs about beacon committees, proposers and attestation
 	PrevEpochCorrectFlags      [][]bool                     // one aray per flag
 	PrevAttestations           []*phase0.PendingAttestation // array of attestations (currently only for Phase0)
+	NumAttestations            int                          // number of attestations in the epoch
 	NumActiveVals              uint                         // number of active validators in the epoch
 	NumExitedVals              uint                         // number of exited validators in the epoch
 	NumSlashedVals             uint                         // number of slashed validators in the epoch
@@ -86,6 +87,13 @@ func (p *AgnosticState) AddBlocks(blockList []*AgnosticBlock) {
 	p.Blocks = blockList
 	p.CalculateWithdrawals()
 	p.CalculateDeposits()
+	p.CalculateNumAttestations()
+}
+
+func (p *AgnosticState) CalculateNumAttestations() {
+	for _, block := range p.Blocks {
+		p.NumAttestations += len(block.Attestations)
+	}
 }
 
 func (p *AgnosticState) CalculateWithdrawals() {


### PR DESCRIPTION
# Description
We calculated the column `f_num_att` from data obtained from the state. On phase0, the state contained the object `previous_epoch_attestations` which was used to obtain the amount of attestations included in the epoch. This object is not available on states of newer forks which meant that only phase0 had this calculation. We now use the sum of the number of attestations per block, which works for all forks.

Note: the calculation for phase0 gave wrong values so this update fixes that as well. See #134 


