### PR TITLE
fix no retry on error download state

### DIFF
--- a/pkg/clientapi/state.go
+++ b/pkg/clientapi/state.go
@@ -35,9 +35,6 @@ func (s *APIClient) RequestBeaconState(slot phase0.Slot) (*local_spec.AgnosticSt
 			State: fmt.Sprintf("%d", slot),
 		})
 
-		if newState == nil {
-			return nil, fmt.Errorf("unable to retrieve Beacon State from the beacon node, closing requester routine. nil State")
-		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			ticker := time.NewTicker(utils.RoutineFlushTimeout)
 			log.Warnf("retrying request: %s", routineKey)


### PR DESCRIPTION
# Description
When downloading the state on a slot, the endpoint call is heavy in terms of processing and size. A context deadline exceeded error can happen and it isn't being handled correctly as it should retry but it crashes.

Removed the return statement that prevented retrying.

Closes #137 

