### PR TITLE
Feature: Add attestation included column val rewards

### DIFF
--- a/docs/tables.md
+++ b/docs/tables.md
@@ -58,7 +58,7 @@
 | f_new_proposer_slashings           | uint64       | amount of new proposer slashings included in the epoch                                                                 |
 | f_new_attester_slashings           | uint64       | amount of new attester slashings included in the epoch                                                                 |
 
-# Pool Summaries
+# Pool Summaries (`t_pool_summaries`)
 
 | Column Name                 | Type of Data | Description                                                                   |     |     |
 | --------------------------- | ------------ | ----------------------------------------------------------------------------- | --- | --- |
@@ -71,6 +71,7 @@
 | count_missing_target        | integer      | amount of validator with a missed target flag for the given pool              |
 | count_missing_head          | integer      | amount of validator with a missed head flag for the given pool                |
 | count_expected_attestations | integer      | amount of attestations expected for the given pool (one per active valdiator) |
+| count_attestations_included | integer      | amount of attestations included for the given pool corresponding to the epoch |
 | proposed_blocks_performance | integer      | sum of proposed blocks by validators in the given pool                        |
 | missed_blocks_performance   | integer      | sum of missed blocks by validators in the given pool                          |
 | number_active_vals          | integer      | number of active validators in the given pool                                 |
@@ -132,7 +133,7 @@
 | f_exit_epoch       | integer      | epoch at which the validator exited the network    |
 | f_public_key       | string       | public key of the validator                        |
 
-# Validator Rewards Summary
+# Validator Rewards Summary (`t_validator_rewards_summary`)
 
 | Column Name                 | Type of Data | Description                                                                                                           |     |     |
 | --------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------- | --- | --- |
@@ -146,6 +147,7 @@
 | f_att_slot                  | integer      | slot the validator had to attest to (2 epochs before)                                                                 |
 | f_base_reward               | integer      | base reward taken into account to calculate the rewards (Gwei)                                                        |
 | f_in_sync_committee         | bool         | whether the validator participated in the sync commmittee in the given epoch                                          |
+| f_attestation_included      | bool         | whether the attestation was included in the chain (2 epochs before)                                                   |
 | f_missing_source            | bool         | whether the validator missed the source flag while attesing (takes into account the attestation to 2 epochs before)   |
 | f_missing_target            | bool         | whether the validator missed the target flag while attesing (takes into account the attestation to 2 epochs before)   |
 | f_missing_head              | bool         | whether the validator missed the head flag while attesing (takes into account the attestation to 2 epochs before)     |
@@ -154,7 +156,7 @@
 | f_block_experimental_reward | integer      | consensus block reward manually calculated by goteth (only if the validator was a proposer in the given epoch) (Gwei) |
 | f_inclusion_delay           | integer      | amount of slots after the attested one at which the attestation was included                                          |
 
-# Validator Rewards Aggregation
+# Validator Rewards Aggregation (`t_validator_rewards_aggregation`)
 
 Table that stores the data from `t_validator_rewards_summary` but aggregated by validator on an epoch range.
 
@@ -169,6 +171,7 @@ Table that stores the data from `t_validator_rewards_summary` but aggregated by 
 | f_max_sync_reward           | uint64       | maximum sync committee that could have been obtained from the previous epoch in the given epoch range (Gwei)                    |
 | f_base_reward               | uint64       | base reward taken into account to calculate the rewards (Gwei)                                                                  |
 | f_in_sync_committee_count   | uint16       | number of times the validator participated in the sync commmittee in the given epoch range                                      |
+| f_attestations_included     | uint16       | number of times the attestation was included in the chain (takes into account the attestation to 2 epochs before)               |
 | f_missing_source_count      | uint16       | the amount of times the validator missed the source flag while attesing (takes into account the attestation to 2 epochs before) |
 | f_missing_target_count      | uint16       | the amount of times the validator missed the target flag while attesing (takes into account the attestation to 2 epochs before) |
 | f_missing_head_count        | uint16       | the amount of times the validator missed the head flag while attesing (takes into account the attestation to 2 epochs before)   |

--- a/pkg/db/migrations/000018_add_att_included_val_rewards_table.down.sql
+++ b/pkg/db/migrations/000018_add_att_included_val_rewards_table.down.sql
@@ -2,3 +2,5 @@ ALTER TABLE t_validator_rewards_summary DROP COLUMN f_attestation_included;
 
 
 ALTER TABLE t_validator_rewards_aggregation DROP COLUMN f_attestations_included;
+
+ALTER TABLE t_pool_summary DROP COLUMN count_attestations_included;

--- a/pkg/db/migrations/000018_add_att_included_val_rewards_table.down.sql
+++ b/pkg/db/migrations/000018_add_att_included_val_rewards_table.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE t_validator_rewards_summary DROP COLUMN f_attestation_included;
+
+
+ALTER TABLE t_validator_rewards_aggregation DROP COLUMN f_attestations_included;

--- a/pkg/db/migrations/000018_add_att_included_val_rewards_table.up.sql
+++ b/pkg/db/migrations/000018_add_att_included_val_rewards_table.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_validator_rewards_summary ADD COLUMN f_attestation_included BOOL AFTER f_att_slot;
+
+ALTER TABLE t_validator_rewards_aggregation ADD COLUMN f_attestations_included UInt16 AFTER f_in_sync_committee_count;

--- a/pkg/db/migrations/000018_add_att_included_val_rewards_table.up.sql
+++ b/pkg/db/migrations/000018_add_att_included_val_rewards_table.up.sql
@@ -1,3 +1,5 @@
 ALTER TABLE t_validator_rewards_summary ADD COLUMN f_attestation_included BOOL AFTER f_att_slot;
 
 ALTER TABLE t_validator_rewards_aggregation ADD COLUMN f_attestations_included UInt16 AFTER f_in_sync_committee_count;
+
+ALTER TABLE t_pool_summary ADD COLUMN count_attestations_included UInt64 AFTER count_expected_attestations;

--- a/pkg/db/pools_summary.go
+++ b/pkg/db/pools_summary.go
@@ -21,6 +21,7 @@ var (
 				COUNT(CASE WHEN f_missing_target = TRUE THEN 1 ELSE null END) as count_missing_target,
 				COUNT(CASE WHEN f_missing_head = TRUE THEN 1 ELSE null END) as count_missing_head,
 				COUNT(*) as count_expected_attestations,
+				SUM(CASE WHEN f_attestation_included = TRUE THEN 1 ELSE 0 END) as count_included_attestations,
 				SUM(CASE WHEN t_proposer_duties.f_proposed = TRUE THEN 1 ELSE 0 END) as proposed_blocks_performance,
 				SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE and t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx THEN 1 ELSE 0 END) as missed_blocks_performance,
 				count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals,

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -19,6 +19,7 @@ var (
 		f_max_att_reward,
 		f_max_sync_reward,
 		f_att_slot,
+		f_attestation_included,
 		f_base_reward,
 		f_in_sync_committee,
 		f_missing_source,
@@ -51,6 +52,7 @@ func rewardsInput(vals []spec.ValidatorRewards) proto.Input {
 		f_max_att_reward            proto.ColUInt64
 		f_max_sync_reward           proto.ColUInt64
 		f_att_slot                  proto.ColUInt64
+		f_attestation_included      proto.ColBool
 		f_base_reward               proto.ColUInt64
 		f_in_sync_committee         proto.ColBool
 		f_missing_source            proto.ColBool
@@ -71,6 +73,7 @@ func rewardsInput(vals []spec.ValidatorRewards) proto.Input {
 		f_max_att_reward.Append(uint64(val.AttestationReward))
 		f_max_sync_reward.Append(uint64(val.SyncCommitteeReward))
 		f_att_slot.Append(uint64(val.AttSlot))
+		f_attestation_included.Append(val.AttestationIncluded)
 		f_base_reward.Append(uint64(val.BaseReward))
 		f_in_sync_committee.Append(val.InSyncCommittee)
 		f_missing_source.Append(val.MissingSource)
@@ -91,6 +94,7 @@ func rewardsInput(vals []spec.ValidatorRewards) proto.Input {
 		{Name: "f_max_att_reward", Data: f_max_att_reward},
 		{Name: "f_max_sync_reward", Data: f_max_sync_reward},
 		{Name: "f_att_slot", Data: f_att_slot},
+		{Name: "f_attestation_included", Data: f_attestation_included},
 		{Name: "f_base_reward", Data: f_base_reward},
 		{Name: "f_in_sync_committee", Data: f_in_sync_committee},
 		{Name: "f_missing_source", Data: f_missing_source},

--- a/pkg/db/validator_rewards_aggregation.go
+++ b/pkg/db/validator_rewards_aggregation.go
@@ -20,6 +20,7 @@ var (
 		f_max_sync_reward,
 		f_base_reward,
 		f_in_sync_committee_count,
+		f_attestations_included,
 		f_missing_source_count,
 		f_missing_target_count,
 		f_missing_head_count,
@@ -45,6 +46,7 @@ func rewardsAggregationInput(vals []spec.ValidatorRewardsAggregation) proto.Inpu
 		f_max_sync_reward           proto.ColUInt64
 		f_base_reward               proto.ColUInt64
 		f_in_sync_committee_count   proto.ColUInt16
+		f_attestations_included     proto.ColUInt16
 		f_missing_source_count      proto.ColUInt16
 		f_missing_target_count      proto.ColUInt16
 		f_missing_head_count        proto.ColUInt16
@@ -63,6 +65,7 @@ func rewardsAggregationInput(vals []spec.ValidatorRewardsAggregation) proto.Inpu
 		f_max_sync_reward.Append(uint64(val.MaxSyncCommitteeReward))
 		f_base_reward.Append(uint64(val.BaseReward))
 		f_in_sync_committee_count.Append(val.InSyncCommitteeCount)
+		f_attestations_included.Append(val.AttestationsIncluded)
 		f_missing_source_count.Append(val.MissingSourceCount)
 		f_missing_target_count.Append(val.MissingTargetCount)
 		f_missing_head_count.Append(val.MissingHeadCount)

--- a/pkg/db/validator_rewards_aggregation.go
+++ b/pkg/db/validator_rewards_aggregation.go
@@ -84,6 +84,7 @@ func rewardsAggregationInput(vals []spec.ValidatorRewardsAggregation) proto.Inpu
 		{Name: "f_max_sync_reward", Data: f_max_sync_reward},
 		{Name: "f_base_reward", Data: f_base_reward},
 		{Name: "f_in_sync_committee_count", Data: f_in_sync_committee_count},
+		{Name: "f_attestations_included", Data: f_attestations_included},
 		{Name: "f_missing_source_count", Data: f_missing_source_count},
 		{Name: "f_missing_target_count", Data: f_missing_target_count},
 		{Name: "f_missing_head_count", Data: f_missing_head_count},

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -22,11 +22,10 @@ type StateMetricsBase struct {
 	CurrentState *local_spec.AgnosticState
 	NextState    *local_spec.AgnosticState
 	// these are the max rewards calculated by our tool
-	MaxSlashingRewards      map[phase0.ValidatorIndex]phase0.Gwei // for now just proposer as per spec
-	MaxBlockRewards         map[phase0.ValidatorIndex]phase0.Gwei // from including attestation and sync aggregates. In this case, not max reward but the actual reward
-	InclusionDelays         []int                                 // from attestation inclusion delay
-	MaxAttesterRewards      map[phase0.ValidatorIndex]phase0.Gwei // rewards from attesting
-	CurrentNumAttestingVals []bool                                // array that marks whether each validator has attested or not
+	MaxSlashingRewards map[phase0.ValidatorIndex]phase0.Gwei // for now just proposer as per spec
+	MaxBlockRewards    map[phase0.ValidatorIndex]phase0.Gwei // from including attestation and sync aggregates. In this case, not max reward but the actual reward
+	InclusionDelays    []int                                 // from attestation inclusion delay
+	MaxAttesterRewards map[phase0.ValidatorIndex]phase0.Gwei // rewards from attesting
 }
 
 func (p StateMetricsBase) EpochReward(valIdx phase0.ValidatorIndex) int64 {
@@ -81,7 +80,7 @@ func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
 		Epoch:                      s.CurrentState.Epoch,
 		Slot:                       s.CurrentState.Slot,
 		NumAttestations:            s.CurrentState.NumAttestations,
-		NumAttValidators:           int(countTrue(s.CurrentNumAttestingVals)),
+		NumAttValidators:           int(countTrue(s.CurrentState.ValidatorAttestationIncluded)),
 		NumValidators:              len(s.CurrentState.Validators),
 		TotalBalance:               float32(s.CurrentState.TotalActiveRealBalance) / float32(local_spec.EffectiveBalanceInc),
 		AttEffectiveBalance:        s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc,

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -38,7 +38,6 @@ func (p *AltairMetrics) InitBundle(nextState *spec.AgnosticState,
 	p.baseMetrics.InclusionDelays = make([]int, len(p.baseMetrics.NextState.Validators))
 	p.baseMetrics.MaxAttesterRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	p.MaxSyncCommitteeRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
-	p.baseMetrics.CurrentNumAttestingVals = make([]bool, len(currentState.Validators))
 }
 
 func (p *AltairMetrics) PreProcessBundle() {
@@ -183,7 +182,7 @@ func (p AltairMetrics) ProcessAttestations() {
 				}
 
 				if slotInEpoch(slot, p.baseMetrics.CurrentState.Epoch) {
-					p.baseMetrics.CurrentNumAttestingVals[valIdx] = true
+					p.baseMetrics.CurrentState.ValidatorAttestationIncluded[valIdx] = true
 				}
 
 				// we are only counting rewards at NextState
@@ -313,6 +312,11 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 	flags := p.baseMetrics.CurrentState.MissingFlags(valIdx)
 	baseReward := p.GetBaseReward(valIdx, p.baseMetrics.NextState.Validators[valIdx].EffectiveBalance, p.baseMetrics.NextState.TotalActiveBalance)
 
+	attestationIncluded := false
+	if int(valIdx) < len(p.baseMetrics.CurrentState.ValidatorAttestationIncluded) {
+		attestationIncluded = p.baseMetrics.CurrentState.ValidatorAttestationIncluded[valIdx]
+	}
+
 	result := spec.ValidatorRewards{
 		ValidatorIndex:       valIdx,
 		Epoch:                p.baseMetrics.NextState.Epoch,
@@ -322,10 +326,11 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		AttestationReward:    flagIndexMaxReward,
 		SyncCommitteeReward:  syncComMaxReward,
 		AttSlot:              p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx],
+		AttestationIncluded:  attestationIncluded,
 		MissingSource:        flags[spec.AttSourceFlagIndex],
 		MissingTarget:        flags[spec.AttTargetFlagIndex],
 		MissingHead:          flags[spec.AttHeadFlagIndex],
-		Status:               p.baseMetrics.NextState.GetValStatus(valIdx),
+		Status:               p.baseMetrics.CurrentState.GetValStatus(valIdx),
 		BaseReward:           baseReward,
 		ProposerApiReward:    proposerApiReward,
 		ProposerManualReward: proposerManualReward,
@@ -418,6 +423,6 @@ func (p AltairMetrics) isFlagPossible(valIdx phase0.ValidatorIndex, flagIndex in
 
 }
 
-func (p AltairMetrics) maxInclusionDelay(valIdx phase0.ValidatorIndex) int {
+func (p AltairMetrics) maxInclusionDelay(_ phase0.ValidatorIndex) int {
 	return spec.SlotsPerEpoch
 }

--- a/pkg/spec/metrics/state_deneb.go
+++ b/pkg/spec/metrics/state_deneb.go
@@ -35,7 +35,6 @@ func (p *DenebMetrics) InitBundle(nextState *spec.AgnosticState,
 	p.baseMetrics.InclusionDelays = make([]int, len(p.baseMetrics.NextState.Validators))
 	p.baseMetrics.MaxAttesterRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	p.MaxSyncCommitteeRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
-	p.baseMetrics.CurrentNumAttestingVals = make([]bool, len(currentState.Validators))
 }
 
 func (p *DenebMetrics) PreProcessBundle() {
@@ -100,7 +99,7 @@ func (p DenebMetrics) ProcessAttestations() {
 				}
 
 				if slotInEpoch(slot, p.baseMetrics.CurrentState.Epoch) {
-					p.baseMetrics.CurrentNumAttestingVals[valIdx] = true
+					p.baseMetrics.CurrentState.ValidatorAttestationIncluded[valIdx] = true
 				}
 
 				// we are only counting rewards at NextState

--- a/pkg/spec/metrics/state_phase0.go
+++ b/pkg/spec/metrics/state_phase0.go
@@ -34,7 +34,6 @@ func (p *Phase0Metrics) InitBundle(nextState *spec.AgnosticState,
 	p.baseMetrics.MaxSlashingRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	p.baseMetrics.InclusionDelays = make([]int, len(p.baseMetrics.NextState.Validators))
 	p.baseMetrics.MaxAttesterRewards = make(map[phase0.ValidatorIndex]phase0.Gwei)
-	p.baseMetrics.CurrentNumAttestingVals = make([]bool, len(currentState.Validators))
 }
 
 func (p *Phase0Metrics) PreProcessBundle() {
@@ -84,7 +83,7 @@ func (p *Phase0Metrics) GetInclusionDelayDeltas() {
 					p.baseMetrics.CurrentState.AttestingBalance[spec.AttSourceFlagIndex] += p.baseMetrics.CurrentState.Validators[attestingValIdx].EffectiveBalance
 
 					// configure attester participation
-					p.baseMetrics.CurrentNumAttestingVals[attestingValIdx] = true
+					p.baseMetrics.CurrentState.ValidatorAttestationIncluded[attestingValIdx] = true
 
 					// add proposer reward
 					proposerReward := p.GetProposerReward(attestingValIdx)
@@ -167,6 +166,7 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		AttestationReward:    p.baseMetrics.MaxAttesterRewards[valIdx],
 		SyncCommitteeReward:  0,
 		AttSlot:              p.baseMetrics.PrevState.EpochStructs.ValidatorAttSlot[valIdx],
+		AttestationIncluded:  p.baseMetrics.CurrentState.ValidatorAttestationIncluded[valIdx],
 		MissingSource:        !p.baseMetrics.CurrentState.PrevEpochCorrectFlags[spec.AttSourceFlagIndex][valIdx],
 		MissingTarget:        !p.baseMetrics.CurrentState.PrevEpochCorrectFlags[spec.AttTargetFlagIndex][valIdx],
 		MissingHead:          !p.baseMetrics.CurrentState.PrevEpochCorrectFlags[spec.AttHeadFlagIndex][valIdx],

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -12,39 +12,40 @@ import (
 
 // This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs
 type AgnosticState struct {
-	Version                    spec.DataVersion
-	GenesisTimestamp           uint64 // genesis timestamp
-	StateRoot                  phase0.Root
-	Epoch                      phase0.Epoch                 // Epoch of the state
-	Slot                       phase0.Slot                  // Slot of the state
-	Balances                   []phase0.Gwei                // balance of each validator
-	Validators                 []*phase0.Validator          // list of validators
-	TotalActiveBalance         phase0.Gwei                  // effective balance
-	TotalActiveRealBalance     phase0.Gwei                  // real balance
-	AttestingBalance           []phase0.Gwei                // one attesting balance per flag (of the previous epoch attestations)
-	EpochStructs               EpochDuties                  // structs about beacon committees, proposers and attestation
-	PrevEpochCorrectFlags      [][]bool                     // one aray per flag
-	PrevAttestations           []*phase0.PendingAttestation // array of attestations (currently only for Phase0)
-	NumAttestations            int                          // number of attestations in the epoch
-	NumActiveVals              uint                         // number of active validators in the epoch
-	NumExitedVals              uint                         // number of exited validators in the epoch
-	NumSlashedVals             uint                         // number of slashed validators in the epoch
-	NumQueuedVals              uint                         // number of validators in the queue
-	BlockRoots                 []phase0.Root                // array of block roots at this point (8192)
-	MissedBlocks               []phase0.Slot                // blocks missed in the epoch until this point
-	SyncCommittee              altair.SyncCommittee         // list of pubkeys in the current sync committe
-	Blocks                     []*AgnosticBlock             // list of blocks in the epoch
-	Withdrawals                []phase0.Gwei                // one position per validator
-	WithdrawalsNum             uint64                       // number of withdrawals
-	TotalWithdrawalsAmount     phase0.Gwei                  // total amount of withdrawals
-	Deposits                   []phase0.Gwei                // one per validator index
-	DepositsNum                uint64                       // number of deposits
-	TotalDepositsAmount        phase0.Gwei                  // total amount of deposits
-	CurrentJustifiedCheckpoint phase0.Checkpoint            // the latest justified checkpoint
-	LatestBlockHeader          *phase0.BeaconBlockHeader
-	SyncCommitteeParticipation uint64 // Tracks sync committee participation
-	NewProposerSlashings       int    // number of new proposer slashings
-	NewAttesterSlashings       int    // number of new attester slashings
+	Version                      spec.DataVersion
+	GenesisTimestamp             uint64 // genesis timestamp
+	StateRoot                    phase0.Root
+	Epoch                        phase0.Epoch                 // Epoch of the state
+	Slot                         phase0.Slot                  // Slot of the state
+	Balances                     []phase0.Gwei                // balance of each validator
+	Validators                   []*phase0.Validator          // list of validators
+	TotalActiveBalance           phase0.Gwei                  // effective balance
+	TotalActiveRealBalance       phase0.Gwei                  // real balance
+	AttestingBalance             []phase0.Gwei                // one attesting balance per flag (of the previous epoch attestations)
+	EpochStructs                 EpochDuties                  // structs about beacon committees, proposers and attestation
+	PrevEpochCorrectFlags        [][]bool                     // one aray per flag
+	PrevAttestations             []*phase0.PendingAttestation // array of attestations (currently only for Phase0)
+	ValidatorAttestationIncluded []bool                       // one per validator, if the validator's attestation was included
+	NumAttestations              int                          // number of attestations in the epoch
+	NumActiveVals                uint                         // number of active validators in the epoch
+	NumExitedVals                uint                         // number of exited validators in the epoch
+	NumSlashedVals               uint                         // number of slashed validators in the epoch
+	NumQueuedVals                uint                         // number of validators in the queue
+	BlockRoots                   []phase0.Root                // array of block roots at this point (8192)
+	MissedBlocks                 []phase0.Slot                // blocks missed in the epoch until this point
+	SyncCommittee                altair.SyncCommittee         // list of pubkeys in the current sync committe
+	Blocks                       []*AgnosticBlock             // list of blocks in the epoch
+	Withdrawals                  []phase0.Gwei                // one position per validator
+	WithdrawalsNum               uint64                       // number of withdrawals
+	TotalWithdrawalsAmount       phase0.Gwei                  // total amount of withdrawals
+	Deposits                     []phase0.Gwei                // one per validator index
+	DepositsNum                  uint64                       // number of deposits
+	TotalDepositsAmount          phase0.Gwei                  // total amount of deposits
+	CurrentJustifiedCheckpoint   phase0.Checkpoint            // the latest justified checkpoint
+	LatestBlockHeader            *phase0.BeaconBlockHeader
+	SyncCommitteeParticipation   uint64 // Tracks sync committee participation
+	NewProposerSlashings         int    // number of new proposer slashings
+	NewAttesterSlashings         int    // number of new attester slashings
 }
 
 func GetCustomState(bstate spec.VersionedBeaconState, duties EpochDuties) (AgnosticState, error) {
@@ -73,15 +74,15 @@ func (p *AgnosticState) Setup() error {
 	if p.Validators == nil {
 		return fmt.Errorf("validator list not provided, cannot create")
 	}
-	arrayLen := len(p.Validators)
+	validatorsNum := len(p.Validators)
 	if p.PrevAttestations == nil {
 		p.PrevAttestations = make([]*phase0.PendingAttestation, 0)
 	}
-
+	p.ValidatorAttestationIncluded = make([]bool, validatorsNum)
 	p.AttestingBalance = make([]phase0.Gwei, 3)
 	p.PrevEpochCorrectFlags = make([][]bool, 3) // matrix of 3 x n_validators
 	for i := range p.PrevEpochCorrectFlags {
-		p.PrevEpochCorrectFlags[i] = make([]bool, arrayLen)
+		p.PrevEpochCorrectFlags[i] = make([]bool, validatorsNum)
 	}
 	p.GetValsStateNums()
 	p.TotalActiveBalance = p.GetTotalActiveEffBalance()
@@ -285,6 +286,12 @@ func (p AgnosticState) GetMissingFlagCount(flagIndex int) uint64 {
 }
 
 func (p AgnosticState) GetValStatus(valIdx phase0.ValidatorIndex) ValidatorStatus {
+	// if the validator index is not in the list, return QUEUE_STATUS. Goteth should be designed to avoid this situation
+	// but by the way that the validator rewards are calculated, it is possible that the index is not in the list
+	// since the rewards are calculated based on the next state.
+	if int(valIdx) >= len(p.Validators) {
+		return QUEUE_STATUS
+	}
 
 	if p.Validators[valIdx].Slashed {
 		return SLASHED_STATUS

--- a/pkg/spec/validator_rewards.go
+++ b/pkg/spec/validator_rewards.go
@@ -14,6 +14,7 @@ type ValidatorRewards struct {
 	SyncCommitteeReward  phase0.Gwei
 	BaseReward           phase0.Gwei
 	AttSlot              phase0.Slot
+	AttestationIncluded  bool
 	InSyncCommittee      bool
 	ProposerSlot         phase0.Slot
 	ProposerApiReward    phase0.Gwei
@@ -44,7 +45,11 @@ func (f ValidatorRewards) ToArray() []interface{} {
 		f.SyncCommitteeReward,
 		f.BaseReward,
 		f.AttSlot,
+		f.AttestationIncluded,
 		f.InSyncCommittee,
+		f.ProposerSlot,
+		f.ProposerApiReward,
+		f.ProposerManualReward,
 		f.MissingSource,
 		f.MissingTarget,
 		f.MissingHead,

--- a/pkg/spec/validator_rewards_aggregation.go
+++ b/pkg/spec/validator_rewards_aggregation.go
@@ -14,6 +14,7 @@ type ValidatorRewardsAggregation struct {
 	MaxSyncCommitteeReward phase0.Gwei
 	BaseReward             phase0.Gwei
 	InSyncCommitteeCount   uint16
+	AttestationsIncluded   uint16
 	MissingSourceCount     uint16
 	MissingTargetCount     uint16
 	MissingHeadCount       uint16
@@ -45,6 +46,7 @@ func (f ValidatorRewardsAggregation) ToArray() []interface{} {
 		f.MaxSyncCommitteeReward,
 		f.BaseReward,
 		f.InSyncCommitteeCount,
+		f.AttestationsIncluded,
 		f.MissingSourceCount,
 		f.MissingTargetCount,
 		f.MissingHeadCount,
@@ -63,6 +65,9 @@ func (f *ValidatorRewardsAggregation) Aggregate(valRewards ValidatorRewards) {
 	f.BaseReward += valRewards.BaseReward
 	if valRewards.InSyncCommittee {
 		f.InSyncCommitteeCount++
+	}
+	if valRewards.AttestationIncluded {
+		f.AttestationsIncluded++
 	}
 	if valRewards.MissingSource {
 		f.MissingSourceCount++


### PR DESCRIPTION
# Motivation
For measuring participation rate of validators/entities, we need to track which validators had their attestation included (correct or incorrect).

# Description
Added columns:
- `f_attestation_included` on `t_validator_rewards_summary`
- `f_attestations_included` on `t_validator_rewards_aggregation`
- `count_attestations_included` on `t_pool_summary`


