### PR TITLE
Fix/the first epoch downloaded has incomplete data

### DIFF
--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -70,8 +70,9 @@ func NewChainAnalyzer(
 				cancel: cancel,
 			}, errors.Errorf("Final Slot cannot be greater than Init Slot")
 		}
-		iConfig.InitSlot = iConfig.InitSlot / spec.SlotsPerEpoch * spec.SlotsPerEpoch
-		iConfig.FinalSlot = iConfig.FinalSlot / spec.SlotsPerEpoch * spec.SlotsPerEpoch
+		// Start 2 epochs before and finish 1 epoch after
+		iConfig.InitSlot = iConfig.InitSlot/spec.SlotsPerEpoch*spec.SlotsPerEpoch - spec.SlotsPerEpoch*2
+		iConfig.FinalSlot = iConfig.FinalSlot/spec.SlotsPerEpoch*spec.SlotsPerEpoch + spec.SlotsPerEpoch
 		log.Infof("generating new Block Analyzer from slots %d:%d", iConfig.InitSlot, iConfig.FinalSlot)
 	}
 

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -47,23 +47,16 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 		s.stop = true
 	}
 
-	// If nextState is filled, we can process proposer duties
-	if !nextState.EmptyStateRoot() {
+	// If prevState, currentState and nextState are filled, we can process proposer duties, epoch metrics and validator rewards
+	if !nextState.EmptyStateRoot() && !currentState.EmptyStateRoot() && !prevState.EmptyStateRoot() {
 		s.processEpochDuties(bundle)
 		s.processValLastStatus(bundle)
 
-		// If currentState and nextState are filled, we can process epoch metrics
-		if !currentState.EmptyStateRoot() {
-			s.processPoolMetrics(bundle.GetMetricsBase().CurrentState.Epoch)
-			s.processEpochMetrics(bundle)
-
-			// If prevState, currentState and nextState are filled, we can process validator rewards
-			if !prevState.EmptyStateRoot() {
-				s.processBlockRewards(bundle) // block rewards depend on two previous epochs
-				if s.metrics.ValidatorRewards {
-					s.processEpochValRewards(bundle)
-				}
-			}
+		s.processPoolMetrics(bundle.GetMetricsBase().CurrentState.Epoch)
+		s.processEpochMetrics(bundle)
+		s.processBlockRewards(bundle) // block rewards depend on two previous epochs
+		if s.metrics.ValidatorRewards {
+			s.processEpochValRewards(bundle)
 		}
 	}
 

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -131,15 +131,15 @@ func (s *ChainAnalyzer) fillToHead() phase0.Slot {
 		log.Errorf("could not obtain last slot in database: %s", err)
 	}
 	// if we did not get a last slot from the database, or we were too close to the head
-	// then start from the current finalized in the chain
+	// then start from two epochs before current finalized in the chain
 	if nextSlotDownload == 0 || nextSlotDownload > finalizedBlock.Slot {
 		log.Infof("continue from finalized slot %d, epoch %d", finalizedBlock.Slot, finalizedBlock.Slot/spec.SlotsPerEpoch)
-		nextSlotDownload = finalizedBlock.Slot
+		nextSlotDownload = finalizedBlock.Slot - (epochsToFinalizedTentative * spec.SlotsPerEpoch) // 2 epochs before
+
 	} else {
 		// database detected
 		log.Infof("database detected, continue from slot %d, epoch %d", nextSlotDownload, nextSlotDownload/spec.SlotsPerEpoch)
 		nextSlotDownload = nextSlotDownload - (epochsToFinalizedTentative * spec.SlotsPerEpoch) // 2 epochs before
-
 	}
 	nextSlotDownload = nextSlotDownload / spec.SlotsPerEpoch * spec.SlotsPerEpoch
 	s.initSlot = nextSlotDownload / spec.SlotsPerEpoch * spec.SlotsPerEpoch


### PR DESCRIPTION
# Description
The first epoch downloaded when running goteth would allways have the `PrevState.EmptyStateRoot()` flag on. This means that this epoch would be stored with incomplete data on the database.

Now we wait until we have 2 epochs downloaded before the current epoch to start storing epoch and rewards data. This ensures that we have the required info and there isn't incomplete data. Goteth now always downloads two epochs before the starting point as well to not leave gaps.

Closes #131
