### PR TITLE
Fix advance finalized redownload

### DIFF
--- a/pkg/analyzer/reorg.go
+++ b/pkg/analyzer/reorg.go
@@ -50,6 +50,7 @@ func (s *ChainAnalyzer) AdvanceFinalized(newFinalizedSlot phase0.Slot) {
 
 				s.dbClient.DeleteBlockMetrics(phase0.Slot(slot))
 				log.Infof("rewriting metrics for slot %d", slot)
+				s.DownloadBlock(phase0.Slot(slot))
 				s.ProcessBlock(phase0.Slot(slot))
 				blocksChanged = true
 			}


### PR DESCRIPTION
## Motivation
Blocks that arrive at the beacon node after goteth's retry limit (3 attempts × 500ms = 1.5s window in `RequestBeaconBlock`) are persisted as missed: `t_block_metrics(f_proposed=false)` with an empty placeholder in the in-memory cache (block root `0x000...000`).

Two epochs later, `AdvanceFinalized` runs its cmpHash check, sees the cache root differs from the finalized root, and triggers a metrics rewrite. The rewrite calls `ProcessBlock(slot)`, which reads the same stale placeholder from cache, so the block gets re-persisted as missed despite being canonical on chain. The slot stays wrong indefinitely.

The symmetric path in `HandleReorg` already does `DownloadBlock` before `ProcessBlock`. `AdvanceFinalized` is missing that one call.

_Related links:_

## Description
Add `s.DownloadBlock(phase0.Slot(slot))` immediately before `s.ProcessBlock(phase0.Slot(slot))` in `pkg/analyzer/reorg.go` `AdvanceFinalized` (one-line change). The download fetches the canonical block fresh from the beacon node and inserts it into the cache, so `ProcessBlock` reads the right payload during the rewrite.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (CLI flag rename, schema change, behavior change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup
- [ ] Performance improvement

## Tasks
<!-- Checklist of in-PR tasks. Tick as you complete them. -->
- [x] Add `DownloadBlock` call before `ProcessBlock` in the metrics-rewrite path
- [x] Verified deployed: log lines now show `block at slot N downloaded` between `rewriting metrics for slot` and `ProcessBlock`

## Testing
`go build ./... `

Manual end-to-end verification via SQL contradiction query (see Proof of Success). The bug is timing-dependent (requires a block to arrive late, then finalize) and not unit-testable without mocking the beacon API and clock.

## Reproduction steps (for bug fixes)
1. Run goteth in head mode with --max-request-retries 1 to shrink the retry window and make propagation-delay 404s easy to trigger: goteth blocks --download-mode head --max-request-retries 1 ...
2. Watch for slots that get marked f_proposed=false due to the 404. Wait for them to finalize (~2 epochs later).
3. Observe in logs:
rewriting metrics for slot N
cache block root: 0x000...000
finalized block root: 0x...
4.  No block at slot N downloaded line between rewrite and process.
5. Query the slot:
`SELECT f_proposed, f_el_block_hash FROM t_block_metrics FINAL WHERE f_slot = N`
6. Returns f_proposed=false despite the canonical block existing on chain.

## Mitigation options considered
- Force cache eviction before reprocess: heavier change, touches more paths, only addresses this one symptom.
- Skip the rewrite entirely and rely on the next finalized round: doesn't help, every subsequent round reads the same stale cache.
- Increase RequestBeaconBlock retry window: orthogonal, treats the symptom (late blocks) not the bug (broken repair path).

## Proof of Success
Pre-fix log (slot 14177568, 2026-04-23):
time="2026-04-23T15:05:59Z" level=info  msg="rewriting metrics for slot 14177568"
time="2026-04-23T15:05:59Z" level=warn  msg="cache block root: 0x000...000\nfinalized block root: 0xff2c2216..."
time="2026-04-23T15:05:59Z" level=warn  msg="block root for block (slot=14177569) incorrect, redownload"
No download between rewrite and process. Cache placeholder gets re-persisted.

Post-fix log (slot 14211072, 2026-04-28):
time="2026-04-28T06:15:22Z" level=info msg="rewriting metrics for slot 14211072"
time="2026-04-28T06:15:23Z" level=info msg="block at slot 14211071 downloaded in 0.199655 seconds"
Download now happens between rewrite and process.

Database contradiction query counts rows where t_block_metrics says missed but t_block_rewards recorded non-zero fees (impossible if not proposed):
```
SELECT count() AS contradicted
FROM t_block_metrics m FINAL
INNER JOIN t_block_rewards r FINAL ON m.f_slot = r.f_slot
WHERE m.f_proposed = false
  AND r.f_reward_fees != '0'
```
- Before fix + backfill: ~2000 rows
- After fix + backfill: 2 rows (those 2 trace to a separate HandleReorg bug, follow-up issue)

## Documentation
- [ ] `README.md` updated (if user-facing flag, install, or run change)
- [ ] `docs/tables.md` updated (if persisted schema change)
- [ ] Inline comments added where the *why* is non-obvious

## Backwards compatibility
No flag, schema, or behavior change. The fix only adds a download step that should already be there by symmetry with HandleReorg.

## Reviewer notes
- Symmetric path in HandleReorg (line 187) already does DownloadBlock before Wait. This brings AdvanceFinalized in line.
- A separate HandleReorg follow-up will be filed: it deletes/reprocesses t_block_metrics on reorg but doesn't re-trigger processBlockRewards, leaving stale fee values in t_block_rewards. That's the source of the 2 leftover contradicted rows.