### PR TITLE
fix: remove inactive vals from rewards table

### DIFF
--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -220,14 +220,9 @@ func (s *ChainAnalyzer) processEpochValRewards(bundle metrics.StateMetrics) {
 	log.Debugf("persising validator metrics: epoch %d", bundle.GetMetricsBase().NextState.Epoch)
 	nextState := bundle.GetMetricsBase().NextState
 	// process each validator
-	for valIdx := range nextState.Validators {
-		if valIdx >= len(nextState.Validators) {
-			continue // validator is not in the chain yet
-		}
-		valIdx := phase0.ValidatorIndex(valIdx)
-
+	for i, validator := range nextState.Validators {
+		valIdx := phase0.ValidatorIndex(i)
 		// Check validator status conditions
-		validator := nextState.Validators[valIdx]
 		isActive := spec.IsActive(*validator, nextState.Epoch)
 		isSlashed := validator.Slashed
 		isExited := validator.ExitEpoch <= nextState.Epoch
@@ -235,10 +230,6 @@ func (s *ChainAnalyzer) processEpochValRewards(bundle metrics.StateMetrics) {
 		// Only process validators that are active or slashed and not exited
 		if !isActive && (!isSlashed || isExited) {
 			continue
-		}
-
-		if validator.Slashed {
-			log.Debugf("validator %d is slashed", valIdx)
 		}
 
 		// get max reward at given epoch using the formulas
@@ -249,8 +240,8 @@ func (s *ChainAnalyzer) processEpochValRewards(bundle metrics.StateMetrics) {
 		}
 		if s.rewardsAggregationEpochs > 1 {
 			// if validator is not in s.validatorsRewardsAggregations, we need to create it
-			if _, ok := s.validatorsRewardsAggregations[phase0.ValidatorIndex(valIdx)]; !ok {
-				s.validatorsRewardsAggregations[phase0.ValidatorIndex(valIdx)] = spec.NewValidatorRewardsAggregation(valIdx, s.startEpochAggregation, s.endEpochAggregation)
+			if _, ok := s.validatorsRewardsAggregations[valIdx]; !ok {
+				s.validatorsRewardsAggregations[valIdx] = spec.NewValidatorRewardsAggregation(valIdx, s.startEpochAggregation, s.endEpochAggregation)
 			}
 			s.validatorsRewardsAggregations[valIdx].Aggregate(maxRewards)
 		}


### PR DESCRIPTION
This pull request involves changes to the `pkg/analyzer/process_state.go` file, specifically within the `processEpochValRewards` function. These changes aim to reduce the size of `t_validator_rewards_summary` and `t_validator_rewards_aggregation` by only storing active validators and slashed (but not exited) validators. Inactive validators don't have rewards so there is no sense to have them on the rewards table.

### Improvements to validator reward processing:

* Refactored the loop to use `nextState` directly, improving code readability and reducing redundancy.
* Added checks for validator status conditions, ensuring that only active or slashed (but not exited) validators are processed. This helps in filtering out irrelevant validators and optimizing performance.
* Updated the condition that checks for reward aggregation epochs to use `nextState.Epoch`, maintaining consistency with the rest of the function.

Closes #158 