### PR TITLE
Bug: Validator Window deleting the whole t_validator_rewards_summary table

### DIFF
--- a/pkg/validator_window/window.go
+++ b/pkg/validator_window/window.go
@@ -82,11 +82,15 @@ func (s *ValidatorWindowRunner) Run() {
 		case <-s.eventsObj.FinalizedChan:
 
 			dbHeadEpoch, err := s.dbClient.RetrieveLastEpoch()
-
 			if err != nil {
 				log.Errorf("could not detect current head epoch in database: %s", err)
 				s.EndProcesses()
 				return
+			}
+
+			if dbHeadEpoch < phase0.Epoch(s.windowEpochSize) {
+				log.Infof("database head epoch: %d is less than window epoch size: %d", dbHeadEpoch, s.windowEpochSize)
+				continue
 			}
 			windowLowerEpochBoundary := dbHeadEpoch - phase0.Epoch(s.windowEpochSize)
 


### PR DESCRIPTION
This pull request introduces a conditional check in the `Run` method of the `ValidatorWindowRunner` to ensure that the database head epoch is not smaller than the window epoch size before proceeding with further logic. This change prevents potential issues when the database head epoch is too small to calculate a valid window lower epoch boundary.

Key change:

* [`pkg/validator_window/window.go`](diffhunk://#diff-9891516680817802586a9b1350ba68ef16e523b5a429b30d426b510df4c36628L85-R94): Added a conditional check to compare `dbHeadEpoch` with `s.windowEpochSize`. If `dbHeadEpoch` is smaller, a log message is generated, and the loop continues without further processing. This ensures robustness when handling edge cases where the database head epoch is insufficient for window calculations.

Closes #179 