### PR TITLE
Fix fillToHead deadlock

### DIFF
--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -175,12 +175,8 @@ func (s *ChainAnalyzer) fillToHead() phase0.Slot {
 
 	log.Infof("filling to head...")
 
-	// Loop historical mode until the gap to live head is small enough for
-	// runHead's incremental dispatch to handle. A single historical pass
-	// can take long enough that the chain head moves by many epochs in the
-	// meantime; runHead's catch-up loop then saturates the processerBook
-	// and stalls. Re-checking head and looping ensures we hand off to
-	// runHead with a manageable gap.
+	// Re-run historical if the chain head moved more than an epoch
+	// during the previous pass. Hands off to runHead with a small gap.
 	for {
 		s.wgMainRoutine.Add(1) // add because historical will defer it
 		s.runHistorical(nextSlotDownload, headSlot)

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -189,7 +189,7 @@ func (s *ChainAnalyzer) fillToHead() phase0.Slot {
 		newHead := s.cli.RequestCurrentHead()
 		handoffThreshold := headSlot + phase0.Slot(spec.SlotsPerEpoch)
 		if newHead <= handoffThreshold {
-			return newHead
+			return headSlot
 		}
 		log.Infof("head moved %d slots during catch-up, looping historical", newHead-headSlot)
 		headSlot = newHead

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -174,9 +174,26 @@ func (s *ChainAnalyzer) fillToHead() phase0.Slot {
 	s.endEpochAggregation = s.startEpochAggregation + phase0.Epoch(s.rewardsAggregationEpochs-1)
 
 	log.Infof("filling to head...")
-	s.wgMainRoutine.Add(1) // add because historical will defer it
-	s.runHistorical(nextSlotDownload, headSlot)
-	return headSlot
+
+	// Loop historical mode until the gap to live head is small enough for
+	// runHead's incremental dispatch to handle. A single historical pass
+	// can take long enough that the chain head moves by many epochs in the
+	// meantime; runHead's catch-up loop then saturates the processerBook
+	// and stalls. Re-checking head and looping ensures we hand off to
+	// runHead with a manageable gap.
+	for {
+		s.wgMainRoutine.Add(1) // add because historical will defer it
+		s.runHistorical(nextSlotDownload, headSlot)
+
+		nextSlotDownload = headSlot + 1
+		newHead := s.cli.RequestCurrentHead()
+		handoffThreshold := headSlot + phase0.Slot(spec.SlotsPerEpoch)
+		if newHead <= handoffThreshold {
+			return newHead
+		}
+		log.Infof("head moved %d slots during catch-up, looping historical", newHead-headSlot)
+		headSlot = newHead
+	}
 }
 
 func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -175,15 +175,34 @@ func (s *ChainAnalyzer) fillToHead() phase0.Slot {
 
 	log.Infof("filling to head...")
 
-	// Re-run historical if the chain head moved more than an epoch
+	// Re-run historical if the chain head moved more than half an epoch
 	// during the previous pass. Hands off to runHead with a small gap.
+	//
+	// The handoff gap is half SlotsPerEpoch (not the full epoch) because
+	// processerBook is sized to SlotsPerEpoch (see NewChainAnalyzer in
+	// chain_analyzer.go). Returning with a gap equal to the pool capacity
+	// lets runHead's first enqueue burst saturate the pool immediately;
+	// any cross-epoch BlockHistory.Wait dependency in the first batch of
+	// ProcessStateTransitionMetrics goroutines then deadlocks the pool —
+	// the exact failure mode this loop was added to avoid in the first
+	// place. Half an epoch leaves room for those dependencies to drain.
+	handoffGapSlots := phase0.Slot(spec.SlotsPerEpoch / 2)
 	for {
 		s.wgMainRoutine.Add(1) // add because historical will defer it
 		s.runHistorical(nextSlotDownload, headSlot)
 
+		// runHistorical returns immediately when s.stop is set. Without
+		// this guard the outer loop would re-query the head and call
+		// runHistorical again — and since the chain keeps advancing,
+		// handoffThreshold is always exceeded and the loop spins
+		// indefinitely on shutdown.
+		if s.stop {
+			return headSlot
+		}
+
 		nextSlotDownload = headSlot + 1
 		newHead := s.cli.RequestCurrentHead()
-		handoffThreshold := headSlot + phase0.Slot(spec.SlotsPerEpoch)
+		handoffThreshold := headSlot + handoffGapSlots
 		if newHead <= handoffThreshold {
 			return headSlot
 		}


### PR DESCRIPTION
## Motivation
After a long historical backfill, `fillToHead` returns the original `headSlot` it queried at the start and hands off to `runHead`. If the chain has moved forward more than `SlotsPerEpoch` during the backfill, `runHead` starts with a gap larger than the processer pool can safely absorb.

`runHead`'s tight loop tries to enqueue every slot between the old `nextSlotDownload` and the current head SSE event:
```go
for nextSlotDownload <= event.HeadEvent.Slot {
    if s.processerBook.NumFreePages() > 0 {
        s.downloadTaskChan <- nextSlotDownload
        nextSlotDownload++
    }
}
```

When the gap is hundreds or thousands of slots wide, every page in `processerBook` ends up held by `ProcessBlock/ProcessStateTransitionMetrics` goroutines that are blocked on `BlockHistory.Wait` for cross-epoch dependencies (state metrics for epoch E need blocks from epoch E-1, which are still in flight). No page ever frees, the loop spins forever, and the head channel is never drained. Goteth deadlocks until restart.

The symptom is repeated Waiting for too long to acquire page slot=N and Waiting for spec.AgnosticBlock M warnings on the same slots over many minutes.

Keeping the historical-to-head handoff gap below one epoch keeps the page demand bounded so the deadlock cannot form.

_Related links:_

## Description
Wrap the `runHistorical` call in `fillToHead` with a loop that re-queries `RequestCurrentHead` after each pass. If the new head is more than SlotsPerEpoch ahead of the previous headSlot, run another historical pass for the gap. Once the gap is within one epoch, return and let runHead take over.

## Type of change
- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (CLI flag rename, schema change, behavior change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup
- [ ] Performance improvement

## Tasks
- [ ] Add loop around runHistorical
- [ ] Re-query head after each pass
- [ ] Handoff threshold of SlotsPerEpoch
- [ ] Verified deployed: logs show convergence (large gap, smaller gap, handoff)

## Testing
`go build ./...`

End-to-end verified on production. The deadlock requires real backpressure on processerBook plus chain advancement during backfill, so unit-testing means mocking the beacon client, SSE stream, and processer pool together.

## Reproduction steps (for bug fixes)
1. Run goteth, then stop it for a few few hours.
2. Restart goteth.
3. While runHistorical runs, the chain advances by another K slots beyond the start-time head.
4. When runHistorical returns, runHead takes over with a K-slot gap.
5. If K is large enough (in practice, more than the processer pool size, ~hundreds of slots), the loop in runHead saturates processerBook and deadlocks. Logs show repeated `Waiting for too long to acquire page slot=N warnings` on the same slots over many minutes with no progress.

## Mitigation options considered
- Resize the processer pool: papers over the deadlock without fixing the root cause. A larger pool just shifts the threshold.
- Single re-check, no loop: insufficient when the historical pass itself takes long enough that the chain moves another epoch during the second pass.

## Proof of Success
Real run on 2026-05-01 showing the loop converging and handing off cleanly:

```
time="2026-05-01T02:24:13Z" level=info msg="head moved 1066 slots during catch-up, looping historical" module=analyzer
time="2026-05-01T02:24:13Z" level=info msg="Switch to historical mode: 14230453 - 14231518" module=analyzer
time="2026-05-01T02:48:49Z" level=info msg="historical mode: all download tasks sent" module=analyzer
time="2026-05-01T02:48:49Z" level=info msg="head moved 123 slots during catch-up, looping historical" module=analyzer
time="2026-05-01T02:48:49Z" level=info msg="Switch to historical mode: 14231519 - 14231641" module=analyzer
time="2026-05-01T02:51:46Z" level=info msg="historical mode: all download tasks sent" module=analyzer
time="2026-05-01T02:51:46Z" level=info msg="waiting for remaining historical blocks (14231481 to 14231641) to complete..." module=analyzer
time="2026-05-01T02:52:30Z" level=info msg="Switch to head mode: following chain head" module=analyzer
```

Three iterations: 1066-slot gap, 123-slot gap, then under one epoch so the handoff happens.

Pre-fix run that deadlocked (2026-04-28) shows the failure mode for comparison:

```
time="2026-04-28T05:57:24Z" level=warning msg="Waiting for spec.AgnosticBlock 14210688..." module=analyzer
time="2026-04-28T05:57:25Z" level=warning msg="Waiting for too long to acquire page slot=14210913..." bookTag=processer module=utils
time="2026-04-28T05:57:25Z" level=warning msg="Waiting for spec.AgnosticBlock 14210910..." module=analyzer
... (same warnings on the same slots repeating for 15+ minutes, no progress)
```

## Documentation
- [ ] `README.md` updated (if user-facing flag, install, or run change)
- [ ] `docs/tables.md` updated (if persisted schema change)
- [x] Inline comments added where the *why* is non-obvious

## Backwards compatibility
No

## Reviewer notes
- Handoff threshold is SlotsPerEpoch (32 slots, ~6.4 minutes). Small enough that runHead cannot saturate the processer pool, large enough to avoid edge cases where head moves a slot or two during the head re-query itself.
- The wait-group `Add(1)` is inside the loop because runHistorical does defer `s.wgMainRoutine.Done() `on entry. Each iteration is a self-contained add/done pair.