### PR TITLE
Fix: t_status rows inserted wrong

### DIFF
--- a/docs/tables.md
+++ b/docs/tables.md
@@ -127,7 +127,7 @@
 | Column Name | Type of Data | Description                                                                                          |     |     |
 | ----------- | ------------ | ---------------------------------------------------------------------------------------------------- | --- | --- |
 | f_id        | uint64       | id of the status                                                                                     |
-| f_status    | string       | name of the status <br> 0, 'in_activation_queue' <br> 1, 'active' <br> 2, 'slashed' <br> 3, 'exited' |
+| f_status    | string       | name of the status <br> 0, 'in_activation_queue' <br> 1, 'active' <br> 2, 'exited' <br> 3, 'slashed' |
 
 # Validator Last Status (`t_validator_last_status`)
 

--- a/pkg/db/migrations/000031_correct_t_status_values.down.sql
+++ b/pkg/db/migrations/000031_correct_t_status_values.down.sql
@@ -1,0 +1,4 @@
+    -- Revert t_status values to original state
+    INSERT INTO t_status VALUES(2, 'slashed');
+    INSERT INTO t_status VALUES(3, 'exited');
+    OPTIMIZE TABLE t_status FINAL;

--- a/pkg/db/migrations/000031_correct_t_status_values.up.sql
+++ b/pkg/db/migrations/000031_correct_t_status_values.up.sql
@@ -1,0 +1,4 @@
+-- Update t_status values to match other tables
+INSERT INTO t_status VALUES(2, 'exited');
+INSERT INTO t_status VALUES(3, 'slashed');
+OPTIMIZE TABLE t_status FINAL;


### PR DESCRIPTION
This pull request includes changes to update the status values in the database and correct documentation. The most important changes include modifying the `t_status` values to ensure consistency across tables and updating the documentation to reflect the correct order of status values.

Database updates:

* [`pkg/db/migrations/000031_correct_t_status_values.up.sql`](diffhunk://#diff-46f5b42aa03aee306cfd16a49c8341823dba81f240d0fe3dab894c382a17f09aR1-R4): Updated `t_status` values to match other tables by inserting the correct status values and optimizing the table.
* [`pkg/db/migrations/000031_correct_t_status_values.down.sql`](diffhunk://#diff-7504f86a76fd4a6fea31252884b123028e135c14ddef48faae10f59b8943439dR1-R4): Added SQL statements to revert the `t_status` values to their original state and optimize the table.

Documentation correction:

* [`docs/tables.md`](diffhunk://#diff-685b5bbe3024412235e5fdbfa26852239c862cc39b32038beb7b698b7a5cc940L130-R130): Corrected the order of status values in the description for `f_status` to match the updated database values.

Closes #159 