### PR TITLE
fix: processBlobSidecars crashes pre-Deneb

### DIFF
--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"fmt"
 
+	eth2_client_spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/migalabs/goteth/pkg/spec"
@@ -54,8 +55,9 @@ func (s *ChainAnalyzer) ProcessETH1Data(block *spec.AgnosticBlock) {
 		log.Errorf("error processing eth1 deposits: %s", err.Error())
 		return
 	}
-
-	s.processBlobSidecars(block, block.ExecutionPayload.AgnosticTransactions)
+	if block.HardForkVersion >= eth2_client_spec.DataVersionDeneb {
+		s.processBlobSidecars(block, block.ExecutionPayload.AgnosticTransactions)
+	}
 }
 
 func (s *ChainAnalyzer) processETH1Deposits(block *spec.AgnosticBlock) error {

--- a/pkg/spec/block.go
+++ b/pkg/spec/block.go
@@ -17,6 +17,7 @@ import (
 
 // This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs
 type AgnosticBlock struct {
+	HardForkVersion       spec.DataVersion
 	Slot                  phase0.Slot
 	StateRoot             phase0.Root
 	Root                  phase0.Root
@@ -117,6 +118,7 @@ func NewPhase0Block(block spec.VersionedSignedBeaconBlock) AgnosticBlock {
 	}
 
 	return AgnosticBlock{
+		HardForkVersion:   spec.DataVersionPhase0,
 		Slot:              block.Phase0.Message.Slot,
 		ParentRoot:        block.Phase0.Message.ParentRoot,
 		Root:              root,
@@ -159,6 +161,7 @@ func NewAltairBlock(block spec.VersionedSignedBeaconBlock) AgnosticBlock {
 		log.Fatalf("could not read root from block %d", block.Altair.Message.Slot)
 	}
 	return AgnosticBlock{
+		HardForkVersion:   spec.DataVersionAltair,
 		Slot:              block.Altair.Message.Slot,
 		Root:              root,
 		ParentRoot:        block.Altair.Message.ParentRoot,
@@ -201,6 +204,7 @@ func NewBellatrixBlock(block spec.VersionedSignedBeaconBlock) AgnosticBlock {
 		log.Fatalf("could not read root from block %d", block.Bellatrix.Message.Slot)
 	}
 	return AgnosticBlock{
+		HardForkVersion:   spec.DataVersionBellatrix,
 		Slot:              block.Bellatrix.Message.Slot,
 		Root:              root,
 		ParentRoot:        block.Bellatrix.Message.ParentRoot,
@@ -243,6 +247,7 @@ func NewCapellaBlock(block spec.VersionedSignedBeaconBlock) AgnosticBlock {
 		log.Fatalf("could not read root from block %d", block.Capella.Message.Slot)
 	}
 	return AgnosticBlock{
+		HardForkVersion:   spec.DataVersionCapella,
 		Slot:              block.Capella.Message.Slot,
 		Root:              root,
 		ParentRoot:        block.Capella.Message.ParentRoot,
@@ -286,6 +291,7 @@ func NewDenebBlock(block spec.VersionedSignedBeaconBlock) AgnosticBlock {
 		log.Fatalf("could not read root from block %d", block.Deneb.Message.Slot)
 	}
 	return AgnosticBlock{
+		HardForkVersion:   spec.DataVersionDeneb,
 		Slot:              block.Deneb.Message.Slot,
 		Root:              root,
 		ParentRoot:        block.Deneb.Message.ParentRoot,
@@ -329,6 +335,7 @@ func NewElectraBlock(block spec.VersionedSignedBeaconBlock) AgnosticBlock {
 		log.Fatalf("could not read root from block %d", block.Electra.Message.Slot)
 	}
 	return AgnosticBlock{
+		HardForkVersion:          spec.DataVersionElectra,
 		Slot:                     block.Electra.Message.Slot,
 		Root:                     root,
 		ParentRoot:               block.Electra.Message.ParentRoot,


### PR DESCRIPTION
This pull request addresses the issue of goteth crashing because of it attempting to download blob sidecars for blocks pre-Deneb. 

### Enhancements to `AgnosticBlock`:

* Added a new `HardForkVersion` field to the `AgnosticBlock` structure to represent the Ethereum hard fork version. (`pkg/spec/block.go`, [pkg/spec/block.goR20](diffhunk://#diff-aa4ade104911f8b1637205318dc2dc68e74ce8190b328f674ec19cdef4d061d3R20))
* Updated constructors (`NewPhase0Block`, `NewAltairBlock`, `NewBellatrixBlock`, `NewCapellaBlock`, `NewDenebBlock`, `NewElectraBlock`) to initialize the `HardForkVersion` field with the appropriate hard fork version for each block type. (`pkg/spec/block.go`, [[1]](diffhunk://#diff-aa4ade104911f8b1637205318dc2dc68e74ce8190b328f674ec19cdef4d061d3R121) [[2]](diffhunk://#diff-aa4ade104911f8b1637205318dc2dc68e74ce8190b328f674ec19cdef4d061d3R164) [[3]](diffhunk://#diff-aa4ade104911f8b1637205318dc2dc68e74ce8190b328f674ec19cdef4d061d3R207) [[4]](diffhunk://#diff-aa4ade104911f8b1637205318dc2dc68e74ce8190b328f674ec19cdef4d061d3R250) [[5]](diffhunk://#diff-aa4ade104911f8b1637205318dc2dc68e74ce8190b328f674ec19cdef4d061d3R294) [[6]](diffhunk://#diff-aa4ade104911f8b1637205318dc2dc68e74ce8190b328f674ec19cdef4d061d3R338)

### Updates to `ChainAnalyzer`:

* Modified the `ProcessETH1Data` method to check the `HardForkVersion` of the block and process Deneb-specific blob sidecars if the version is `DataVersionDeneb` or higher. (`pkg/analyzer/process_block.go`, [pkg/analyzer/process_block.goL57-R61](diffhunk://#diff-b1d26964cb159e7cd61cf79df8740cf223019616f59717abcd512b55df625132L57-R61))

Closes #183 