### PR TITLE
Fix/track inactive vals in sync committee rewards

### DIFF
--- a/docs/tables.md
+++ b/docs/tables.md
@@ -174,6 +174,12 @@ The `f_withdrawal_prefix` column indicates the type of withdrawal credentials as
 
 Config: `engine = ReplacingMergeTree ORDER BY f_epoch, f_val_idx`
 
+This table stores the data of the rewards obtained by validators in the network. It will only have rows for validators that are either:
+
+- Active in the current epoch.
+- Inactive but with duties still assigned (edge case of validators that are in the sync committee but not active).
+- Slashed and not yet exited.
+
 | Column Name                              | Type of Data | Description                                                                                                           |
 | ---------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------- |
 | f_val_idx                                | uint64       | validator index                                                                                                       |


### PR DESCRIPTION
# Description

This PR contains a fix to an edge case of missing validators from the sync committee on the rewards table. On a rare (but very possible) scenario, validators can be assigned to participate in the sync committee and exit (before duties start or during the duty period). In this case, the validator can still participate in the protocol (while not being active) untill the sync committee period ends, and gain the corresponding rewards. To support this case, the table now contains rows for these validators. 