### PR TITLE
Feature/add columns tracking consolidated validators

### DIFF
--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -176,15 +176,16 @@ func (s *ChainAnalyzer) processValLastStatus(bundle metrics.StateMetrics) {
 		for valIdx, validator := range bundle.GetMetricsBase().NextState.Validators {
 
 			newVal := spec.ValidatorLastStatus{
-				ValIdx:          phase0.ValidatorIndex(valIdx),
-				Epoch:           bundle.GetMetricsBase().NextState.Epoch,
-				CurrentBalance:  bundle.GetMetricsBase().NextState.Balances[valIdx],
-				CurrentStatus:   bundle.GetMetricsBase().NextState.GetValStatus(phase0.ValidatorIndex(valIdx)),
-				Slashed:         validator.Slashed,
-				ActivationEpoch: validator.ActivationEpoch,
-				WithdrawalEpoch: validator.WithdrawableEpoch,
-				ExitEpoch:       validator.ExitEpoch,
-				PublicKey:       validator.PublicKey,
+				ValIdx:                phase0.ValidatorIndex(valIdx),
+				Epoch:                 bundle.GetMetricsBase().NextState.Epoch,
+				CurrentBalance:        bundle.GetMetricsBase().NextState.Balances[valIdx],
+				CurrentStatus:         bundle.GetMetricsBase().NextState.GetValStatus(phase0.ValidatorIndex(valIdx)),
+				Slashed:               validator.Slashed,
+				ActivationEpoch:       validator.ActivationEpoch,
+				WithdrawalEpoch:       validator.WithdrawableEpoch,
+				ExitEpoch:             validator.ExitEpoch,
+				PublicKey:             validator.PublicKey,
+				WithdrawalCredentials: validator.WithdrawalCredentials,
 			}
 			valStatusArr = append(valStatusArr, newVal)
 		}

--- a/pkg/db/epoch_metrics.go
+++ b/pkg/db/epoch_metrics.go
@@ -17,6 +17,7 @@ var (
 		f_num_att,
 		f_num_att_vals,
 		f_num_vals,
+		f_num_compounding_vals,
 		f_total_balance_eth,
 		f_att_effective_balance_eth,
 		f_source_att_effective_balance_eth,
@@ -65,6 +66,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		f_num_att                          proto.ColUInt64
 		f_num_att_vals                     proto.ColUInt64
 		f_num_vals                         proto.ColUInt64
+		f_num_compounding_vals             proto.ColUInt64
 		f_total_balance_eth                proto.ColFloat32
 		f_att_effective_balance_eth        proto.ColUInt64
 		f_source_att_effective_balance_eth proto.ColUInt64
@@ -98,6 +100,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		f_num_att.Append(uint64(epoch.NumAttestations))
 		f_num_att_vals.Append(uint64(epoch.NumAttValidators))
 		f_num_vals.Append(uint64(epoch.NumValidators))
+		f_num_compounding_vals.Append(epoch.NumCompoundingVals)
 		f_total_balance_eth.Append(float32(epoch.TotalBalance))
 		f_att_effective_balance_eth.Append(uint64(epoch.AttEffectiveBalance))
 		f_source_att_effective_balance_eth.Append(uint64(epoch.SourceAttEffectiveBalance))
@@ -131,6 +134,7 @@ func epochsInput(epochs []spec.Epoch) proto.Input {
 		{Name: "f_num_att", Data: f_num_att},
 		{Name: "f_num_att_vals", Data: f_num_att_vals},
 		{Name: "f_num_vals", Data: f_num_vals},
+		{Name: "f_num_compounding_vals", Data: f_num_compounding_vals},
 		{Name: "f_total_balance_eth", Data: f_total_balance_eth},
 		{Name: "f_att_effective_balance_eth", Data: f_att_effective_balance_eth},
 		{Name: "f_source_att_effective_balance_eth", Data: f_source_att_effective_balance_eth},

--- a/pkg/db/migrations/000027_add_columns_tracking_consolidated_vals.down.sql
+++ b/pkg/db/migrations/000027_add_columns_tracking_consolidated_vals.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE t_epoch_metrics_summary DROP COLUMN f_num_compounding_vals;
+
+ALTER TABLE t_pool_summary DROP COLUMN number_compounding_vals;
+
+ALTER TABLE t_validator_rewards_summary DROP COLUMN f_withdrawal_prefix;
+
+ALTER TABLE t_validator_last_status DROP COLUMN f_withdrawal_prefix;
+ALTER TABLE t_validator_last_status DROP COLUMN f_withdrawal_credentials;

--- a/pkg/db/migrations/000027_add_columns_tracking_consolidated_vals.up.sql
+++ b/pkg/db/migrations/000027_add_columns_tracking_consolidated_vals.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE t_epoch_metrics_summary ADD COLUMN f_num_compounding_vals UInt64 AFTER f_num_vals;
+
+ALTER TABLE t_pool_summary ADD COLUMN number_compounding_vals UInt64 AFTER number_active_vals;
+
+ALTER TABLE t_validator_rewards_summary ADD COLUMN f_withdrawal_prefix UInt8 AFTER f_balance_eth;
+
+ALTER TABLE t_validator_last_status ADD COLUMN f_withdrawal_prefix UInt8;
+ALTER TABLE t_validator_last_status ADD COLUMN f_withdrawal_credentials TEXT;

--- a/pkg/db/pools_summary.go
+++ b/pkg/db/pools_summary.go
@@ -25,6 +25,7 @@ var (
 				SUM(CASE WHEN t_proposer_duties.f_proposed = TRUE THEN 1 ELSE 0 END) as proposed_blocks_performance,
 				SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE and t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx THEN 1 ELSE 0 END) as missed_blocks_performance,
 				count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals,
+				count(CASE WHEN f_withdrawal_prefix = 2 THEN 1 ELSE null END) as number_compounding_vals,
 				AVG(f_inclusion_delay) as avg_inclusion_delay
 			FROM t_validator_rewards_summary
 			LEFT JOIN t_eth2_pubkeys 

--- a/pkg/db/validator_last_status.go
+++ b/pkg/db/validator_last_status.go
@@ -18,7 +18,9 @@ var (
 		f_activation_epoch,
 		f_withdrawal_epoch,
 		f_exit_epoch,
-		f_public_key)
+		f_public_key,
+		f_withdrawal_prefix,
+		f_withdrawal_credentials)
 	VALUES`
 
 	deleteValidatorStatus = `
@@ -29,15 +31,17 @@ var (
 func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 	// one object per column
 	var (
-		f_val_idx          proto.ColUInt64
-		f_epoch            proto.ColUInt64
-		f_balance_eth      proto.ColFloat32
-		f_status           proto.ColUInt8
-		f_slashed          proto.ColBool
-		f_activation_epoch proto.ColUInt64
-		f_withdrawal_epoch proto.ColUInt64
-		f_exit_epoch       proto.ColUInt64
-		f_public_key       proto.ColStr
+		f_val_idx                proto.ColUInt64
+		f_epoch                  proto.ColUInt64
+		f_balance_eth            proto.ColFloat32
+		f_status                 proto.ColUInt8
+		f_slashed                proto.ColBool
+		f_activation_epoch       proto.ColUInt64
+		f_withdrawal_epoch       proto.ColUInt64
+		f_exit_epoch             proto.ColUInt64
+		f_public_key             proto.ColStr
+		f_withdrawal_prefix      proto.ColUInt8
+		f_withdrawal_credentials proto.ColStr
 	)
 
 	for _, status := range validatorStatuses {
@@ -51,6 +55,8 @@ func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 		f_withdrawal_epoch.Append(uint64(status.WithdrawalEpoch))
 		f_exit_epoch.Append(uint64(status.ExitEpoch))
 		f_public_key.Append(status.PublicKey.String())
+		f_withdrawal_prefix.Append(status.WithdrawalCredentials[0])
+		f_withdrawal_credentials.Append(status.WithdrawalCredentialsString())
 	}
 
 	return proto.Input{
@@ -64,6 +70,8 @@ func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 		{Name: "f_withdrawal_epoch", Data: f_withdrawal_epoch},
 		{Name: "f_exit_epoch", Data: f_exit_epoch},
 		{Name: "f_public_key", Data: f_public_key},
+		{Name: "f_withdrawal_prefix", Data: f_withdrawal_prefix},
+		{Name: "f_withdrawal_credentials", Data: f_withdrawal_credentials},
 	}
 }
 

--- a/pkg/db/validator_rewards.go
+++ b/pkg/db/validator_rewards.go
@@ -14,6 +14,7 @@ var (
 		f_val_idx, 
 		f_epoch, 
 		f_balance_eth, 
+		f_withdrawal_prefix,
 		f_reward, 
 		f_max_reward,
 		f_max_att_reward,
@@ -47,6 +48,7 @@ func rewardsInput(vals []spec.ValidatorRewards) proto.Input {
 		f_val_idx                   proto.ColUInt64
 		f_epoch                     proto.ColUInt64
 		f_balance_eth               proto.ColFloat32
+		f_withdrawal_prefix         proto.ColUInt8
 		f_reward                    proto.ColInt64
 		f_max_reward                proto.ColUInt64
 		f_max_att_reward            proto.ColUInt64
@@ -68,6 +70,7 @@ func rewardsInput(vals []spec.ValidatorRewards) proto.Input {
 		f_val_idx.Append(uint64(val.ValidatorIndex))
 		f_epoch.Append(uint64(val.Epoch))
 		f_balance_eth.Append(float32(val.BalanceToEth()))
+		f_withdrawal_prefix.Append(uint8(val.WithdrawalPrefix))
 		f_reward.Append(int64(val.Reward))
 		f_max_reward.Append(uint64(val.MaxReward))
 		f_max_att_reward.Append(uint64(val.AttestationReward))
@@ -89,6 +92,7 @@ func rewardsInput(vals []spec.ValidatorRewards) proto.Input {
 		{Name: "f_val_idx", Data: f_val_idx},
 		{Name: "f_epoch", Data: f_epoch},
 		{Name: "f_balance_eth", Data: f_balance_eth},
+		{Name: "f_withdrawal_prefix", Data: f_withdrawal_prefix},
 		{Name: "f_reward", Data: f_reward},
 		{Name: "f_max_reward", Data: f_max_reward},
 		{Name: "f_max_att_reward", Data: f_max_att_reward},

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -66,7 +66,7 @@ const (
 
 // Electra
 const (
-	CompoundingWithdrawalPrefix = 0x02
+	CompoundingWithdrawalPrefix uint8 = 0x02
 
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#state-list-lengths
 	PendingConsolidationsLimit     uint64 = 1 << 18

--- a/pkg/spec/epoch.go
+++ b/pkg/spec/epoch.go
@@ -10,6 +10,7 @@ type Epoch struct {
 	NumAttestations               int
 	NumAttValidators              int
 	NumValidators                 int
+	NumCompoundingVals            uint64
 	TotalBalance                  float32
 	AttEffectiveBalance           phase0.Gwei
 	SourceAttEffectiveBalance     phase0.Gwei

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -84,6 +84,7 @@ func (s StateMetricsBase) ExportToEpoch() local_spec.Epoch {
 		NumAttestations:               s.CurrentState.NumAttestations,
 		NumAttValidators:              int(countTrue(s.CurrentState.ValidatorAttestationIncluded)),
 		NumValidators:                 len(s.CurrentState.Validators),
+		NumCompoundingVals:            s.CurrentState.GetCompoundingValsNum(),
 		TotalBalance:                  float32(s.CurrentState.TotalActiveRealBalance) / float32(local_spec.EffectiveBalanceInc),
 		AttEffectiveBalance:           s.NextState.AttestingBalance[local_spec.AttTargetFlagIndex] / local_spec.EffectiveBalanceInc,
 		SourceAttEffectiveBalance:     s.NextState.AttestingBalance[local_spec.AttSourceFlagIndex] / local_spec.EffectiveBalanceInc,

--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -295,6 +295,7 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		ValidatorIndex:       valIdx,
 		Epoch:                p.baseMetrics.NextState.Epoch,
 		ValidatorBalance:     p.baseMetrics.NextState.Balances[valIdx],
+		WithdrawalPrefix:     p.baseMetrics.NextState.Validators[valIdx].WithdrawalCredentials[0],
 		Reward:               p.baseMetrics.EpochReward(valIdx),
 		MaxReward:            maxReward,
 		AttestationReward:    flagIndexMaxReward,

--- a/pkg/spec/metrics/state_phase0.go
+++ b/pkg/spec/metrics/state_phase0.go
@@ -222,6 +222,7 @@ func (p Phase0Metrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		ValidatorIndex:       valIdx,
 		Epoch:                p.baseMetrics.NextState.Epoch,
 		ValidatorBalance:     p.baseMetrics.CurrentState.Balances[valIdx],
+		WithdrawalPrefix:     p.baseMetrics.CurrentState.Validators[valIdx].WithdrawalCredentials[0],
 		Reward:               p.baseMetrics.EpochReward(valIdx),
 		MaxReward:            maxReward,
 		AttestationReward:    p.baseMetrics.MaxAttesterRewards[valIdx],

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -197,6 +197,16 @@ func (p *AgnosticState) GetValsStateNums() {
 	p.NumQueuedVals = uint(len(result[QUEUE_STATUS]))
 }
 
+func (p *AgnosticState) GetCompoundingValsNum() uint64 {
+	numCompoundingVals := uint64(0)
+	for _, validator := range p.Validators {
+		if uint8(validator.WithdrawalCredentials[0]) == CompoundingWithdrawalPrefix {
+			numCompoundingVals += 1
+		}
+	}
+	return numCompoundingVals
+}
+
 // Not effective balance, but balance
 func (p AgnosticState) GetTotalActiveRealBalance() phase0.Gwei {
 	totalBalance := phase0.Gwei(0)

--- a/pkg/spec/validator_last_status.go
+++ b/pkg/spec/validator_last_status.go
@@ -1,23 +1,26 @@
 package spec
 
 import (
+	"fmt"
+
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
 type ValidatorLastStatus struct {
-	ValIdx          phase0.ValidatorIndex
-	Epoch           phase0.Epoch
-	CurrentBalance  phase0.Gwei
-	CurrentStatus   ValidatorStatus
-	Slashed         bool
-	ActivationEpoch phase0.Epoch
-	WithdrawalEpoch phase0.Epoch
-	ExitEpoch       phase0.Epoch
-	PublicKey       phase0.BLSPubKey
+	ValIdx                phase0.ValidatorIndex
+	Epoch                 phase0.Epoch
+	CurrentBalance        phase0.Gwei
+	CurrentStatus         ValidatorStatus
+	Slashed               bool
+	ActivationEpoch       phase0.Epoch
+	WithdrawalEpoch       phase0.Epoch
+	ExitEpoch             phase0.Epoch
+	PublicKey             phase0.BLSPubKey
+	WithdrawalCredentials []byte
 }
 
 func (f ValidatorLastStatus) ToArray() []interface{} {
-	resultArgs := make([]interface{}, 0)
+	resultArgs := make([]any, 0)
 	resultArgs = append(resultArgs, f.ValIdx)
 	resultArgs = append(resultArgs, f.Epoch)
 	resultArgs = append(resultArgs, f.BalanceToEth())
@@ -27,6 +30,7 @@ func (f ValidatorLastStatus) ToArray() []interface{} {
 	resultArgs = append(resultArgs, f.WithdrawalEpoch)
 	resultArgs = append(resultArgs, f.ExitEpoch)
 	resultArgs = append(resultArgs, f.PublicKey.String())
+	resultArgs = append(resultArgs, f.WithdrawalCredentials)
 	return resultArgs
 }
 
@@ -36,4 +40,8 @@ func (f ValidatorLastStatus) Type() ModelType {
 
 func (f ValidatorLastStatus) BalanceToEth() float32 {
 	return float32(f.CurrentBalance) / EffectiveBalanceInc
+}
+
+func (f ValidatorLastStatus) WithdrawalCredentialsString() string {
+	return fmt.Sprintf("0x%x", f.WithdrawalCredentials)
 }

--- a/pkg/spec/validator_rewards.go
+++ b/pkg/spec/validator_rewards.go
@@ -8,6 +8,7 @@ type ValidatorRewards struct {
 	ValidatorIndex       phase0.ValidatorIndex
 	Epoch                phase0.Epoch
 	ValidatorBalance     phase0.Gwei
+	WithdrawalPrefix     byte
 	Reward               int64 // it can be negative
 	MaxReward            phase0.Gwei
 	AttestationReward    phase0.Gwei
@@ -35,7 +36,7 @@ func (f ValidatorRewards) BalanceToEth() float32 {
 }
 
 func (f ValidatorRewards) ToArray() []interface{} {
-	rows := []interface{}{
+	rows := []any{
 		f.ValidatorIndex,
 		f.Epoch,
 		f.BalanceToEth(),


### PR DESCRIPTION
This pull request includes several updates to the database schema and related code to track additional metrics for validators, specifically focusing on compounding validators and withdrawal credentials. The most important changes include adding new columns to various tables, updating SQL migrations, and modifying Go code to handle the new data.

### Database Schema Updates:
* Added `f_num_compounding_vals` to `t_epoch_metrics_summary` and `number_compounding_vals` to `t_pool_summary` to track the number of compounding validators. [[1]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R20) [[2]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R69) [[3]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R103) [[4]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R137) [[5]](diffhunk://#diff-0b1281bf1361e7a859e6c6d03d888484aff62869cd358d30bf40479f90b80a06R1-R8) [[6]](diffhunk://#diff-18c0edf2832858e0dcefc16824de08fcabac1d9d9573613f4dfba0436f43dd85R1-R8)
* Added `f_withdrawal_prefix` and `f_withdrawal_credentials` to `t_validator_last_status` and `t_validator_rewards_summary` to store withdrawal credentials details. [[1]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fL21-R23) [[2]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fR43-R44) [[3]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fR58-R59) [[4]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fR73-R74) [[5]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R17) [[6]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R51) [[7]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R73) [[8]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R95) [[9]](diffhunk://#diff-0b1281bf1361e7a859e6c6d03d888484aff62869cd358d30bf40479f90b80a06R1-R8) [[10]](diffhunk://#diff-18c0edf2832858e0dcefc16824de08fcabac1d9d9573613f4dfba0436f43dd85R1-R8)

### Documentation Updates:
* Updated `docs/tables.md` to include descriptions for the new columns `f_num_compounding_vals`, `number_compounding_vals`, `f_withdrawal_prefix`, and `f_withdrawal_credentials`. [[1]](diffhunk://#diff-685b5bbe3024412235e5fdbfa26852239c862cc39b32038beb7b698b7a5cc940R41) [[2]](diffhunk://#diff-685b5bbe3024412235e5fdbfa26852239c862cc39b32038beb7b698b7a5cc940L69-R71) [[3]](diffhunk://#diff-685b5bbe3024412235e5fdbfa26852239c862cc39b32038beb7b698b7a5cc940L79-R85) [[4]](diffhunk://#diff-685b5bbe3024412235e5fdbfa26852239c862cc39b32038beb7b698b7a5cc940L130-R133) [[5]](diffhunk://#diff-685b5bbe3024412235e5fdbfa26852239c862cc39b32038beb7b698b7a5cc940R143-R172)

### Code Modifications:
* Updated Go structs and methods to handle the new columns, ensuring that the additional data is correctly processed and stored. [[1]](diffhunk://#diff-80aba09372cdd70ad72ec1a3a28c1b8efce92f06618ef1353be849691f1452d1R188) [[2]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R20) [[3]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R69) [[4]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R103) [[5]](diffhunk://#diff-ac20cb311a70d94e71398f38be8ba23447011f66992f6e1bbb2fe0e2921e8ef5R137) [[6]](diffhunk://#diff-8c914ffc10007abc7b0308f14a1f421102b1d6cdd16d5083b2a88afd681d39fdR28) [[7]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fL21-R23) [[8]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fR43-R44) [[9]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fR58-R59) [[10]](diffhunk://#diff-885ce4669fae2b561185ca1cba39ca526f3163535efcbd688c110cede188397fR73-R74) [[11]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R17) [[12]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R51) [[13]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R73) [[14]](diffhunk://#diff-26f5e657e42be8c22844ead54364be0b96aa9e5e8361ec9b3b533e4ed6afba00R95) [[15]](diffhunk://#diff-09ba35aa3134bad0b6214cb3baa8bca7882084ac55f26d3675f505cefba73946L69-R69) [[16]](diffhunk://#diff-6f34ab8667d8e673a32a5e676cc944bbdd273c335fbc43a3fe37e6754eb4d42cR13) [[17]](diffhunk://#diff-1df45a52cbb23eb2dba24bed87f0af8076b7a9e58e3793980c9d47088cd34c41R87)

These changes ensure that the system can now track and report on the number of compounding validators and their withdrawal credentials, providing more detailed insights into validator behavior and performance.