### PR TITLE
docs: fix authors formatting and add Current Maintainers section

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,22 +6,26 @@ Primary Authors
 * __[Mikel Cortes](https://github.com/cortze)__
 
 	@cortze is the researcher that started this project and had the idea to build a consensus layer data analyzer.
-	He started the code, built the basis and release a simple version of what today we call GotEth.
+	He started the code, built the basis and released a simple version of what today we call GotEth.
 
 * __[Tarun Mohandas](https://github.com/tdahar)__
 
-    @tdahar is the engineer that maintained the repository for a long time.
+	@tdahar is the engineer that maintained the repository for a long time.
 	He deployed new features, tested for bugs and ran the tool for internal analysis.
-	He did improve the tool from the simple first releases to most complex / complete logic.
+	He improved the tool from the simple first releases to the most complex / complete logic.
+
+Current Maintainers
+===================
 
 * __[Zyra V21](https://github.com/Zyra-V21)__
 
-* 	@Zyra-V21 is the engineer currently developing and maintaining GotEth.                                                                                                                                                                            
-  	He triages production reports, ships fixes against the live mainnet pipeline.
+	@Zyra-V21 is the engineer currently developing and maintaining GotEth.
+	He triages production reports and ships fixes against the live mainnet pipeline.
+	He continues to improve the tool, keeping it reliable and aligned with each network upgrade.
 
 * __[Leo Bautista-Gomez](https://github.com/leobago)__
 
-* 	@leobago is the repository main reviewer and release coordinator.
+	@leobago is the repository main reviewer and release coordinator.
 
 Other Contributors
 ==================
@@ -33,5 +37,4 @@ everyone who has contributed to the project in any way.
 * [Alejandro Laguna](https://github.com/alejandrolaguna20) — Fusaka blob support and toolchain bumps.
 * [Patrick Ocheja](https://github.com/ocheja)
 * [Santiago Somoza](https://github.com/santi1234567)
-
 * [Barnabas Busa](https://github.com/barnabasbusa) — Dockerfile fixes.


### PR DESCRIPTION
## Summary

Cleans up `AUTHORS.md` formatting and reorganises the structure so it renders correctly on GitHub and the categories better reflect who is doing what today.

## Changes

**Formatting fixes**
- Restored tab-indented continuation paragraphs for the Zyra V21 and Leo Bautista-Gomez entries (they previously started with an extra `*` marker that GitHub rendered as a broken empty bullet followed by a new bullet).
- Stripped trailing whitespace from the Zyra V21 description line.
- Removed the blank line that split *Other Contributors* in two before Barnabas Busa, so the section renders as a single bullet list.
- Normalised the Tarun Mohandas first description line to use a tab like the rest of the file.

**Copy edits**
- `release a simple version` → `released a simple version` in the Mikel Cortes entry.
- `He did improve the tool from the simple first releases to most complex / complete logic.` → `He improved the tool from the simple first releases to the most complex / complete logic.` in the Tarun Mohandas entry.

**Restructure**
- Added a **Current Maintainers** section between *Primary Authors* and *Other Contributors* and moved Zyra V21 and Leo Bautista-Gomez into it. *Primary Authors* now lists Mikel and Tarun (creator and the engineer who built most of the current logic), while *Current Maintainers* covers the people running the repository today.
- Added a third line to the Zyra V21 bio noting ongoing improvements to the tool, without going into specifics.

## Test plan

- [x] Render `AUTHORS.md` on GitHub and confirm both bullet lists (Primary Authors / Current Maintainers / Other Contributors) render correctly with continuation paragraphs.
- [x] Confirm there are no broken links and all GitHub handles still resolve.

## Out of scope

No code or schema changes. No CI changes.