### PR TITLE
Fix: f_reward includes consolidation and deposit amount

### DIFF
--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -101,6 +101,7 @@ func (s *ChainAnalyzer) processDeposits(block *spec.AgnosticBlock) {
 	for i, item := range block.Deposits {
 		deposits = append(deposits, spec.Deposit{
 			Slot:                  block.Slot,
+			EpochProcessed:        spec.EpochAtSlot(block.Slot),
 			PublicKey:             item.Data.PublicKey,
 			WithdrawalCredentials: item.Data.WithdrawalCredentials,
 			Amount:                item.Data.Amount,

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -57,6 +57,7 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 			s.processEpochValRewards(bundle)
 		}
 		s.processSlashings(bundle)
+		s.storeDepositsProcessed(bundle) // we store deposits processed from electra + in the database
 		s.storeConsolidationRequests(bundle)
 		s.storeWithdrawalRequests(bundle)
 		s.storeDepositRequests(bundle)
@@ -76,6 +77,18 @@ func (s *ChainAnalyzer) processSlashings(bundle metrics.StateMetrics) {
 	err := s.dbClient.PersistSlashings(slashings)
 	if err != nil {
 		log.Errorf("error persisting slashings: %s", err.Error())
+	}
+}
+
+// storeDepositsProcessed stores the deposits processed from electra + in the database
+func (s *ChainAnalyzer) storeDepositsProcessed(bundle metrics.StateMetrics) {
+	depositsProcessed := bundle.GetMetricsBase().NextState.DepositsProcessed
+	if len(depositsProcessed) == 0 {
+		return
+	}
+	err := s.dbClient.PersistDeposits(depositsProcessed)
+	if err != nil {
+		log.Errorf("error persisting deposits processed: %s", err.Error())
 	}
 }
 

--- a/pkg/db/deposits.go
+++ b/pkg/db/deposits.go
@@ -12,6 +12,7 @@ var (
 	insertDepositQuery = `
 	INSERT INTO %s (
 		f_slot,
+		f_epoch_processed,
 		f_public_key,
 		f_withdrawal_credentials,
 		f_amount,
@@ -25,6 +26,7 @@ func depositsInput(depositss []spec.Deposit) proto.Input {
 	// one object per column
 	var (
 		f_slot                   proto.ColUInt64
+		f_epoch_processed        proto.ColUInt64
 		f_public_key             proto.ColStr
 		f_withdrawal_credentials proto.ColStr
 		f_amount                 proto.ColUInt64
@@ -35,6 +37,7 @@ func depositsInput(depositss []spec.Deposit) proto.Input {
 	for _, deposit := range depositss {
 
 		f_slot.Append(uint64(deposit.Slot))
+		f_epoch_processed.Append(uint64(deposit.EpochProcessed))
 		f_public_key.Append(deposit.PublicKey.String())
 		f_withdrawal_credentials.Append(fmt.Sprintf("%#x", deposit.WithdrawalCredentials))
 		f_amount.Append(uint64(deposit.Amount))
@@ -44,6 +47,7 @@ func depositsInput(depositss []spec.Deposit) proto.Input {
 
 	return proto.Input{
 		{Name: "f_slot", Data: f_slot},
+		{Name: "f_epoch_processed", Data: f_epoch_processed},
 		{Name: "f_public_key", Data: f_public_key},
 		{Name: "f_withdrawal_credentials", Data: f_withdrawal_credentials},
 		{Name: "f_amount", Data: f_amount},

--- a/pkg/db/migrations/000033_add_epoch_processed_t_deposits.down.sql
+++ b/pkg/db/migrations/000033_add_epoch_processed_t_deposits.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE t_deposits DROP COLUMN f_epoch_processed;

--- a/pkg/db/migrations/000033_add_epoch_processed_t_deposits.up.sql
+++ b/pkg/db/migrations/000033_add_epoch_processed_t_deposits.up.sql
@@ -1,0 +1,31 @@
+-- Create new table with f_epoch_processed column
+CREATE TABLE new_t_deposits(
+	f_slot UInt64,
+	f_epoch_processed UInt64,
+	f_public_key TEXT,
+	f_withdrawal_credentials TEXT,
+	f_amount UInt64,
+	f_signature TEXT,
+	f_index UInt8
+	)
+	ENGINE = ReplacingMergeTree()
+ORDER BY (f_slot, f_index);
+
+-- Migrate data from old t_deposits to new_t_deposits
+INSERT INTO new_t_deposits
+SELECT
+	f_slot,
+	CAST(f_slot / 32 AS UInt64) AS f_epoch_processed,
+	f_public_key,
+	f_withdrawal_credentials,
+	f_amount,
+	f_signature,
+	f_index
+FROM t_deposits;
+
+-- Rename tables
+RENAME TABLE t_deposits TO t_deposits_old;
+RENAME TABLE new_t_deposits TO t_deposits;
+
+-- Drop temporary table
+DROP TABLE t_deposits_old;

--- a/pkg/spec/constants.go
+++ b/pkg/spec/constants.go
@@ -80,6 +80,8 @@ const (
 	// https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#misc
 	FullExitRequestAmount          uint64 = 0
 	UnsetDepositRequestsStartIndex uint64 = 1<<64 - 1 //uint64(2**64 - 1)
+
+	MaxPendingDepositsPerEpoch uint64 = 16 // 2**4
 )
 
 var (

--- a/pkg/spec/deposit.go
+++ b/pkg/spec/deposit.go
@@ -6,6 +6,7 @@ import (
 
 type Deposit struct {
 	Slot                  phase0.Slot
+	EpochProcessed        phase0.Epoch
 	PublicKey             phase0.BLSPubKey
 	WithdrawalCredentials []byte
 	Amount                phase0.Gwei
@@ -17,9 +18,10 @@ func (f Deposit) Type() ModelType {
 	return DepositModel
 }
 
-func (f Deposit) ToArray() []interface{} {
-	rows := []interface{}{
+func (f Deposit) ToArray() []any {
+	rows := []any{
 		f.Slot,
+		f.EpochProcessed,
 		f.PublicKey,
 		f.WithdrawalCredentials,
 		f.Amount,

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -33,10 +33,17 @@ func (p StateMetricsBase) EpochReward(valIdx phase0.ValidatorIndex) int64 {
 	if !ok {
 		consolidatedAmount = 0
 	}
+
+	// After electra, we have deposits in depositedAmounts since the logic of deposits changed
+	depositedAmount, ok := p.CurrentState.DepositedAmounts[valIdx]
+	if !ok {
+		depositedAmount = 0
+	}
+	depositedAmount += p.NextState.Deposits[valIdx]
 	if valIdx < phase0.ValidatorIndex(len(p.CurrentState.Balances)) && valIdx < phase0.ValidatorIndex(len(p.NextState.Balances)) {
 		reward := int64(p.NextState.Balances[valIdx]) - int64(p.CurrentState.Balances[valIdx])
 		reward += int64(p.NextState.Withdrawals[valIdx])
-		reward -= int64(p.NextState.Deposits[valIdx])
+		reward -= int64(depositedAmount)
 		reward -= int64(consolidatedAmount)
 		return reward
 	}

--- a/pkg/spec/metrics/standard.go
+++ b/pkg/spec/metrics/standard.go
@@ -29,10 +29,15 @@ type StateMetricsBase struct {
 }
 
 func (p StateMetricsBase) EpochReward(valIdx phase0.ValidatorIndex) int64 {
+	consolidatedAmount, ok := p.CurrentState.ConsolidatedAmounts[valIdx]
+	if !ok {
+		consolidatedAmount = 0
+	}
 	if valIdx < phase0.ValidatorIndex(len(p.CurrentState.Balances)) && valIdx < phase0.ValidatorIndex(len(p.NextState.Balances)) {
 		reward := int64(p.NextState.Balances[valIdx]) - int64(p.CurrentState.Balances[valIdx])
 		reward += int64(p.NextState.Withdrawals[valIdx])
 		reward -= int64(p.NextState.Deposits[valIdx])
+		reward -= int64(consolidatedAmount)
 		return reward
 	}
 

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -46,6 +46,7 @@ func (p *ElectraMetrics) PreProcessBundle() {
 
 	if !p.baseMetrics.CurrentState.EmptyStateRoot() {
 		p.ProcessAttestations()
+		p.processPendingDeposits()
 		p.processPendingConsolidations(p.baseMetrics.NextState)
 		if !p.baseMetrics.PrevState.EmptyStateRoot() {
 			// block rewards
@@ -670,4 +671,78 @@ func (p *ElectraMetrics) ProcessSlashings() {
 
 		block.ManualReward += proposerReward + (whistleBlowerReward - proposerReward)
 	}
+}
+
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_pending_deposits
+func (p *ElectraMetrics) processPendingDeposits() {
+	nextEpoch := p.baseMetrics.NextState.Epoch + 1
+	state := p.baseMetrics.NextState
+	availableForProcessing := state.DepositBalanceToConsume + phase0.Gwei(getActivationExitChurnLimit(state))
+	processedAmount := phase0.Gwei(0)
+	nextDepositIndex := uint64(0)
+	finalizedSlot := spec.ComputeStartSlotAtEpoch(state.CurrentFinalizedCheckpoint.Epoch)
+	processedDeposits := make([]spec.Deposit, 0)
+	index := uint8(0)
+	validatorPubkeys := make(map[[48]byte]phase0.ValidatorIndex)
+	for i, v := range state.Validators {
+		validatorPubkeys[v.PublicKey] = phase0.ValidatorIndex(i)
+	}
+	for _, deposit := range state.PendingDeposits {
+		// Do not process deposit requests if Eth1 bridge deposits are not yet applied.
+		if deposit.Slot > 0 &&
+			state.Eth1DepositIndex < state.DepositRequestsStartIndex {
+			break
+		}
+
+		// Check if deposit has been finalized, otherwise, stop processing.
+		if deposit.Slot > finalizedSlot {
+			break
+		}
+
+		// Check if number of processed deposits has not reached the limit, otherwise, stop processing.
+		if nextDepositIndex >= spec.MaxPendingDepositsPerEpoch {
+			break
+		}
+
+		// Read validator state
+		isValidatorExited := false
+		isValidatorWithdrawn := false
+		validatorIdx, exists := validatorPubkeys[deposit.Pubkey]
+		var validator *phase0.Validator
+		if exists {
+			validator = state.Validators[validatorIdx]
+			isValidatorExited = validator.ExitEpoch < phase0.Epoch(spec.FarFutureEpoch)
+			isValidatorWithdrawn = validator.WithdrawableEpoch < nextEpoch
+		}
+		processedDeposit := spec.Deposit{
+			Slot:                  deposit.Slot,
+			PublicKey:             deposit.Pubkey,
+			WithdrawalCredentials: deposit.WithdrawalCredentials,
+			Amount:                deposit.Amount,
+			Signature:             deposit.Signature,
+			Index:                 index,
+		}
+		nextDepositIndex++
+
+		if isValidatorWithdrawn {
+			// Deposited balance will never become active. Increase balance but do not consume churn
+			processedDeposits = append(processedDeposits, processedDeposit)
+		} else if isValidatorExited {
+			// Validator is exiting, postpone the deposit until after withdrawable epoch
+			continue
+		} else {
+			// Check if deposit fits in the churn, otherwise, do no more deposit processing in this epoch.
+			if processedAmount+deposit.Amount > phase0.Gwei(availableForProcessing) {
+				break
+			}
+			// Consume churn and apply deposit.
+			processedAmount += deposit.Amount
+			processedDeposits = append(processedDeposits, processedDeposit)
+		}
+		index++
+		state.DepositedAmounts[validatorIdx] += deposit.Amount
+		state.DepositsNum += 1
+		state.TotalDepositsAmount += deposit.Amount
+	}
+	state.DepositsProcessed = processedDeposits
 }

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -716,6 +716,7 @@ func (p *ElectraMetrics) processPendingDeposits() {
 		}
 		processedDeposit := spec.Deposit{
 			Slot:                  deposit.Slot,
+			EpochProcessed:        state.Epoch,
 			PublicKey:             deposit.Pubkey,
 			WithdrawalCredentials: deposit.WithdrawalCredentials,
 			Amount:                deposit.Amount,

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -46,6 +46,7 @@ func (p *ElectraMetrics) PreProcessBundle() {
 
 	if !p.baseMetrics.CurrentState.EmptyStateRoot() {
 		p.ProcessAttestations()
+		p.processPendingConsolidations(p.baseMetrics.NextState)
 		if !p.baseMetrics.PrevState.EmptyStateRoot() {
 			// block rewards
 			p.ProcessSlashings()
@@ -55,7 +56,6 @@ func (p *ElectraMetrics) PreProcessBundle() {
 			p.processDepositRequests()
 			p.GetMaxFlagIndexDeltas()
 			p.ProcessInclusionDelays()
-			p.processPendingConsolidations(p.baseMetrics.NextState)
 		}
 	}
 }
@@ -607,6 +607,7 @@ func (p ElectraMetrics) processPendingConsolidations(s *spec.AgnosticState) {
 
 		sourceEffectiveBalance := min(s.Balances[pendingConsolidation.SourceIndex], sourceValidator.EffectiveBalance)
 		consolidationProcessed.ConsolidatedAmount = sourceEffectiveBalance
+		s.ConsolidatedAmounts[pendingConsolidation.TargetIndex] += sourceEffectiveBalance
 		s.ConsolidationsProcessed = append(s.ConsolidationsProcessed, *consolidationProcessed)
 		s.ConsolidationsProcessedAmount += sourceEffectiveBalance
 	}

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -55,8 +55,9 @@ type AgnosticState struct {
 	PendingConsolidations         []*electra.PendingConsolidation
 	PendingPartialWithdrawals     []*electra.PendingPartialWithdrawal
 	ConsolidationsProcessed       []ConsolidationProcessed
-	ConsolidationsProcessedAmount phase0.Gwei             // total amount of Gwei consolidated
-	NewExitingValidators          []phase0.ValidatorIndex // list of validators that are exiting due to consolidation/withdrawal requests, used for tracking errors of a validator trying to consolidate/withdraw twice on same epoch.
+	ConsolidationsProcessedAmount phase0.Gwei                           // total amount of Gwei consolidated
+	NewExitingValidators          []phase0.ValidatorIndex               // list of validators that are exiting due to consolidation/withdrawal requests, used for tracking errors of a validator trying to consolidate/withdraw twice on same epoch.
+	ConsolidatedAmounts           map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to consolidated amount
 }
 
 func GetCustomState(bstate spec.VersionedBeaconState, duties EpochDuties) (AgnosticState, error) {
@@ -105,6 +106,7 @@ func (p *AgnosticState) Setup() error {
 	p.ConsolidationRequests = make([]ConsolidationRequest, 0)
 	p.ConsolidationsProcessed = make([]ConsolidationProcessed, 0)
 	p.NewExitingValidators = make([]phase0.ValidatorIndex, 0)
+	p.ConsolidatedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	return nil
 }
 

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -43,6 +43,7 @@ type AgnosticState struct {
 	DepositsNum                  uint64                       // number of deposits
 	TotalDepositsAmount          phase0.Gwei                  // total amount of deposits
 	CurrentJustifiedCheckpoint   phase0.Checkpoint            // the latest justified checkpoint
+	CurrentFinalizedCheckpoint   phase0.Checkpoint            // the latest finalized checkpoint
 	LatestBlockHeader            *phase0.BeaconBlockHeader
 	SyncCommitteeParticipation   uint64 // Tracks sync committee participation
 	NewProposerSlashings         int    // number of new proposer slashings
@@ -58,6 +59,12 @@ type AgnosticState struct {
 	ConsolidationsProcessedAmount phase0.Gwei                           // total amount of Gwei consolidated
 	NewExitingValidators          []phase0.ValidatorIndex               // list of validators that are exiting due to consolidation/withdrawal requests, used for tracking errors of a validator trying to consolidate/withdraw twice on same epoch.
 	ConsolidatedAmounts           map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to consolidated amount
+	PendingDeposits               []*electra.PendingDeposit
+	DepositsProcessed             []Deposit
+	DepositedAmounts              map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to deposited amount (used for Electra Fork)
+	DepositBalanceToConsume       phase0.Gwei                           // balance to consume for deposits, used for Electra Fork
+	Eth1DepositIndex              uint64                                // index of the next deposit request to be processed, used for Electra Fork
+	DepositRequestsStartIndex     uint64                                // index of the next deposit request to be processed, used for Electra Fork
 }
 
 func GetCustomState(bstate spec.VersionedBeaconState, duties EpochDuties) (AgnosticState, error) {
@@ -107,6 +114,7 @@ func (p *AgnosticState) Setup() error {
 	p.ConsolidationsProcessed = make([]ConsolidationProcessed, 0)
 	p.NewExitingValidators = make([]phase0.ValidatorIndex, 0)
 	p.ConsolidatedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	p.DepositedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	return nil
 }
 
@@ -523,6 +531,11 @@ func NewElectraState(bstate spec.VersionedBeaconState, duties EpochDuties) Agnos
 		LatestBlockHeader:          bstate.Electra.LatestBlockHeader,
 		PendingConsolidations:      bstate.Electra.PendingConsolidations,
 		PendingPartialWithdrawals:  bstate.Electra.PendingPartialWithdrawals,
+		DepositBalanceToConsume:    bstate.Electra.DepositBalanceToConsume,
+		PendingDeposits:            bstate.Electra.PendingDeposits,
+		CurrentFinalizedCheckpoint: *bstate.Electra.FinalizedCheckpoint,
+		Eth1DepositIndex:           bstate.Electra.ETH1DepositIndex,
+		DepositRequestsStartIndex:  bstate.Electra.DepositRequestsStartIndex,
 	}
 
 	electraObj.Setup()

--- a/pkg/spec/utils.go
+++ b/pkg/spec/utils.go
@@ -28,6 +28,11 @@ type BlockRewardsContent struct {
 	AttesterSlashings uint64 `json:"attester_slashings,string"`
 }
 
+// https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
+func ComputeStartSlotAtEpoch(epoch phase0.Epoch) phase0.Slot {
+	return phase0.Slot(uint64(epoch) * SlotsPerEpoch)
+}
+
 func FirstSlotInEpoch(slot phase0.Slot) phase0.Slot {
 	return slot / SlotsPerEpoch * SlotsPerEpoch
 }


### PR DESCRIPTION
# Description
This fixes the issue #187 by tracking consolidated and deposited amounts per validator and substracting it to the balance change (to obtain the reward).

To address the deposited amount, the new deposit processing logic introduced in electra was implemented. Now deposits processed are being inserted again in the `t_deposits` table.

## Schema changes
The deposit processing logic changed with the introduction of deposit requests on [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110). The deposits are now entered on a queue and then processed based on the deposit churn limit. This means that the `f_slot` field of the deposit is now the slot in which the deposit request was included in. A new column `f_epoch_processed` was added to track the epoch in which the deposit is processed. For deposits previous to the electra fork, `f_epoch_processed = f_slot // 32`.