### PR TITLE
Feature: expand blob sidecars events table

### DIFF
--- a/docs/tables.md
+++ b/docs/tables.md
@@ -239,13 +239,16 @@ Table that stores the data from `t_validator_rewards_summary` but aggregated by 
 | f_kzg_proof      | string       | kzg proof of the blob                                      |
 | f_ending_0s      | integer      | amount of consecutive 0s at the end of the blob bytes      |
 
-# Blob Sidecars Events
+# Blob Sidecars Events (`t_blob_sidecars_events`)
 
 | Column Name            | Type of Data | Description                                       |     |     |
 | ---------------------- | ------------ | ------------------------------------------------- | --- | --- |
 | f_arrival_timestamp_ms | integer      | timestamp at which goteth received the blob event |
 | f_blob_hash            | string       | hash of the blob                                  |
 | f_slot                 | integer      | slot at which the blob was sent                   |
+| f_block_root           | string       | block root hash                                   |
+| f_index                | integer      | index of the blob                                 |
+| f_kzg_commitment       | string       | kzg commitment of the blob                        |
 
 # Block Rewards
 

--- a/pkg/db/blob_events.go
+++ b/pkg/db/blob_events.go
@@ -11,7 +11,10 @@ var (
 	INSERT INTO %s (
 		f_arrival_timestamp_ms,
 		f_blob_hash,
-		f_slot)
+		f_slot,
+		f_block_root,
+		f_index,
+		f_kzg_commitment)
 		VALUES`
 )
 
@@ -21,6 +24,9 @@ func blobSidecarsEventInput(blobSidecarsEvents []spec.BlobSideCarEventWraper) pr
 		f_arrival_timestamp_ms proto.ColUInt64
 		f_blob_hash            proto.ColStr
 		f_slot                 proto.ColUInt64
+		f_block_root           proto.ColStr
+		f_index                proto.ColUInt8
+		f_kzg_commitment       proto.ColStr
 	)
 
 	for _, blobSidecar := range blobSidecarsEvents {
@@ -28,7 +34,9 @@ func blobSidecarsEventInput(blobSidecarsEvents []spec.BlobSideCarEventWraper) pr
 		f_arrival_timestamp_ms.Append(uint64(blobSidecar.Timestamp.UnixMilli()))
 		f_blob_hash.Append(blobSidecar.BlobSidecarEvent.VersionedHash.String())
 		f_slot.Append(uint64(blobSidecar.BlobSidecarEvent.Slot))
-
+		f_block_root.Append(blobSidecar.BlobSidecarEvent.BlockRoot.String())
+		f_index.Append(uint8(blobSidecar.BlobSidecarEvent.Index))
+		f_kzg_commitment.Append(blobSidecar.BlobSidecarEvent.KZGCommitment.String())
 	}
 
 	return proto.Input{
@@ -36,6 +44,9 @@ func blobSidecarsEventInput(blobSidecarsEvents []spec.BlobSideCarEventWraper) pr
 		{Name: "f_arrival_timestamp_ms", Data: f_arrival_timestamp_ms},
 		{Name: "f_blob_hash", Data: f_blob_hash},
 		{Name: "f_slot", Data: f_slot},
+		{Name: "f_block_root", Data: f_block_root},
+		{Name: "f_index", Data: f_index},
+		{Name: "f_kzg_commitment", Data: f_kzg_commitment},
 	}
 }
 

--- a/pkg/db/migrations/000015_blob_events_add_missing_columns.down.sql
+++ b/pkg/db/migrations/000015_blob_events_add_missing_columns.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_blob_sidecars_events DROP COLUMN f_block_root;
+ALTER TABLE t_blob_sidecars_events DROP COLUMN f_index;
+ALTER TABLE t_blob_sidecars_events DROP COLUMN f_kzg_commitment;

--- a/pkg/db/migrations/000015_blob_events_add_missing_columns.up.sql
+++ b/pkg/db/migrations/000015_blob_events_add_missing_columns.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_blob_sidecars_events ADD COLUMN f_block_root TEXT;
+ALTER TABLE t_blob_sidecars_events ADD COLUMN f_index UInt8;
+ALTER TABLE t_blob_sidecars_events ADD COLUMN f_kzg_commitment TEXT;


### PR DESCRIPTION
# Description
Added missing columns `f_block_root`, `f_index` and `f_kzg_commitment` to `t_blob_sidecars_events`. 