### PR TITLE
fix copylock warning and add tx idx

### DIFF
--- a/pkg/analyzer/metrics_test.go
+++ b/pkg/analyzer/metrics_test.go
@@ -324,12 +324,12 @@ func TestCapellaBlock(t *testing.T) {
 
 	tx := block.ExecutionPayload.Transactions[0]
 	receipt, err := blockAnalyzer.cli.GetTransactionReceipt(tx, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
-	var parsedTx = types.Transaction{}
+	var parsedTx = &types.Transaction{}
 	if err := parsedTx.UnmarshalBinary(tx); err != nil {
 		t.Errorf("could not unmarshal transaction: %s", err)
 		return
 	}
-	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp, uint64(0))
 
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)
@@ -393,13 +393,13 @@ func TestBellatrixBlock(t *testing.T) {
 	tx := block.ExecutionPayload.Transactions[0]
 
 	receipt, err := blockAnalyzer.cli.GetTransactionReceipt(tx, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
-	var parsedTx = types.Transaction{}
+	var parsedTx = &types.Transaction{}
 	if err := parsedTx.UnmarshalBinary(tx); err != nil {
 		t.Errorf("could not unmarshal transaction: %s", err)
 		return
 	}
 
-	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp, uint64(0))
 
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)
@@ -555,13 +555,13 @@ func TestTransactionGasWhenELIsProvided(t *testing.T) {
 		t.Errorf("could not retrieve transaction receipt: %s", err)
 		return
 	}
-	var parsedTx = types.Transaction{}
+	var parsedTx = &types.Transaction{}
 	if err := parsedTx.UnmarshalBinary(tx); err != nil {
 		t.Errorf("could not unmarshal transaction: %s", err)
 		return
 	}
 
-	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp, uint64(0))
 
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)
@@ -595,13 +595,13 @@ func TestTransactionGasWhenELNotProvided(t *testing.T) {
 		t.Errorf("could not retrieve transaction receipt: %s", err)
 		return
 	}
-	var parsedTx = types.Transaction{}
+	var parsedTx = &types.Transaction{}
 	if err := parsedTx.UnmarshalBinary(tx); err != nil {
 		t.Errorf("could not unmarshal transaction: %s", err)
 		return
 	}
 
-	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp)
+	transaction, err := spec.ParseTransactionFromReceipt(parsedTx, receipt, block.Slot, block.ExecutionPayload.BlockNumber, block.ExecutionPayload.Timestamp, uint64(0))
 
 	if err != nil {
 		t.Errorf("could not retrieve transaction details: %s", err)

--- a/pkg/db/transactions.go
+++ b/pkg/db/transactions.go
@@ -9,6 +9,7 @@ var (
 	transactionsTable       = "t_transactions"
 	insertTransactionsQuery = `
 		INSERT INTO %s(
+			f_tx_idx,
 			f_tx_type, 
 			f_chain_id, 
 			f_data, f_gas, 
@@ -40,6 +41,7 @@ var (
 func transactionsInput(transactions []spec.AgnosticTransaction) proto.Input {
 	// one object per column
 	var (
+		f_tx_idx           proto.ColUInt64
 		f_tx_type          proto.ColUInt64
 		f_chain_id         proto.ColUInt64
 		f_data             proto.ColStr
@@ -64,7 +66,7 @@ func transactionsInput(transactions []spec.AgnosticTransaction) proto.Input {
 	)
 
 	for _, transaction := range transactions {
-
+		f_tx_idx.Append(transaction.TxIdx)
 		f_tx_type.Append(uint64(transaction.TxType))
 		f_chain_id.Append(uint64(transaction.ChainId))
 		f_data.Append(transaction.Data)
@@ -95,7 +97,7 @@ func transactionsInput(transactions []spec.AgnosticTransaction) proto.Input {
 	}
 
 	return proto.Input{
-
+		{Name: "f_tx_idx", Data: f_tx_idx},
 		{Name: "f_tx_type", Data: f_tx_type},
 		{Name: "f_chain_id", Data: f_chain_id},
 		{Name: "f_data", Data: f_data},


### PR DESCRIPTION
This pull request introduces changes to enhance transaction parsing and database handling by adding support for transaction indices (`TxIdx`) and refactoring code to use pointers for transactions. The updates improve the functionality and maintainability of the codebase.

### Enhancements to transaction parsing:

* Added `TxIdx` (transaction index in the block) as a new field in the `AgnosticTransaction` struct in `pkg/spec/transactions.go`. This provides additional context for transactions within a block.
* Updated `ParseTransactionsFromBlock` and `ParseTransactionFromReceipt` functions in `pkg/spec/transactions.go` to include `TxIdx` in transaction parsing logic. This ensures that transaction indices are correctly propagated and utilized. [[1]](diffhunk://#diff-934187c42ad0096b1e1d29d0affe37ffd79ad366ec1b6a91a3b01ea7d712e23cL58-R59) [[2]](diffhunk://#diff-934187c42ad0096b1e1d29d0affe37ffd79ad366ec1b6a91a3b01ea7d712e23cL67-R73) [[3]](diffhunk://#diff-934187c42ad0096b1e1d29d0affe37ffd79ad366ec1b6a91a3b01ea7d712e23cL84-R94) [[4]](diffhunk://#diff-934187c42ad0096b1e1d29d0affe37ffd79ad366ec1b6a91a3b01ea7d712e23cR122)
* Refactored transaction-related test cases in `pkg/analyzer/metrics_test.go` to use pointers (`*types.Transaction`) instead of value types for transactions. This aligns with the updated parsing logic. [[1]](diffhunk://#diff-2db67d984a6b55e7f95bdab9d1d909a14ed5603008dfb5240b7d16963be9f4c2L327-R332) [[2]](diffhunk://#diff-2db67d984a6b55e7f95bdab9d1d909a14ed5603008dfb5240b7d16963be9f4c2L396-R402) [[3]](diffhunk://#diff-2db67d984a6b55e7f95bdab9d1d909a14ed5603008dfb5240b7d16963be9f4c2L558-R564) [[4]](diffhunk://#diff-2db67d984a6b55e7f95bdab9d1d909a14ed5603008dfb5240b7d16963be9f4c2L598-R604)

### Database handling updates:

* Added support for storing `TxIdx` in the database by introducing a new column (`f_tx_idx`) in `pkg/db/transactions.go`. This allows transaction indices to be persisted. [[1]](diffhunk://#diff-5f595b4f69b4a6d307de63df4038fa45f2a10e1e8b36be3313db95d58318f2d1R12) [[2]](diffhunk://#diff-5f595b4f69b4a6d307de63df4038fa45f2a10e1e8b36be3313db95d58318f2d1R44) [[3]](diffhunk://#diff-5f595b4f69b4a6d307de63df4038fa45f2a10e1e8b36be3313db95d58318f2d1L67-R69) [[4]](diffhunk://#diff-5f595b4f69b4a6d307de63df4038fa45f2a10e1e8b36be3313db95d58318f2d1L98-R100)