### PR TITLE
fix: attestation included out of phase

### DIFF
--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -42,15 +42,17 @@ func (p *AltairMetrics) InitBundle(nextState *spec.AgnosticState,
 
 func (p *AltairMetrics) PreProcessBundle() {
 
-	if !p.baseMetrics.PrevState.EmptyStateRoot() && !p.baseMetrics.CurrentState.EmptyStateRoot() {
+	if !p.baseMetrics.PrevState.EmptyStateRoot() {
 		// block rewards
 		p.ProcessAttestations()
-		p.ProcessSlashings()
-		p.ProcessSyncAggregates()
+		if !p.baseMetrics.CurrentState.EmptyStateRoot() {
+			p.ProcessSlashings()
+			p.ProcessSyncAggregates()
 
-		p.GetMaxFlagIndexDeltas()
-		p.ProcessInclusionDelays()
-		p.GetMaxSyncComReward()
+			p.GetMaxFlagIndexDeltas()
+			p.ProcessInclusionDelays()
+			p.GetMaxSyncComReward()
+		}
 	}
 }
 
@@ -276,7 +278,6 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 			proposerManualReward += phase0.Gwei(block.ManualReward)
 		}
 	}
-
 	proposerReward = proposerManualReward
 	if proposerApiReward > 0 {
 		proposerReward = proposerApiReward // if API rewards, always prioritize api
@@ -287,8 +288,8 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 	baseReward := p.GetBaseReward(valIdx, p.baseMetrics.NextState.Validators[valIdx].EffectiveBalance, p.baseMetrics.NextState.TotalActiveBalance)
 
 	attestationIncluded := false
-	if int(valIdx) < len(p.baseMetrics.CurrentState.ValidatorAttestationIncluded) {
-		attestationIncluded = p.baseMetrics.CurrentState.ValidatorAttestationIncluded[valIdx]
+	if int(valIdx) < len(p.baseMetrics.PrevState.ValidatorAttestationIncluded) {
+		attestationIncluded = p.baseMetrics.PrevState.ValidatorAttestationIncluded[valIdx]
 	}
 
 	result := spec.ValidatorRewards{

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -43,18 +43,20 @@ func (p *ElectraMetrics) InitBundle(nextState *spec.AgnosticState,
 
 func (p *ElectraMetrics) PreProcessBundle() {
 
-	if !p.baseMetrics.PrevState.EmptyStateRoot() && !p.baseMetrics.CurrentState.EmptyStateRoot() {
-		// block rewards
+	if !p.baseMetrics.CurrentState.EmptyStateRoot() {
 		p.ProcessAttestations()
-		p.ProcessSlashings()
-		p.ProcessSyncAggregates()
-		p.processConsolidationRequests()
-		p.processWithdrawalRequests()
-		p.processDepositRequests()
-		p.GetMaxFlagIndexDeltas()
-		p.ProcessInclusionDelays()
-		p.GetMaxSyncComReward()
-		p.processPendingConsolidations(p.baseMetrics.NextState)
+		if !p.baseMetrics.PrevState.EmptyStateRoot() {
+			// block rewards
+			p.ProcessSlashings()
+			p.ProcessSyncAggregates()
+			p.processConsolidationRequests()
+			p.processWithdrawalRequests()
+			p.processDepositRequests()
+			p.GetMaxFlagIndexDeltas()
+			p.ProcessInclusionDelays()
+			p.GetMaxSyncComReward()
+			p.processPendingConsolidations(p.baseMetrics.NextState)
+		}
 	}
 }
 


### PR DESCRIPTION
The `f_attestation_included` from `t_validator_rewards_summary` should correspond to two epochs before `f_epoch` as per the documentation but it actually corresponds to the epoch before.

This PR fixes the issue by correcting the state reference from `CurrentState` to `PrevState` for checking if a validator's attestation was included in `GetMaxReward`.   [`pkg/spec/metrics/state_altair.go`](diffhunk://#diff-05d71dff6aa15e1ab4c29f254b5d7c1457fa73425bf7ecc5e0a8498a0d2a16a3L290-R292)

Closes #166 