### PR TITLE
Feature: add hoodi support and bump version to 3.6.0

### DIFF
--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -7,6 +7,7 @@ const (
 	MainnetBeaconContractAddress = "0x00000000219ab540356cBB839Cbe05303d7705Fa"
 	SepoliaBeaconContractAddress = "0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"
 	HoleskyBeaconContractAddress = "0x4242424242424242424242424242424242424242"
+	HoodiBeaconContractAddress   = MainnetBeaconContractAddress
 	DepositEventTopic            = "0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5"
 	DepositEventDataLength       = 576
 )
@@ -15,6 +16,7 @@ var BeaconContractAddresses = map[string]string{
 	"mainnet": MainnetBeaconContractAddress,
 	"sepolia": SepoliaBeaconContractAddress,
 	"holesky": HoleskyBeaconContractAddress,
+	"hoodi":   HoodiBeaconContractAddress,
 }
 
 /*

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -3,7 +3,7 @@ package utils
 import "time"
 
 const (
-	Version                = "v3.5.0"
+	Version                = "v3.6.0"
 	CliName                = "GotEth"
 	RoutineFlushTimeout    = time.Duration(1 * time.Second)
 	AcquireWaitIntervalLog = 1 * time.Minute


### PR DESCRIPTION
This pull request includes updates to the `pkg/spec/constants.go` and `pkg/utils/constants.go` files to add support for a new hoodi testnet and update the version number to `v3.6.0`.

Support for new network:

* [`pkg/spec/constants.go`](diffhunk://#diff-09ba35aa3134bad0b6214cb3baa8bca7882084ac55f26d3675f505cefba73946R10): Added `HoodiBeaconContractAddress` with the same address as `MainnetBeaconContractAddress` and included it in the `BeaconContractAddresses` map. [[1]](diffhunk://#diff-09ba35aa3134bad0b6214cb3baa8bca7882084ac55f26d3675f505cefba73946R10) [[2]](diffhunk://#diff-09ba35aa3134bad0b6214cb3baa8bca7882084ac55f26d3675f505cefba73946R19)

Version update:

* [`pkg/utils/constants.go`](diffhunk://#diff-4b60b6372744a7df66ef729623f32e667540567365e1319c654b1dd2cfd3d1a2L6-R6): Updated the `Version` constant from `v3.5.0` to `v3.6.0`.