### PR TITLE
Fix: f_status out of phase in t_validator_rewards_summary

### DIFF
--- a/pkg/spec/metrics/state_altair.go
+++ b/pkg/spec/metrics/state_altair.go
@@ -316,7 +316,7 @@ func (p AltairMetrics) GetMaxReward(valIdx phase0.ValidatorIndex) (spec.Validato
 		MissingSource:        flags[spec.AttSourceFlagIndex],
 		MissingTarget:        flags[spec.AttTargetFlagIndex],
 		MissingHead:          flags[spec.AttHeadFlagIndex],
-		Status:               currentState.GetValStatus(valIdx),
+		Status:               nextState.GetValStatus(valIdx),
 		BaseReward:           baseReward,
 		ProposerApiReward:    proposerApiReward,
 		ProposerManualReward: proposerManualReward,


### PR DESCRIPTION
This pull request includes a small but important change in the `AltairMetrics` implementation to ensure the correct state is used when determining validator status.

* [`pkg/spec/metrics/state_altair.go`](diffhunk://#diff-05d71dff6aa15e1ab4c29f254b5d7c1457fa73425bf7ecc5e0a8498a0d2a16a3L319-R319): Updated the `Status` field in the `GetMaxReward` method to use `nextState.GetValStatus(valIdx)` instead of `currentState.GetValStatus(valIdx)`, ensuring the validator status reflects the next state rather than the current state.