### PR TITLE
Refactor: Cleanup clientapi transaction module to only fetch data

### DIFF
--- a/pkg/analyzer/metrics_test.go
+++ b/pkg/analyzer/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/migalabs/goteth/pkg/clientapi"
 	"github.com/migalabs/goteth/pkg/db"
 	"github.com/migalabs/goteth/pkg/spec"
@@ -321,12 +322,15 @@ func TestCapellaBlock(t *testing.T) {
 	assert.Equal(t, len(block.ExecutionPayload.Transactions), 222)
 	assert.Equal(t, len(block.ExecutionPayload.Withdrawals), 16)
 
-	transaction, err := blockAnalyzer.cli.RequestTransactionDetails(
-		block.ExecutionPayload.Transactions[0],
-		block.Slot,
-		block.ExecutionPayload.BlockNumber,
-		block.ExecutionPayload.Timestamp,
-	)
+	tx := block.ExecutionPayload.Transactions[0]
+	receipt, err := blockAnalyzer.cli.GetTransactionReceipt(tx, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	var parsedTx = types.Transaction{}
+	if err := parsedTx.UnmarshalBinary(tx); err != nil {
+		t.Errorf("could not unmarshal transaction: %s", err)
+		return
+	}
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)
 		return
@@ -386,12 +390,16 @@ func TestBellatrixBlock(t *testing.T) {
 	assert.Equal(t, len(block.ExecutionPayload.Transactions), 441)
 	assert.Equal(t, len(block.ExecutionPayload.Withdrawals), 0)
 
-	transaction, err := blockAnalyzer.cli.RequestTransactionDetails(
-		block.ExecutionPayload.Transactions[0],
-		block.Slot,
-		block.ExecutionPayload.BlockNumber,
-		block.ExecutionPayload.Timestamp,
-	)
+	tx := block.ExecutionPayload.Transactions[0]
+
+	receipt, err := blockAnalyzer.cli.GetTransactionReceipt(tx, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	var parsedTx = types.Transaction{}
+	if err := parsedTx.UnmarshalBinary(tx); err != nil {
+		t.Errorf("could not unmarshal transaction: %s", err)
+		return
+	}
+
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
 
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)
@@ -535,14 +543,25 @@ func TestTransactionGasWhenELIsProvided(t *testing.T) {
 
 	// Test regular case
 	block, err := blockAnalyzer.cli.RequestBeaconBlock(8020631) //block number 18826815
+	if err != nil {
+		t.Errorf("could not download block: %s", err)
+		return
+	}
 	assert.Equal(t, block.Proposed, true)
 
-	transaction, err := blockAnalyzer.cli.RequestTransactionDetails(
-		block.ExecutionPayload.Transactions[10],
-		block.Slot,
-		block.ExecutionPayload.BlockNumber,
-		block.ExecutionPayload.Timestamp,
-	)
+	tx := block.ExecutionPayload.Transactions[10]
+	receipt, err := blockAnalyzer.cli.GetTransactionReceipt(tx, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	if err != nil {
+		t.Errorf("could not retrieve transaction receipt: %s", err)
+		return
+	}
+	var parsedTx = types.Transaction{}
+	if err := parsedTx.UnmarshalBinary(tx); err != nil {
+		t.Errorf("could not unmarshal transaction: %s", err)
+		return
+	}
+
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
 
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)
@@ -564,14 +583,25 @@ func TestTransactionGasWhenELNotProvided(t *testing.T) {
 
 	// Test regular case
 	block, err := blockAnalyzer.cli.RequestBeaconBlock(8020631) //block number 18826815
+	if err != nil {
+		t.Errorf("could not download block: %s", err)
+		return
+	}
 	assert.Equal(t, block.Proposed, true)
 
-	transaction, err := blockAnalyzer.cli.RequestTransactionDetails(
-		block.ExecutionPayload.Transactions[10],
-		block.Slot,
-		block.ExecutionPayload.BlockNumber,
-		block.ExecutionPayload.Timestamp,
-	)
+	tx := block.ExecutionPayload.Transactions[10]
+	receipt, err := blockAnalyzer.cli.GetTransactionReceipt(tx, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	if err != nil {
+		t.Errorf("could not retrieve transaction receipt: %s", err)
+		return
+	}
+	var parsedTx = types.Transaction{}
+	if err := parsedTx.UnmarshalBinary(tx); err != nil {
+		t.Errorf("could not unmarshal transaction: %s", err)
+		return
+	}
+
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
 
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -123,7 +123,9 @@ func (s *ChainAnalyzer) processTransactions(block *spec.AgnosticBlock, receipts 
 		return err
 	}
 	block.ExecutionPayload.AgnosticTransactions = txs
-
+	if len(txs) == 0 {
+		return nil
+	}
 	err = s.dbClient.PersistTransactions(txs)
 	if err != nil {
 		log.Errorf("error persisting transactions: %s", err.Error())

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/migalabs/goteth/pkg/spec"
 )
 
@@ -27,14 +28,30 @@ func (s *ChainAnalyzer) ProcessBlock(slot phase0.Slot) {
 	s.processWithdrawals(block)
 
 	if s.metrics.Transactions {
-		s.processTransactions(block)
-		s.processBlobSidecars(block, block.ExecutionPayload.AgnosticTransactions)
+		s.ProcessETH1Data(block)
 	}
 	s.processBLSToExecutionChanges(block)
 	s.processDeposits(block)
 	s.processerBook.FreePage(routineKey)
 }
 
+func (s *ChainAnalyzer) ProcessETH1Data(block *spec.AgnosticBlock) {
+	receipts, err := s.cli.GetBlockReceipts(*block)
+	if err != nil {
+		log.Errorf("error getting slot %d receipts: %s", block.Slot, err.Error())
+		return
+	}
+
+	err = s.processTransactions(block, receipts)
+	if err != nil {
+		log.Errorf("error processing transactions: %s", err.Error())
+		return
+	}
+
+	s.processBlobSidecars(block, block.ExecutionPayload.AgnosticTransactions)
+}
+
+// Process consensus layer deposits
 func (s *ChainAnalyzer) processDeposits(block *spec.AgnosticBlock) {
 	if len(block.Deposits) == 0 {
 		return
@@ -98,11 +115,12 @@ func (s *ChainAnalyzer) processWithdrawals(block *spec.AgnosticBlock) {
 
 }
 
-func (s *ChainAnalyzer) processTransactions(block *spec.AgnosticBlock) {
+func (s *ChainAnalyzer) processTransactions(block *spec.AgnosticBlock, receipts []*types.Receipt) error {
 
-	txs, err := s.cli.GetBlockTransactions(*block)
+	txs, err := spec.ParseTransactionsFromBlock(*block, receipts)
 	if err != nil {
 		log.Errorf("error getting slot %d transactions: %s", block.Slot, err.Error())
+		return err
 	}
 	block.ExecutionPayload.AgnosticTransactions = txs
 
@@ -110,7 +128,7 @@ func (s *ChainAnalyzer) processTransactions(block *spec.AgnosticBlock) {
 	if err != nil {
 		log.Errorf("error persisting transactions: %s", err.Error())
 	}
-
+	return err
 }
 
 func (s *ChainAnalyzer) processBlobSidecars(block *spec.AgnosticBlock, txs []spec.AgnosticTransaction) {

--- a/pkg/clientapi/block.go
+++ b/pkg/clientapi/block.go
@@ -86,13 +86,7 @@ func (s *APIClient) RequestBeaconBlock(slot phase0.Slot) (*local_spec.AgnosticBl
 
 		customBlock.Reward = reward
 	}
-	if s.Metrics.Transactions {
-		txs, err := s.GetBlockTransactions(customBlock)
-		if err != nil {
-			log.Errorf("error getting slot %d transactions: %s", customBlock.Slot, err.Error())
-		}
-		customBlock.ExecutionPayload.AgnosticTransactions = txs
-	}
+
 	log.Infof("block at slot %d downloaded in %f seconds", slot, time.Since(startTime).Seconds())
 
 	return &customBlock, nil

--- a/pkg/spec/transactions.go
+++ b/pkg/spec/transactions.go
@@ -1,8 +1,16 @@
 package spec
 
 import (
+	"encoding/hex"
+
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	blobTxType uint8 = 3
 )
 
 // A wrapper for blockchain transaction with basic information retrieved from the Ethereum blockchain
@@ -35,4 +43,97 @@ type AgnosticTransaction struct {
 
 func (txs AgnosticTransaction) Type() ModelType {
 	return TransactionsModel
+}
+
+func ParseTransactionsFromBlock(block AgnosticBlock, receipts []*types.Receipt) ([]AgnosticTransaction, error) {
+	agnosticTxs := make([]AgnosticTransaction, 0)
+	txs := make([]bellatrix.Transaction, len(block.ExecutionPayload.Transactions))
+	copy(txs, block.ExecutionPayload.Transactions)
+
+	// match receipts and transactions
+
+	for _, tx := range txs {
+		var parsedTx = &types.Transaction{}
+		if err := parsedTx.UnmarshalBinary(tx); err != nil {
+			return nil, err
+		}
+		for _, receipt := range receipts {
+			if receipt.TxHash.String() == parsedTx.Hash().String() {
+				// we found a match
+				agnosticTx, err := ParseTransactionFromReceipt(
+					*parsedTx,
+					receipt,
+					block.Slot,
+					block.ExecutionPayload.BlockNumber,
+					block.ExecutionPayload.Timestamp)
+				if err != nil {
+					return nil, err
+				}
+				agnosticTxs = append(agnosticTxs, agnosticTx)
+				break
+			}
+		}
+	}
+	return agnosticTxs, nil
+}
+
+func ParseTransactionFromReceipt(
+	parsedTx types.Transaction,
+	receipt *types.Receipt,
+	slot phase0.Slot,
+	blockNumber uint64,
+	timestamp uint64) (AgnosticTransaction, error) {
+
+	from, err := types.Sender(types.LatestSignerForChainID(parsedTx.ChainId()), &parsedTx)
+	if err != nil {
+		log.Warnf("unable to retrieve sender address from transaction: %s", err)
+		return AgnosticTransaction{}, err
+	}
+
+	gasUsed := parsedTx.Gas()
+	gasPrice := parsedTx.GasPrice().Uint64()
+	contractAddress := common.Address{}
+	blobGasUsed := uint64(0)
+	blobGasPrice := uint64(0)
+	blobGasLimit := uint64(0)
+	blobGasFeeCap := uint64(0)
+
+	if receipt != nil {
+		gasUsed = receipt.GasUsed
+		gasPrice = receipt.EffectiveGasPrice.Uint64()
+		contractAddress = receipt.ContractAddress
+	}
+
+	if parsedTx.Type() == blobTxType {
+		blobGasUsed = receipt.BlobGasUsed
+		blobGasPrice = receipt.BlobGasPrice.Uint64()
+		blobGasLimit = parsedTx.BlobGas()
+		blobGasFeeCap = parsedTx.BlobGasFeeCap().Uint64()
+	}
+
+	return AgnosticTransaction{
+		TxType:          parsedTx.Type(),
+		ChainId:         uint8(parsedTx.ChainId().Uint64()),
+		Data:            hex.EncodeToString(parsedTx.Data()),
+		Gas:             gasUsed,
+		GasPrice:        gasPrice,
+		GasTipCap:       parsedTx.GasTipCap().Uint64(),
+		GasFeeCap:       parsedTx.GasFeeCap().Uint64(),
+		Value:           parsedTx.Value().Uint64(),
+		Nonce:           parsedTx.Nonce(),
+		To:              parsedTx.To(),
+		From:            from,
+		Hash:            phase0.Hash32(parsedTx.Hash()),
+		Size:            parsedTx.Size(),
+		Slot:            slot,
+		BlockNumber:     blockNumber,
+		Timestamp:       timestamp,
+		ContractAddress: contractAddress,
+		BlobGasUsed:     blobGasUsed,
+		BlobGasPrice:    blobGasPrice,
+		BlobGasLimit:    blobGasLimit,
+		BlobGasFeeCap:   blobGasFeeCap,
+		BlobHashes:      parsedTx.BlobHashes(),
+	}, nil
+
 }


### PR DESCRIPTION
# Motivation
The clientapi modules fetch and parse data which. Parsing here is overloading the module as the process should be done on the spec module.
 
# Description
Change fetcher functions to only get the receipts for transactions and parse on the spec module.
