### PR TITLE
Fix: Pool summary race condition and counting multiple rows when rerunning

### DIFF
--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -51,8 +51,6 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 	if !nextState.EmptyStateRoot() && !currentState.EmptyStateRoot() && !prevState.EmptyStateRoot() {
 		s.processEpochDuties(bundle)
 		s.processValLastStatus(bundle)
-
-		s.processPoolMetrics(bundle.GetMetricsBase().CurrentState.Epoch)
 		s.processEpochMetrics(bundle)
 		s.processBlockRewards(bundle) // block rewards depend on two previous epochs
 		if s.metrics.ValidatorRewards {
@@ -63,6 +61,7 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 		s.storeWithdrawalRequests(bundle)
 		s.storeDepositRequests(bundle)
 		s.storeConsoidationsProcessed(bundle)
+		s.processPoolMetrics(bundle.GetMetricsBase().PrevState.Epoch) // Calculated over prev state so we make sure that tables are filled
 	}
 
 	s.processerBook.FreePage(routineKey)

--- a/pkg/db/pools_summary.go
+++ b/pkg/db/pools_summary.go
@@ -29,10 +29,10 @@ var (
 				count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals,
 				count(CASE WHEN f_withdrawal_prefix = 2 THEN 1 ELSE null END) as number_compounding_vals,
 				AVG(f_inclusion_delay) as avg_inclusion_delay
-			FROM t_validator_rewards_summary
-			LEFT JOIN t_eth2_pubkeys 
+			FROM t_validator_rewards_summary final
+			LEFT JOIN t_eth2_pubkeys final
 				ON t_validator_rewards_summary.f_val_idx = t_eth2_pubkeys.f_val_idx
-			LEFT JOIN t_proposer_duties 
+			LEFT JOIN t_proposer_duties final
 				ON t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx 
 				AND t_validator_rewards_summary.f_epoch = toUInt64(t_proposer_duties.f_proposer_slot/32)
 			WHERE f_epoch = $1 AND f_status = 1 AND f_pool_name != ''


### PR DESCRIPTION
This pull request refactors the handling of pool metrics and updates SQL queries for improved clarity and accuracy. The most important changes include modifying how pool metrics are calculated in the `ProcessStateTransitionMetrics` function and updating SQL queries in `pools_summary.go` to use the `final` modifier for tables to use the optimized version of the merging tree tables..

### Refactoring pool metrics calculation:

* [`pkg/analyzer/process_state.go`](diffhunk://#diff-80aba09372cdd70ad72ec1a3a28c1b8efce92f06618ef1353be849691f1452d1L54-L55): The call to `processPoolMetrics` has been moved to use the `PrevState.Epoch` instead of `CurrentState.Epoch` to ensure calculations are based on the previous state, improving data consistency. [[1]](diffhunk://#diff-80aba09372cdd70ad72ec1a3a28c1b8efce92f06618ef1353be849691f1452d1L54-L55) [[2]](diffhunk://#diff-80aba09372cdd70ad72ec1a3a28c1b8efce92f06618ef1353be849691f1452d1R64)

### SQL query updates:

* [`pkg/db/pools_summary.go`](diffhunk://#diff-8c914ffc10007abc7b0308f14a1f421102b1d6cdd16d5083b2a88afd681d39fdL32-R35): Updated SQL queries to use the `final` modifier for tables (`t_validator_rewards_summary`, `t_eth2_pubkeys`, and `t_proposer_duties`) to ensure the queries operate on finalized data. This change enhances the accuracy of the results.
