### PR TITLE
v3.8.1

### DIFF
--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -54,7 +54,7 @@ type ChainAnalyzer struct {
 	downloadCache                    ChainCache // store the blocks and states downloaded
 	validatorsRewardsAggregations   map[phase0.ValidatorIndex]*spec.ValidatorRewardsAggregation
 	validatorsRewardsAggregationsMu sync.Mutex
-	aggregatedEpochsInWindow        int // tracks how many epochs have been aggregated in the current window
+	aggregatedEpochsInWindow        map[phase0.Epoch]bool // set of unique epochs aggregated in current window; prevents double-counting on reprocessing (#255)
 	epochBoundaryStateRoots       sync.Map   // slot -> phase0.Root, caches state roots from Head SSE events at epoch boundaries
 
 	initTime    time.Time
@@ -177,6 +177,7 @@ func NewChainAnalyzer(
 		PromMetrics:                   promethMetrics,
 		downloadCache:                 NewQueue(),
 		validatorsRewardsAggregations: make(map[phase0.ValidatorIndex]*spec.ValidatorRewardsAggregation),
+		aggregatedEpochsInWindow:      make(map[phase0.Epoch]bool),
 		processerBook:                 utils.NewRoutineBook(32, "processer"), // one whole epoch
 		wgMainRoutine:                 &sync.WaitGroup{},
 		wgDownload:                    &sync.WaitGroup{},

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -182,6 +182,36 @@ func (s *ChainAnalyzer) processTransactions(block *spec.AgnosticBlock, receipts 
 	return err
 }
 
+// recoverBlockReceipts retries fetching EL receipts for blocks where
+// ProcessETH1Data failed to populate AgnosticTransactions.
+// Called from processBlockRewards as a second chance before fee calculation.
+// See https://github.com/migalabs/goteth/issues/251
+func (s *ChainAnalyzer) recoverBlockReceipts(block *spec.AgnosticBlock) {
+	if len(block.ExecutionPayload.AgnosticTransactions) > 0 {
+		return // already populated
+	}
+	if len(block.ExecutionPayload.Transactions) == 0 {
+		return // no transactions in block
+	}
+	if !s.metrics.Transactions {
+		return // transactions metric not enabled
+	}
+
+	log.Warnf("slot %d: retrying receipt fetch for block reward calculation", block.Slot)
+	receipts, err := s.cli.GetBlockReceipts(*block)
+	if err != nil {
+		log.Errorf("slot %d: receipt recovery failed: %s", block.Slot, err)
+		return
+	}
+	txs, err := spec.ParseTransactionsFromBlock(*block, receipts)
+	if err != nil {
+		log.Errorf("slot %d: transaction parse failed during recovery: %s", block.Slot, err)
+		return
+	}
+	block.ExecutionPayload.AgnosticTransactions = txs
+	log.Infof("slot %d: recovered %d transaction receipts for fee calculation", block.Slot, len(txs))
+}
+
 func (s *ChainAnalyzer) processBlobSidecars(block *spec.AgnosticBlock, txs []spec.AgnosticTransaction) {
 	var blobs []*spec.AgnosticBlobSidecar
 	var err error

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -357,6 +357,10 @@ func (s *ChainAnalyzer) processBlockRewards(bundle metrics.StateMetrics) {
 		slotKey := fmt.Sprintf("%s%d", slotProcesserTag, block.Slot)
 		s.processerBook.WaitUntilInactive(slotKey)
 
+		// Retry fetching receipts if ProcessBlock failed to get them.
+		// By now the EL may have recovered from the transient issue (#251).
+		s.recoverBlockReceipts(block)
+
 		blockRewards = append(blockRewards, s.getSingleBlockRewards(*block, mevBids))
 	}
 

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -298,27 +298,42 @@ func (s *ChainAnalyzer) processEpochValRewards(bundle metrics.StateMetrics) {
 	if s.rewardsAggregationEpochs > 1 {
 		s.validatorsRewardsAggregationsMu.Lock()
 
-		for _, maxRewards := range insertValsObj {
-			valIdx := maxRewards.ValidatorIndex
-			if _, ok := s.validatorsRewardsAggregations[valIdx]; !ok {
-				s.validatorsRewardsAggregations[valIdx] = spec.NewValidatorRewardsAggregation(valIdx, s.startEpochAggregation, s.endEpochAggregation)
-			}
-			s.validatorsRewardsAggregations[valIdx].Aggregate(maxRewards)
-		}
+		epoch := bundle.GetMetricsBase().NextState.Epoch
 
-		s.aggregatedEpochsInWindow++
+		// Only aggregate if:
+		//  1. The epoch belongs to the current window (rejects stale epochs
+		//     from already-flushed windows reprocessed by AdvanceFinalized).
+		//  2. The epoch hasn't been aggregated yet (rejects duplicate calls
+		//     for the same epoch, e.g. AdvanceFinalized reprocessing an epoch
+		//     that the normal flow already handled). Using a set of seen
+		//     epochs instead of a counter prevents the cumulative window
+		//     shift described in #255.
+		inWindow := epoch >= s.startEpochAggregation && epoch <= s.endEpochAggregation
+		_, alreadySeen := s.aggregatedEpochsInWindow[epoch]
 
-		if s.aggregatedEpochsInWindow >= s.rewardsAggregationEpochs {
-			if len(s.validatorsRewardsAggregations) > 0 {
-				err := s.dbClient.PersistValidatorRewardsAggregation(s.validatorsRewardsAggregations)
-				if err != nil {
-					log.Fatalf("error persisting validator rewards aggregation: %s", err.Error())
+		if inWindow && !alreadySeen {
+			for _, maxRewards := range insertValsObj {
+				valIdx := maxRewards.ValidatorIndex
+				if _, ok := s.validatorsRewardsAggregations[valIdx]; !ok {
+					s.validatorsRewardsAggregations[valIdx] = spec.NewValidatorRewardsAggregation(valIdx, s.startEpochAggregation, s.endEpochAggregation)
 				}
+				s.validatorsRewardsAggregations[valIdx].Aggregate(maxRewards)
 			}
-			s.validatorsRewardsAggregations = make(map[phase0.ValidatorIndex]*spec.ValidatorRewardsAggregation)
-			s.startEpochAggregation = s.endEpochAggregation + 1
-			s.endEpochAggregation = s.endEpochAggregation + phase0.Epoch(s.rewardsAggregationEpochs)
-			s.aggregatedEpochsInWindow = 0
+
+			s.aggregatedEpochsInWindow[epoch] = true
+
+			if len(s.aggregatedEpochsInWindow) >= s.rewardsAggregationEpochs {
+				if len(s.validatorsRewardsAggregations) > 0 {
+					err := s.dbClient.PersistValidatorRewardsAggregation(s.validatorsRewardsAggregations)
+					if err != nil {
+						log.Fatalf("error persisting validator rewards aggregation: %s", err.Error())
+					}
+				}
+				s.validatorsRewardsAggregations = make(map[phase0.ValidatorIndex]*spec.ValidatorRewardsAggregation)
+				s.startEpochAggregation = s.endEpochAggregation + 1
+				s.endEpochAggregation = s.endEpochAggregation + phase0.Epoch(s.rewardsAggregationEpochs)
+				s.aggregatedEpochsInWindow = make(map[phase0.Epoch]bool)
+			}
 		}
 
 		s.validatorsRewardsAggregationsMu.Unlock()

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -50,13 +50,20 @@ func (s *ChainAnalyzer) runHead() {
 	log.Info("launching head routine")
 	nextSlotDownload := s.fillToHead()
 
-	// Wait for ALL blocks in the historical range to be downloaded, not
-	// just the last one. With parallel workers, blocks are downloaded
-	// out of order — the last slot may be ready while intermediate slots
-	// are still in-flight. Without this, the switch to head mode drops
-	// those pending downloads and the processer deadlocks. (#248)
-	log.Infof("waiting for all historical blocks (%d to %d) to complete...", s.initSlot, nextSlotDownload)
-	for slot := s.initSlot; slot <= nextSlotDownload; slot++ {
+	// Wait for blocks that may still be in-flight. During historical
+	// processing, CleanUpTo evicts blocks older than 5 epochs, so only
+	// blocks within the last 5 epochs can still be pending. Waiting from
+	// initSlot would deadlock on evicted blocks (#253), and skipping via
+	// Available() would miss in-flight downloads (#248).
+	waitFrom := nextSlotDownload
+	if nextSlotDownload > 5*spec.SlotsPerEpoch {
+		waitFrom = nextSlotDownload - 5*spec.SlotsPerEpoch
+	}
+	if waitFrom < s.initSlot {
+		waitFrom = s.initSlot
+	}
+	log.Infof("waiting for remaining historical blocks (%d to %d) to complete...", waitFrom, nextSlotDownload)
+	for slot := waitFrom; slot <= nextSlotDownload; slot++ {
 		if _, err := s.downloadCache.BlockHistory.Wait(s.ctx, SlotTo[uint64](slot)); err != nil {
 			log.Errorf("context cancelled waiting for block at slot %d: %s", slot, err)
 			return

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -3,7 +3,7 @@ package utils
 import "time"
 
 const (
-	Version                = "v3.8.0"
+	Version                = "v3.8.1"
 	CliName                = "GotEth"
 	RoutineFlushTimeout    = time.Duration(1 * time.Second)
 	AcquireWaitIntervalLog = 1 * time.Minute


### PR DESCRIPTION
## Summary

- fix: limit historical block wait to last 5 epochs (#253)
- fix: retry receipt fetch in processBlockRewards before fee calculation (#251)
- fix: use epoch set instead of counter for aggregation window flush (#255)

🤖 Generated with [Claude Code](https://claude.com/claude-code)