### PR TITLE
validate deposit log entries in processETH1Deposits function

### DIFF
--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -62,7 +62,18 @@ func (s *ChainAnalyzer) processETH1Deposits(block *spec.AgnosticBlock) error {
 	var deposits []spec.ETH1Deposit
 	for _, tx := range block.ExecutionPayload.AgnosticTransactions {
 		for _, logEntry := range tx.Receipt.Logs {
-			if logEntry.Address == s.beaconContractAddress {
+			if logEntry.Address == s.beaconContractAddress { //&& logEntry.Topics[0] == common.HexToHash(spec.DepositEventTopic) {
+				if len(logEntry.Topics) == 0 {
+					log.Warnf("deposit log entry has no topics")
+					continue
+				}
+				if logEntry.Topics[0].String() != spec.DepositEventTopic { // Added because on sepolia deposits have more than one log
+					continue
+				}
+				if len(logEntry.Data) < spec.DepositEventDataLength {
+					log.Warnf("deposit log entry has the incorrect length")
+					continue
+				}
 				deposit := spec.ParseETH1DepositFromLog(logEntry, &tx)
 				deposits = append(deposits, deposit)
 			}

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -7,6 +7,8 @@ const (
 	MainnetBeaconContractAddress = "0x00000000219ab540356cBB839Cbe05303d7705Fa"
 	SepoliaBeaconContractAddress = "0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"
 	HoleskyBeaconContractAddress = "0x4242424242424242424242424242424242424242"
+	DepositEventTopic            = "0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5"
+	DepositEventDataLength       = 576
 )
 
 var BeaconContractAddresses = map[string]string{


### PR DESCRIPTION
# Description
Due to Sepolia having a different deposit contract, the eth1 deposits processing function needs to account for this differences. As a bonus, the function now does checks in order for it to never crash.

Improvements to ETH1 deposit processing:

* [`pkg/analyzer/process_block.go`](diffhunk://#diff-b1d26964cb159e7cd61cf79df8740cf223019616f59717abcd512b55df625132L65-R76): Added checks for the presence and correctness of log entry topics and data length in the `processETH1Deposits` function. This ensures that only valid deposit logs are processed.

Updates to constants:

* [`pkg/spec/constants.go`](diffhunk://#diff-09ba35aa3134bad0b6214cb3baa8bca7882084ac55f26d3675f505cefba73946R10-R11): Introduced new constants `DepositEventTopic` and `DepositEventDataLength` to be used in the ETH1 deposit processing.