### PR TITLE
docs: streamline contribution guide and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,9 +11,7 @@ body:
         will be asked for the missing information before any investigation starts.
 
         Before filing, please:
-        - Read the [Recurring gotchas](https://github.com/migalabs/goteth/blob/master/CLAUDE.md#6-recurring-gotchas) section.
         - Search [existing issues](https://github.com/migalabs/goteth/issues?q=is%3Aissue) for prior discussion.
-        - For data-quality bugs against `t_validator_rewards_summary`, follow the checklist in `CLAUDE.md` §6.2.
 
   - type: input
     id: version
@@ -124,8 +122,6 @@ body:
     attributes:
       label: Pre-flight checks
       options:
-        - label: I have read the recurring gotchas in `CLAUDE.md` §6.
-          required: true
         - label: I have searched existing issues and PRs.
           required: true
         - label: My GotEth binary was built after 2026-02-20 (post-Electra consolidation rework) — or I have already retested on `master`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,6 @@ _Related links:_
 <!--
 How the change works. Major structural changes, new packages or tables, new flags.
 Call out any non-obvious decisions and the alternatives you rejected.
-If the change touches reward math, reorg handling, or ClickHouse mutation paths,
-explicitly cite the relevant CLAUDE.md section you reviewed.
 -->
 
 ## Type of change
@@ -78,7 +76,6 @@ the indexer pipeline, include at least one run against a live beacon endpoint.
 ## Documentation
 - [ ] `README.md` updated (if user-facing flag, install, or run change)
 - [ ] `docs/tables.md` updated (if persisted schema change)
-- [ ] `CLAUDE.md` updated (if recurring gotcha or mental-model change)
 - [ ] Inline comments added where the *why* is non-obvious
 
 ## Backwards compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,10 +113,6 @@ A high-quality bug report contains:
   this by querying the beacon node directly". This helps the reviewer skip
   suggestions you already ruled out.
 
-For data-quality bugs against `t_validator_rewards_summary`, follow the checklist
-in `CLAUDE.md` §6.2 ("`f_reward > f_max_reward` investigation pattern") before
-filing — most reports fall into a known pattern documented there.
-
 ## Proposing a Feature
 
 Open a [feature request](https://github.com/migalabs/goteth/issues/new?template=feature_request.yml).
@@ -144,7 +140,7 @@ Include:
 3. **Match the existing style**. Run `gofmt`, keep package layout consistent, do
    not introduce new third-party dependencies without justification.
 4. **Update documentation**. If you change a CLI flag, schema, or behavior, update
-   `README.md`, `docs/tables.md`, and `CLAUDE.md` in the same PR.
+   `README.md` and `docs/tables.md` in the same PR.
 5. **Add or update tests** (see [Testing Requirements](#testing-requirements)).
 6. **Run the full suite locally** before pushing: `go test ./...` plus the relevant
    Python integration tests under `tests/`.
@@ -209,7 +205,7 @@ When in doubt, smaller is better. A 200-line PR that lands in two days beats a
 
 | Change type | Minimum required |
 |---|---|
-| Reward math (any file under `pkg/spec/metrics/`) | Unit test that drives `EpochReward` with a known synthetic state and asserts the expected gwei value. **Reward changes will not be merged without a test.** See `CLAUDE.md` §5 and §7. |
+| Reward math (any file under `pkg/spec/metrics/`) | Unit test that drives `EpochReward` with a known synthetic state and asserts the expected gwei value. **Reward changes will not be merged without a test.** |
 | Reorg / lock model (`pkg/analyzer/`) | Unit test reproducing the failure mode if it is a fix. The existing `pkg/analyzer/reorg_deadlock_test.go` is the canonical example. |
 | New persisted table | A round-trip integration test under `tests/` that writes a row and reads it back. Update `docs/tables.md`. |
 | New CLI flag | The flag must round-trip through `pkg/config` defaults and be listed in `cmd/<command>.go`. Manual run output in the PR is sufficient — no unit test required. |


### PR DESCRIPTION
## Summary

Trim internal-only references from `CONTRIBUTING.md`, `.github/pull_request_template.md`, and `.github/ISSUE_TEMPLATE/bug_report.yml` so the public-facing docs only point at files that actually exist in the repository.

Concretely:

- **CONTRIBUTING.md** — drop the data-quality-bug paragraph that referenced an internal section, drop the doc-update reference to a file not in the repo, and drop the testing-table footnote pointer.
- **PR template** — drop the "explicitly cite the section you reviewed" line in *Description* and the corresponding documentation checkbox.
- **Bug-report issue template** — drop the "Recurring gotchas" link in the markdown intro, drop the `t_validator_rewards_summary` checklist line, and drop the matching pre-flight checkbox.

## Why

Several of the original references pointed at sections / files that aren't tracked in this repository, so external contributors landing on those links would hit dead ends. Keeping the docs limited to the files actually in `master` avoids that confusion.

## Test plan

- [ ] Render `CONTRIBUTING.md` on GitHub and confirm there are no broken links.
- [ ] Open the bug-report and feature-request issue templates from the *New issue* picker and confirm the forms render correctly.
- [ ] Open a draft PR against this branch and confirm the PR template renders correctly.

## Out of scope

No code or schema changes. No CI changes. No dependency updates.