### PR TITLE
Prepare v3.6.1

### DIFF
--- a/pkg/relay/relay_bid_trace.go
+++ b/pkg/relay/relay_bid_trace.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	moduleName      = "relays"
-	mevRelayTimeout = 3 * time.Minute
+	mevRelayTimeout = 10 * time.Second
 )
 
 var (

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -3,7 +3,7 @@ package utils
 import "time"
 
 const (
-	Version                = "v3.6.0"
+	Version                = "v3.6.1"
 	CliName                = "GotEth"
 	RoutineFlushTimeout    = time.Duration(1 * time.Second)
 	AcquireWaitIntervalLog = 1 * time.Minute


### PR DESCRIPTION
This pull request includes changes to update timeout settings and version information in the codebase. The most important changes are:

Timeout settings update:
* [`pkg/relay/relay_bid_trace.go`](diffhunk://#diff-8f6f9622800ebd0f27dc3f24a610721a765121a1979e00f7df7b4b1ff382c173L19-R19): Changed `mevRelayTimeout` from 3 minutes to 10 seconds to improve responsiveness.

Version information update:
* [`pkg/utils/constants.go`](diffhunk://#diff-4b60b6372744a7df66ef729623f32e667540567365e1319c654b1dd2cfd3d1a2L6-R6): Updated `Version` from "v3.6.0" to "v3.6.1" to reflect the latest release.

Closes #153
Closes #160