### PR TITLE
Feature: Index Withdrawal Requests

### DIFF
--- a/docs/tables.md
+++ b/docs/tables.md
@@ -1,7 +1,7 @@
 # Block Metrics | Orphans (`t_block_metrics`, `t_orphans`)
 
-| Column Name                  | Type of Data | Description                                            |     |     |
-| ---------------------------- | ------------ | ------------------------------------------------------ | --- | --- |
+| Column Name                  | Type of Data | Description                                            |
+| ---------------------------- | ------------ | ------------------------------------------------------ |
 | f_timestamp                  | uint64       | unix time of the slot                                  |
 | f_epoch                      | uint64       | epoch number                                           |
 | f_slot                       | uint64       | slot number                                            |
@@ -11,6 +11,7 @@
 | f_attestations               | uint64       | number of attestations included in the block           |
 | f_deposits                   | uint64       | number of deposits included in the block               |
 | f_consolidation_requests_num | uint64       | number of consolidation requests included in the block |
+| f_withdrawal_requests_num    | uint64       | number of withdrawal requests included in the block    |
 | f_proposer_slashings         | uint64       | number of proposer slashings included in the block     |
 | f_attester_slashings         | uint64       | number of attester slashings included in the block     |
 | f_voluntary_exits            | uint64       | number of voluntary exits included in the block        |
@@ -30,8 +31,8 @@
 
 # Epoch Metrics (`t_epoch_metrics_summary`)
 
-| Column Name                        | Type of Data | Description                                                                                                            |     |     |
-| ---------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- | --- | --- |
+| Column Name                        | Type of Data | Description                                                                                                            |
+| ---------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
 | f_epoch                            | uint64       | epoch number                                                                                                           |
 | f_slot                             | uint64       | slot number                                                                                                            |
 | f_num_att                          | uint64       | number of attestations included in blocks in the epoch                                                                 |
@@ -59,6 +60,7 @@
 | f_new_proposer_slashings           | uint64       | amount of new [valid](https://github.com/migalabs/goteth/pull/146) proposer slashings included in the epoch            |
 | f_new_attester_slashings           | uint64       | amount of new [valid](https://github.com/migalabs/goteth/pull/146) attester slashings included in the epoch            |
 | f_consolidation_requests_num       | uint64       | number of consolidation requests included in the epoch                                                                 |
+| f_withdrawal_requests_num          | uint64       | number of withdrawal requests included in the epoch                                                                    |
 | f_consolidations_processed_num     | uint64       | number of consolidations processed in the epoch                                                                        |
 | f_consolidations_processed_amount  | uint64       | total amount of ETH consolidated in the epoch (Gwei)                                                                   |
 
@@ -373,19 +375,6 @@ Table that stores the data of consolidation requests in the network.
 - `34`: **TgtNotActive** - Target validator is not active.
 - `35`: **TgtExitAlreadyInitiated** - Target validator has already initiated an exit.
 
-# Consolidations Processed (`t_consolidations_processed`)
-
-Table that stores the data of processed consolidations in the network.
-
-| Column Name           | Type of Data | Description                                                 |
-| --------------------- | ------------ | ----------------------------------------------------------- |
-| f_epoch               | uint64       | Epoch at which the consolidation was processed              |
-| f_index               | uint64       | Index of the consolidation within the epoch                 |
-| f_source_index        | uint64       | Index of the source validator involved in the consolidation |
-| f_target_index        | uint64       | Index of the target validator involved in the consolidation |
-| f_consolidated_amount | uint64       | Amount of ETH consolidated (Gwei)                           |
-| f_valid               | bool         | Whether the consolidation was valid (default is `true`)     |
-
 # Withdrawal Requests (`t_withdrawal_requests`)
 
 Table that stores the data of withdrawal requests in the network.
@@ -418,3 +407,16 @@ Table that stores the data of withdrawal requests in the network.
 - `9`: **InsufficientBalance** - The validator has insufficient balance for the withdrawal.
 - `10`: **ValidatorNotCompounding** - The validator is not compounding.
 - `11`: **NoExcessBalance** - The validator has no excess balance to withdraw.
+
+# Consolidations Processed (`t_consolidations_processed`)
+
+Table that stores the data of processed consolidations in the network.
+
+| Column Name           | Type of Data | Description                                                 |
+| --------------------- | ------------ | ----------------------------------------------------------- |
+| f_epoch               | uint64       | Epoch at which the consolidation was processed              |
+| f_index               | uint64       | Index of the consolidation within the epoch                 |
+| f_source_index        | uint64       | Index of the source validator involved in the consolidation |
+| f_target_index        | uint64       | Index of the target validator involved in the consolidation |
+| f_consolidated_amount | uint64       | Amount of ETH consolidated (Gwei)                           |
+| f_valid               | bool         | Whether the consolidation was valid (default is `true`)     |

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -385,3 +385,36 @@ Table that stores the data of processed consolidations in the network.
 | f_target_index        | uint64       | Index of the target validator involved in the consolidation |
 | f_consolidated_amount | uint64       | Amount of ETH consolidated (Gwei)                           |
 | f_valid               | bool         | Whether the consolidation was valid (default is `true`)     |
+
+# Withdrawal Requests (`t_withdrawal_requests`)
+
+Table that stores the data of withdrawal requests in the network.
+
+| Column Name        | Type of Data | Description                                                        |
+| ------------------ | ------------ | ------------------------------------------------------------------ |
+| f_slot             | uint64       | Slot at which the withdrawal request was made                      |
+| f_index            | uint64       | Index of the withdrawal request within the slot                    |
+| f_source_address   | string       | Address of the source from which the withdrawal request originated |
+| f_validator_pubkey | string       | Public key of the validator involved in the withdrawal request     |
+| f_amount           | uint64       | Amount of ETH requested for withdrawal (Gwei)                      |
+| f_result           | uint8        | Result of the withdrawal request (see reference below)             |
+
+## Reference for `f_result`
+
+### General Results
+
+- `0`: **Unknown** - Withdrawal request result is unknown.
+- `1`: **Success** - Withdrawal request was successful.
+
+### Errors
+
+- `2`: **QueueFull** - The withdrawal request queue is full.
+- `3`: **ValidatorNotFound** - The validator associated with the request was not found.
+- `4`: **InvalidCredentials** - The validator has invalid credentials.
+- `5`: **ValidatorNotActive** - The validator is not active.
+- `6`: **ExitAlreadyInitiated** - The validator has already initiated an exit.
+- `7`: **ValidatorNotOldEnough** - The validator is not old enough.
+- `8`: **PendingWithdrawalExists** - A pending withdrawal already exists for the validator.
+- `9`: **InsufficientBalance** - The validator has insufficient balance for the withdrawal.
+- `10`: **ValidatorNotCompounding** - The validator is not compounding.
+- `11`: **NoExcessBalance** - The validator has no excess balance to withdraw.

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -60,6 +60,7 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 		}
 		s.processSlashings(bundle)
 		s.storeConsolidationRequests(bundle)
+		s.storeWithdrawalRequests(bundle)
 		s.storeConsoidationsProcessed(bundle)
 	}
 
@@ -86,6 +87,17 @@ func (s *ChainAnalyzer) storeConsoidationsProcessed(bundle metrics.StateMetrics)
 	err := s.dbClient.PersistConsolidationsProcessed(consolidationsProcessed)
 	if err != nil {
 		log.Errorf("error persisting consolidationsProcessed: %s", err.Error())
+	}
+}
+
+func (s *ChainAnalyzer) storeWithdrawalRequests(bundle metrics.StateMetrics) {
+	withdrawalRequests := bundle.GetMetricsBase().NextState.WithdrawalRequests
+	if len(withdrawalRequests) == 0 {
+		return
+	}
+	err := s.dbClient.PersistWithdrawalRequests(withdrawalRequests)
+	if err != nil {
+		log.Errorf("error persisting withdrawal requests: %s", err.Error())
 	}
 }
 

--- a/pkg/db/block_metrics.go
+++ b/pkg/db/block_metrics.go
@@ -23,6 +23,7 @@ var (
 		f_attestations,
 		f_deposits,
 		f_consolidation_requests_num,
+		f_withdrawal_requests_num,
 		f_proposer_slashings,
 		f_attester_slashings,
 		f_voluntary_exits,
@@ -64,6 +65,7 @@ func blocksInput(blocks []spec.AgnosticBlock) proto.Input {
 		f_attestations               proto.ColUInt64
 		f_deposits                   proto.ColUInt64
 		f_consolidation_requests_num proto.ColUInt64
+		f_withdrawal_requests_num    proto.ColUInt64
 		f_proposer_slashings         proto.ColUInt64
 		f_attester_slashings         proto.ColUInt64
 		f_voluntary_exits            proto.ColUInt64
@@ -102,8 +104,10 @@ func blocksInput(blocks []spec.AgnosticBlock) proto.Input {
 
 		if block.ExecutionRequests != nil {
 			f_consolidation_requests_num.Append(uint64(len(block.ExecutionRequests.Consolidations)))
+			f_withdrawal_requests_num.Append(uint64(len(block.ExecutionRequests.Withdrawals)))
 		} else {
 			f_consolidation_requests_num.Append(uint64(0))
+			f_withdrawal_requests_num.Append(uint64(0))
 		}
 
 		f_proposer_slashings.Append(uint64(len(block.ProposerSlashings)))
@@ -139,6 +143,7 @@ func blocksInput(blocks []spec.AgnosticBlock) proto.Input {
 		{Name: "f_attestations", Data: f_attestations},
 		{Name: "f_deposits", Data: f_deposits},
 		{Name: "f_consolidation_requests_num", Data: f_consolidation_requests_num},
+		{Name: "f_withdrawal_requests_num", Data: f_withdrawal_requests_num},
 		{Name: "f_proposer_slashings", Data: f_proposer_slashings},
 		{Name: "f_attester_slashings", Data: f_attester_slashings},
 		{Name: "f_voluntary_exits", Data: f_voluntary_exits},

--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -39,6 +39,7 @@ var (
 		f_new_proposer_slashings,
 		f_new_attester_slashings,
 		f_consolidation_requests_num,
+		f_withdrawal_requests_num,
 		f_consolidations_processed_num,
 		f_consolidations_processed_amount	
 		)
@@ -86,6 +87,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		f_new_proposer_slashings           proto.ColUInt64
 		f_new_attester_slashings           proto.ColUInt64
 		f_consolidation_requests_num       proto.ColUInt64
+		f_withdrawal_requests_num          proto.ColUInt64
 		f_consolidations_processed_num     proto.ColUInt64
 		f_consolidations_processed_amount  proto.ColUInt64
 	)
@@ -118,6 +120,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		f_new_proposer_slashings.Append(uint64(epoch.NewProposerSlashings))
 		f_new_attester_slashings.Append(uint64(epoch.NewAttesterSlashings))
 		f_consolidation_requests_num.Append(uint64(epoch.ConsolidationRequestsNum))
+		f_withdrawal_requests_num.Append(uint64(epoch.WithdrawalRequestsNum))
 		f_consolidations_processed_num.Append(epoch.ConsolidationsProcessedNum)
 		f_consolidations_processed_amount.Append(uint64(epoch.ConsolidationsProcessedAmount))
 	}
@@ -151,6 +154,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		{Name: "f_new_attester_slashings", Data: f_new_attester_slashings},
 		{Name: "f_consolidation_requests_num", Data: f_consolidation_requests_num},
 		{Name: "f_consolidations_processed_num", Data: f_consolidations_processed_num},
+		{Name: "f_withdrawal_requests_num", Data: f_withdrawal_requests_num},
 		{Name: "f_consolidations_processed_amount", Data: f_consolidations_processed_amount},
 	}
 }

--- a/pkg/db/migrations/000025_create_withdrawal_requests_table.down.sql
+++ b/pkg/db/migrations/000025_create_withdrawal_requests_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS t_withdrawal_requests;

--- a/pkg/db/migrations/000025_create_withdrawal_requests_table.up.sql
+++ b/pkg/db/migrations/000025_create_withdrawal_requests_table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE t_withdrawal_requests
+(
+    f_slot UInt64,
+    f_index UInt64,
+    f_source_address TEXT,
+    f_validator_pubkey TEXT,
+    f_amount UInt64,
+    f_result UInt8
+)
+ENGINE = ReplacingMergeTree()
+ORDER BY (f_slot, f_index);

--- a/pkg/db/migrations/000026_add_withdrawal_requests_num.down.sql
+++ b/pkg/db/migrations/000026_add_withdrawal_requests_num.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_withdrawal_requests_num;
+
+ALTER TABLE t_block_metrics DROP COLUMN f_withdrawal_requests_num;

--- a/pkg/db/migrations/000026_add_withdrawal_requests_num.up.sql
+++ b/pkg/db/migrations/000026_add_withdrawal_requests_num.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_epoch_metrics_summary ADD COLUMN f_withdrawal_requests_num UInt64 AFTER f_consolidation_requests_num;
+
+ALTER TABLE t_block_metrics ADD COLUMN f_withdrawal_requests_num UInt64 AFTER f_consolidation_requests_num;

--- a/pkg/db/prometheus_metrics.go
+++ b/pkg/db/prometheus_metrics.go
@@ -98,6 +98,7 @@ func (r *DBService) initMonitorMetrics() {
 		eth1DepositsTable,
 		consolidationRequestsTable,
 		consolidationsProcessedTable,
+		withdrawalRequestsTable,
 	}
 
 	for _, tableName := range tablesArr {

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -152,7 +152,8 @@ type PersistableObject[
 		spec.Deposit |
 		spec.ETH1Deposit |
 		spec.ConsolidationRequest |
-		spec.ConsolidationProcessed] struct {
+		spec.ConsolidationProcessed |
+		spec.WithdrawalRequest] struct {
 	table string
 	query string
 	data  []T

--- a/pkg/db/withdrawal_requests.go
+++ b/pkg/db/withdrawal_requests.go
@@ -1,0 +1,69 @@
+package db
+
+import (
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+var (
+	withdrawalRequestsTable      = "t_withdrawal_requests"
+	insertWithdrawalRequestQuery = `
+	INSERT INTO %s (
+		f_slot,
+		f_index,
+		f_source_address,
+		f_validator_pubkey,
+		f_amount,
+		f_result
+		)
+		VALUES`
+)
+
+func withdrawalRequestsInput(withdrawalRequests []spec.WithdrawalRequest) proto.Input {
+	// one object per column
+	var (
+		f_slot             proto.ColUInt64
+		f_index            proto.ColUInt64
+		f_source_address   proto.ColStr
+		f_validator_pubkey proto.ColStr
+		f_amount           proto.ColUInt64
+		f_result           proto.ColUInt8
+	)
+
+	for _, withdrawalRequest := range withdrawalRequests {
+
+		f_slot.Append(uint64(withdrawalRequest.Slot))
+		f_index.Append(withdrawalRequest.Index)
+		f_source_address.Append(withdrawalRequest.SourceAddress.String())
+		f_validator_pubkey.Append(withdrawalRequest.ValidatorPubkey.String())
+		f_amount.Append(uint64(withdrawalRequest.Amount))
+		f_result.Append(uint8(withdrawalRequest.Result))
+	}
+
+	return proto.Input{
+		{Name: "f_slot", Data: f_slot},
+		{Name: "f_index", Data: f_index},
+		{Name: "f_source_address", Data: f_source_address},
+		{Name: "f_validator_pubkey", Data: f_validator_pubkey},
+		{Name: "f_amount", Data: f_amount},
+		{Name: "f_result", Data: f_result},
+	}
+}
+
+func (p *DBService) PersistWithdrawalRequests(data []spec.WithdrawalRequest) error {
+	persistObj := PersistableObject[spec.WithdrawalRequest]{
+		input: withdrawalRequestsInput,
+		table: withdrawalRequestsTable,
+		query: insertWithdrawalRequestQuery,
+	}
+
+	for _, item := range data {
+		persistObj.Append(item)
+	}
+
+	err := p.Persist(persistObj.ExportPersist())
+	if err != nil {
+		log.Errorf("error persisting withdrawalRequests: %s", err.Error())
+	}
+	return err
+}

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -69,12 +69,16 @@ const (
 	CompoundingWithdrawalPrefix = 0x02
 
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#state-list-lengths
-	PendingConsolidationsLimit uint64 = 1 << 18
+	PendingConsolidationsLimit     uint64 = 1 << 18
+	PendingPartialWithdrawalsLimit uint64 = 1 << 27 // uint64(2**27) (= 134,217,728)
 
 	MinPerEpochChurnLimitElectra               uint64 = 128000000000 // Gwei(2**7 * 10**9)
 	MaxPerEpochActivationExitChurnLimitElectra uint64 = 256000000000 // Gwei(2**8 * 10**9)
 
 	MinActivationBalance uint64 = 32000000000 // Gwei(2**5 * 10**9)
+
+	// https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#misc
+	FullExitRequestAmount uint64 = 0
 )
 
 var (
@@ -108,6 +112,7 @@ const (
 	DepositModel
 	ETH1DepositModel
 	ConsolidationRequestModel
+	WithdrawalRequestModel
 )
 
 type ValidatorStatus int8

--- a/pkg/spec/epoch.go
+++ b/pkg/spec/epoch.go
@@ -32,6 +32,7 @@ type Epoch struct {
 	NewProposerSlashings          int
 	NewAttesterSlashings          int
 	ConsolidationRequestsNum      int
+	WithdrawalRequestsNum         int
 	ConsolidationsProcessedNum    uint64
 	ConsolidationsProcessedAmount phase0.Gwei
 }

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -106,6 +106,7 @@ func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
 		NewProposerSlashings:          int(s.CurrentState.NewProposerSlashings),
 		NewAttesterSlashings:          int(s.CurrentState.NewAttesterSlashings),
 		ConsolidationRequestsNum:      int(len(s.CurrentState.ConsolidationRequests)),
+		WithdrawalRequestsNum:         int(len(s.CurrentState.WithdrawalRequests)),
 		ConsolidationsProcessedNum:    uint64(len(s.CurrentState.ConsolidationsProcessed)),
 		ConsolidationsProcessedAmount: s.CurrentState.ConsolidationsProcessedAmount,
 	}

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -223,7 +223,7 @@ func (p ElectraMetrics) processConsolidationRequest(consolidationRequest *electr
 	}
 
 	// Verify exits for source and target have not been initiated
-	alreadyConsolidated := slices.Contains(currentState.ConsolidatedValidators, sourceValidatorIndex)
+	alreadyConsolidated := slices.Contains(currentState.NewExitingValidators, sourceValidatorIndex)
 	if sourceValidator.ExitEpoch != phase0.Epoch(spec.FarFutureEpoch) || alreadyConsolidated {
 		return spec.ConsolidationRequestResultSrcExitAlreadyInitiated
 	}
@@ -242,7 +242,7 @@ func (p ElectraMetrics) processConsolidationRequest(consolidationRequest *electr
 		return spec.ConsolidationRequestResultSrcHasPendingWithdrawal
 	}
 
-	currentState.ConsolidatedValidators = append(currentState.ConsolidatedValidators, sourceValidatorIndex)
+	currentState.NewExitingValidators = append(currentState.NewExitingValidators, sourceValidatorIndex)
 	return spec.ConsolidationRequestResultSuccess
 }
 

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -243,6 +243,7 @@ func (p ElectraMetrics) processConsolidationRequest(consolidationRequest *electr
 	}
 
 	currentState.NewExitingValidators = append(currentState.NewExitingValidators, sourceValidatorIndex)
+	currentState.PendingConsolidations = append(currentState.PendingConsolidations, &electra.PendingConsolidation{}) // Wont be processed, just used to check the queue limit
 	return spec.ConsolidationRequestResultSuccess
 }
 
@@ -345,7 +346,10 @@ func (p ElectraMetrics) processWithdrawalRequest(withdrawalRequest *electra.With
 	if !hasExcessBalance {
 		return spec.WithdrawalRequestResultNoExcessBalance
 	}
-
+	state.PendingPartialWithdrawals = append(state.PendingPartialWithdrawals, &electra.PendingPartialWithdrawal{
+		ValidatorIndex: validatorIndex,
+		Amount:         amount,
+	}) // Wont be processed, just used to check the queue limit
 	return spec.WithdrawalRequestResultSuccess
 }
 

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -243,7 +243,7 @@ func (p ElectraMetrics) processConsolidationRequest(consolidationRequest *electr
 	}
 
 	currentState.NewExitingValidators = append(currentState.NewExitingValidators, sourceValidatorIndex)
-	currentState.PendingConsolidations = append(currentState.PendingConsolidations, &electra.PendingConsolidation{}) // Wont be processed, just used to check the queue limit
+	currentState.PendingConsolidations = append(currentState.PendingConsolidations, &electra.PendingConsolidation{}) // Won't be processed, just used to check the queue limit
 	return spec.ConsolidationRequestResultSuccess
 }
 
@@ -349,7 +349,7 @@ func (p ElectraMetrics) processWithdrawalRequest(withdrawalRequest *electra.With
 	state.PendingPartialWithdrawals = append(state.PendingPartialWithdrawals, &electra.PendingPartialWithdrawal{
 		ValidatorIndex: validatorIndex,
 		Amount:         amount,
-	}) // Wont be processed, just used to check the queue limit
+	}) // Won't be processed, just used to check the queue limit
 	return spec.WithdrawalRequestResultSuccess
 }
 

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -307,7 +307,8 @@ func (p ElectraMetrics) processWithdrawalRequest(withdrawalRequest *electra.With
 	}
 
 	// Verify exit has not been initiated
-	if validator.ExitEpoch != phase0.Epoch(spec.FarFutureEpoch) {
+	alreadyExiting := slices.Contains(state.NewExitingValidators, validatorIndex)
+	if validator.ExitEpoch != phase0.Epoch(spec.FarFutureEpoch) || alreadyExiting {
 		return spec.WithdrawalRequestResultExitAlreadyInitiated
 	}
 
@@ -322,6 +323,7 @@ func (p ElectraMetrics) processWithdrawalRequest(withdrawalRequest *electra.With
 	if isFullExitRequest {
 		// Only exit validator if it has no pending withdrawals in the queue
 		if pendingBalanceToWithdraw == 0 {
+			state.NewExitingValidators = append(state.NewExitingValidators, validatorIndex)
 			return spec.WithdrawalRequestResultSuccess
 		}
 		return spec.WithdrawalRequestResultPendingWithdrawalExists

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -50,6 +50,7 @@ type AgnosticState struct {
 	Slashings                    []AgnosticSlashing
 	// Electra
 	ConsolidationRequests         []ConsolidationRequest
+	WithdrawalRequests            []WithdrawalRequest
 	PendingConsolidations         []*electra.PendingConsolidation
 	PendingPartialWithdrawals     []*electra.PendingPartialWithdrawal
 	ConsolidationsProcessed       []ConsolidationProcessed

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -55,7 +55,7 @@ type AgnosticState struct {
 	PendingPartialWithdrawals     []*electra.PendingPartialWithdrawal
 	ConsolidationsProcessed       []ConsolidationProcessed
 	ConsolidationsProcessedAmount phase0.Gwei             // total amount of Gwei consolidated
-	ConsolidatedValidators        []phase0.ValidatorIndex // list of validators that have been consolidated, used for tracking errors of a validator trying to consolidate twice on same epoch.
+	NewExitingValidators          []phase0.ValidatorIndex // list of validators that are exiting due to consolidation/withdrawal requests, used for tracking errors of a validator trying to consolidate/withdraw twice on same epoch.
 }
 
 func GetCustomState(bstate spec.VersionedBeaconState, duties EpochDuties) (AgnosticState, error) {
@@ -103,7 +103,7 @@ func (p *AgnosticState) Setup() error {
 	p.Slashings = make([]AgnosticSlashing, 0)
 	p.ConsolidationRequests = make([]ConsolidationRequest, 0)
 	p.ConsolidationsProcessed = make([]ConsolidationProcessed, 0)
-	p.ConsolidatedValidators = make([]phase0.ValidatorIndex, 0)
+	p.NewExitingValidators = make([]phase0.ValidatorIndex, 0)
 	return nil
 }
 

--- a/pkg/spec/withdrawal_request.go
+++ b/pkg/spec/withdrawal_request.go
@@ -1,0 +1,47 @@
+package spec
+
+import (
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+type WithdrawalRequestResult uint8
+
+const (
+	WithdrawalRequestResultSuccess WithdrawalRequestResult = iota
+	WithdrawalRequestResultQueueFull
+	WithdrawalRequestResultValidatorNotFound
+	WithdrawalRequestResultInvalidCredentials
+	WithdrawalRequestResultValidatorNotActive
+	WithdrawalRequestResultExitAlreadyInitiated
+	WithdrawalRequestResultValidatorNotOldEnough
+	WithdrawalRequestResultPendingWithdrawalExists
+	WithdrawalRequestResultInsufficientBalance
+	WithdrawalRequestResultValidatorNotCompounding
+	WithdrawalRequestResultNoExcessBalance
+)
+
+type WithdrawalRequest struct {
+	Slot            phase0.Slot
+	Index           uint64
+	SourceAddress   bellatrix.ExecutionAddress
+	ValidatorPubkey phase0.BLSPubKey
+	Amount          phase0.Gwei
+	Result          WithdrawalRequestResult
+}
+
+func (f WithdrawalRequest) Type() ModelType {
+	return WithdrawalRequestModel
+}
+
+func (f WithdrawalRequest) ToArray() []interface{} {
+	rows := []interface{}{
+		f.Slot,
+		f.Index,
+		f.SourceAddress,
+		f.ValidatorPubkey,
+		f.Amount,
+		f.Result,
+	}
+	return rows
+}

--- a/pkg/spec/withdrawal_request.go
+++ b/pkg/spec/withdrawal_request.go
@@ -8,7 +8,8 @@ import (
 type WithdrawalRequestResult uint8
 
 const (
-	WithdrawalRequestResultSuccess WithdrawalRequestResult = iota
+	WithdrawalRequestResultUnknown WithdrawalRequestResult = iota
+	WithdrawalRequestResultSuccess
 	WithdrawalRequestResultQueueFull
 	WithdrawalRequestResultValidatorNotFound
 	WithdrawalRequestResultInvalidCredentials


### PR DESCRIPTION
This pull request introduces the handling of withdrawal requests in the network, including changes to the database schema, metrics processing, and state transitions. The most important changes are summarized below:

### Database Schema Changes:
* Added a new table `t_withdrawal_requests` to store withdrawal request data.
* Updated the `t_epoch_metrics_summary` and `t_block_metrics` tables to include the `f_withdrawal_requests_num` column. [[1]](diffhunk://#diff-18d854f51f11c4089694beb70608e6c660172a36fe10af6cc6715014ddc34d41R1-R3) [[2]](diffhunk://#diff-a4c2e892236e4cc87c609f2e7fd0ef6d54e3ee56d8ed6cbea150d5ef7a5cb09fR1-R3)

### Metrics Processing:
* Added processing of withdrawal requests in the `ProcessStateTransitionMetrics` and `PreProcessBundle` functions. [[1]](diffhunk://#diff-80aba09372cdd70ad72ec1a3a28c1b8efce92f06618ef1353be849691f1452d1R63) [[2]](diffhunk://#diff-878a5cec5781d8ba1bf3f7f40afbb90c836542610bd64b594cd76b3175cb59c6R52)
* Implemented the `storeWithdrawalRequests` function to persist withdrawal requests.

### State and Constants Updates:
* Added `WithdrawalRequestsNum` to the `Epoch` struct and updated related functions to handle this new field. [[1]](diffhunk://#diff-6f34ab8667d8e673a32a5e676cc944bbdd273c335fbc43a3fe37e6754eb4d42cR35) [[2]](diffhunk://#diff-1df45a52cbb23eb2dba24bed87f0af8076b7a9e58e3793980c9d47088cd34c41R109)
* Introduced new constants for withdrawal request limits. [[1]](diffhunk://#diff-09ba35aa3134bad0b6214cb3baa8bca7882084ac55f26d3675f505cefba73946R73-R81) [[2]](diffhunk://#diff-09ba35aa3134bad0b6214cb3baa8bca7882084ac55f26d3675f505cefba73946R115)

### Additional Changes:
* Updated the `docs/tables.md` file to document the new `t_withdrawal_requests` table and its columns.
* Ensured the `PersistWithdrawalRequests` method is available for persisting withdrawal requests.