### PR TITLE
feat: persist f_activation_eligibility_epoch on t_validator_last_status

### DIFF
--- a/docs/tables.md
+++ b/docs/tables.md
@@ -175,7 +175,7 @@ deposit pipeline (EIP-6110/EIP-7251) and there is no deposit-queue state:
 | Derived status | Condition | Meaning |
 | -------------- | --------- | ------- |
 | `deposit_inqueue` | pubkey present in `t_deposit_requests`, absent from `t_validator_last_status` (not yet a registered validator) | Deposit waiting in `state.pending_deposits`; the real churn-limited queue |
-| `pending_balance` | `f_status = 0` and `f_activation_eligibility_epoch = FAR_FUTURE_EPOCH` | Validator created, effective balance < 32 ETH (not yet eligible) |
+| `pending_minBalance` | `f_status = 0` and `f_activation_eligibility_epoch = FAR_FUTURE_EPOCH` | Validator created, effective balance < 32 ETH (not yet eligible) |
 | `pending_lookahead` | `f_status = 0` and `f_activation_eligibility_epoch != FAR_FUTURE_EPOCH` | Eligible; fixed `1 + MAX_SEED_LOOKAHEAD` delay (not a queue) |
 | `active` / `exited` / `slashed` | `f_status` 1 / 2 / 3 | unchanged |
 

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -156,11 +156,30 @@ Config: `engine = MergeTree ORDER BY f_val_idx`
 | f_status                 | uint8        | status (see status table)                           |
 | f_slashed                | bool         | whether the validator has ever been slashed or not  |
 | f_activation_epoch       | uint64       | epoch at which the validator was activated          |
+| f_activation_eligibility_epoch | uint64 | epoch at which the validator became eligible for activation; `FAR_FUTURE_EPOCH` (`18446744073709551615`) means not yet eligible. Combined with `f_activation_epoch`, this splits the pre-activation queue (`f_status = 0`) into the two deposit-lifecycle states described below. |
 | f_withdrawal_epoch       | uint64       | epoch at which the validator can withdraw funds     |
 | f_exit_epoch             | uint64       | epoch at which the validator exited the network     |
 | f_public_key             | string       | public key of the validator                         |
 | f_withdrawal_prefix      | uint8        | withdrawal prefix of the validator's credentials    |
 | f_withdrawal_credentials | text         | withdrawal credentials of the validator (see below) |
+
+## Appendix: deposit-lifecycle status vocabulary
+
+`f_status` keeps its coarse, stable encoding (`0 in_activation_queue · 1 active · 2 exited · 3 slashed`).
+Consumers that want the finer, Beacon-API-aligned deposit-lifecycle vocabulary derive it from
+`f_status` + `f_activation_eligibility_epoch` (and, for pre-registration deposits, from
+`t_deposit_requests`). This is the terminology proposed upstream for the `ValidatorStatus` enum
+(EIP-6110/EIP-7251 deposit pipeline):
+
+| Derived status | Condition | Meaning |
+| -------------- | --------- | ------- |
+| `deposit_inqueue` | pubkey present in `t_deposit_requests`, absent from `t_validator_last_status` (not yet a registered validator) | Deposit waiting in `state.pending_deposits`; the real churn-limited queue |
+| `pending_balance` | `f_status = 0` and `f_activation_eligibility_epoch = FAR_FUTURE_EPOCH` | Validator created, effective balance < 32 ETH (not yet eligible) |
+| `pending_lookahead` | `f_status = 0` and `f_activation_eligibility_epoch != FAR_FUTURE_EPOCH` | Eligible; fixed `1 + MAX_SEED_LOOKAHEAD` delay (not a queue) |
+| `active` / `exited` / `slashed` | `f_status` 1 / 2 / 3 | unchanged |
+
+`deposit_inqueue` is not a `t_validator_last_status` row because the deposit has no validator index
+yet; it is materialised by downstream consumers (e.g. bindeth) joining `t_deposit_requests`.
 
 ## Appendix: Reference for `f_withdrawal_prefix`
 

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -166,10 +166,11 @@ Config: `engine = MergeTree ORDER BY f_val_idx`
 ## Appendix: deposit-lifecycle status vocabulary
 
 `f_status` keeps its coarse, stable encoding (`0 in_activation_queue · 1 active · 2 exited · 3 slashed`).
-Consumers that want the finer, Beacon-API-aligned deposit-lifecycle vocabulary derive it from
+Consumers that want the finer deposit-lifecycle vocabulary derive it from
 `f_status` + `f_activation_eligibility_epoch` (and, for pre-registration deposits, from
-`t_deposit_requests`). This is the terminology proposed upstream for the `ValidatorStatus` enum
-(EIP-6110/EIP-7251 deposit pipeline):
+`t_deposit_requests`). This is a proposed vocabulary the current Beacon API `ValidatorStatus`
+enum does not provide — its `pending_initialized` / `pending_queued` predate the post-Electra
+deposit pipeline (EIP-6110/EIP-7251) and there is no deposit-queue state:
 
 | Derived status | Condition | Meaning |
 | -------------- | --------- | ------- |

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -234,17 +234,18 @@ func (s *ChainAnalyzer) processValLastStatus(bundle metrics.StateMetrics) {
 		for i, validator := range nextState.Validators {
 			valIdx := phase0.ValidatorIndex(i)
 			newVal := spec.ValidatorLastStatus{
-				ValIdx:                valIdx,
-				Epoch:                 nextState.Epoch,
-				CurrentBalance:        nextState.Balances[valIdx],
-				EffectiveBalance:      validator.EffectiveBalance,
-				CurrentStatus:         nextState.GetValStatus(valIdx),
-				Slashed:               validator.Slashed,
-				ActivationEpoch:       validator.ActivationEpoch,
-				WithdrawalEpoch:       validator.WithdrawableEpoch,
-				ExitEpoch:             validator.ExitEpoch,
-				PublicKey:             validator.PublicKey,
-				WithdrawalCredentials: validator.WithdrawalCredentials,
+				ValIdx:                     valIdx,
+				Epoch:                      nextState.Epoch,
+				CurrentBalance:             nextState.Balances[valIdx],
+				EffectiveBalance:           validator.EffectiveBalance,
+				CurrentStatus:              nextState.GetValStatus(valIdx),
+				Slashed:                    validator.Slashed,
+				ActivationEpoch:            validator.ActivationEpoch,
+				ActivationEligibilityEpoch: validator.ActivationEligibilityEpoch,
+				WithdrawalEpoch:            validator.WithdrawableEpoch,
+				ExitEpoch:                  validator.ExitEpoch,
+				PublicKey:                  validator.PublicKey,
+				WithdrawalCredentials:      validator.WithdrawalCredentials,
 			}
 			valStatusArr = append(valStatusArr, newVal)
 		}

--- a/pkg/db/migrations/000037_add_activation_eligibility_epoch.down.sql
+++ b/pkg/db/migrations/000037_add_activation_eligibility_epoch.down.sql
@@ -1,0 +1,3 @@
+-- Remove f_activation_eligibility_epoch column from t_validator_last_status.
+ALTER TABLE t_validator_last_status
+DROP COLUMN IF EXISTS f_activation_eligibility_epoch;

--- a/pkg/db/migrations/000037_add_activation_eligibility_epoch.up.sql
+++ b/pkg/db/migrations/000037_add_activation_eligibility_epoch.up.sql
@@ -1,0 +1,13 @@
+-- Add f_activation_eligibility_epoch column to t_validator_last_status.
+-- Default is FAR_FUTURE_EPOCH (2^64 - 1) so historical rows that pre-date
+-- this migration read as "not yet eligible" — which matches the consensus
+-- spec semantics for an unset eligibility epoch. goteth rewrites every row
+-- on each finalized epoch, so the default is corrected for live validators
+-- on the next analyzer pass.
+--
+-- IF NOT EXISTS: the column may already be present on databases where the
+-- earlier #268 migration was applied before it was reverted in code; this
+-- keeps the migration idempotent. ADD COLUMN with a DEFAULT is a metadata-only
+-- operation in ClickHouse (no data rewrite).
+ALTER TABLE t_validator_last_status
+ADD COLUMN IF NOT EXISTS f_activation_eligibility_epoch UInt64 DEFAULT 18446744073709551615 AFTER f_activation_epoch;

--- a/pkg/db/validator_last_status.go
+++ b/pkg/db/validator_last_status.go
@@ -17,6 +17,7 @@ var (
 		f_status,
 		f_slashed,
 		f_activation_epoch,
+		f_activation_eligibility_epoch,
 		f_withdrawal_epoch,
 		f_exit_epoch,
 		f_public_key,
@@ -36,14 +37,15 @@ func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 		f_epoch                  proto.ColUInt64
 		f_balance_eth            proto.ColFloat32
 		f_effective_balance      proto.ColUInt64
-		f_status                 proto.ColUInt8
-		f_slashed                proto.ColBool
-		f_activation_epoch       proto.ColUInt64
-		f_withdrawal_epoch       proto.ColUInt64
-		f_exit_epoch             proto.ColUInt64
-		f_public_key             proto.ColStr
-		f_withdrawal_prefix      proto.ColUInt8
-		f_withdrawal_credentials proto.ColStr
+		f_status                       proto.ColUInt8
+		f_slashed                      proto.ColBool
+		f_activation_epoch             proto.ColUInt64
+		f_activation_eligibility_epoch proto.ColUInt64
+		f_withdrawal_epoch             proto.ColUInt64
+		f_exit_epoch                   proto.ColUInt64
+		f_public_key                   proto.ColStr
+		f_withdrawal_prefix            proto.ColUInt8
+		f_withdrawal_credentials       proto.ColStr
 	)
 
 	for _, status := range validatorStatuses {
@@ -54,6 +56,7 @@ func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 		f_status.Append(uint8(status.CurrentStatus))
 		f_slashed.Append(status.Slashed)
 		f_activation_epoch.Append(uint64(status.ActivationEpoch))
+		f_activation_eligibility_epoch.Append(uint64(status.ActivationEligibilityEpoch))
 		f_withdrawal_epoch.Append(uint64(status.WithdrawalEpoch))
 		f_exit_epoch.Append(uint64(status.ExitEpoch))
 		f_public_key.Append(status.PublicKey.String())
@@ -69,6 +72,7 @@ func valStatusInput(validatorStatuses []spec.ValidatorLastStatus) proto.Input {
 		{Name: "f_status", Data: f_status},
 		{Name: "f_slashed", Data: f_slashed},
 		{Name: "f_activation_epoch", Data: f_activation_epoch},
+		{Name: "f_activation_eligibility_epoch", Data: f_activation_eligibility_epoch},
 		{Name: "f_withdrawal_epoch", Data: f_withdrawal_epoch},
 		{Name: "f_exit_epoch", Data: f_exit_epoch},
 		{Name: "f_public_key", Data: f_public_key},

--- a/pkg/spec/validator_last_status.go
+++ b/pkg/spec/validator_last_status.go
@@ -7,17 +7,18 @@ import (
 )
 
 type ValidatorLastStatus struct {
-	ValIdx                phase0.ValidatorIndex
-	Epoch                 phase0.Epoch
-	CurrentBalance        phase0.Gwei
-	EffectiveBalance      phase0.Gwei
-	CurrentStatus         ValidatorStatus
-	Slashed               bool
-	ActivationEpoch       phase0.Epoch
-	WithdrawalEpoch       phase0.Epoch
-	ExitEpoch             phase0.Epoch
-	PublicKey             phase0.BLSPubKey
-	WithdrawalCredentials []byte
+	ValIdx                     phase0.ValidatorIndex
+	Epoch                      phase0.Epoch
+	CurrentBalance             phase0.Gwei
+	EffectiveBalance           phase0.Gwei
+	CurrentStatus              ValidatorStatus
+	Slashed                    bool
+	ActivationEpoch            phase0.Epoch
+	ActivationEligibilityEpoch phase0.Epoch
+	WithdrawalEpoch            phase0.Epoch
+	ExitEpoch                  phase0.Epoch
+	PublicKey                  phase0.BLSPubKey
+	WithdrawalCredentials      []byte
 }
 
 func (f ValidatorLastStatus) ToArray() []interface{} {
@@ -29,6 +30,7 @@ func (f ValidatorLastStatus) ToArray() []interface{} {
 	resultArgs = append(resultArgs, f.CurrentStatus)
 	resultArgs = append(resultArgs, f.Slashed)
 	resultArgs = append(resultArgs, f.ActivationEpoch)
+	resultArgs = append(resultArgs, f.ActivationEligibilityEpoch)
 	resultArgs = append(resultArgs, f.WithdrawalEpoch)
 	resultArgs = append(resultArgs, f.ExitEpoch)
 	resultArgs = append(resultArgs, f.PublicKey.String())


### PR DESCRIPTION
Adds `f_activation_eligibility_epoch` to `t_validator_last_status`, enabling the pre-activation queue (`f_status = 0`) to be split into the Electra+ deposit-lifecycle states `pending_balance` (eligibility = `FAR_FUTURE_EPOCH`) and `pending_lookahead` (eligibility set). The coarse `f_status` (0–3) encoding is unchanged; the split is derived downstream from the new column.

**Changes**
- `spec.ValidatorLastStatus`: field + `ToArray()`
- `processValLastStatus`: populated from `validator.ActivationEligibilityEpoch`
- `db/validator_last_status.go`: column in INSERT / proto input
- Migration `000037`: `ADD COLUMN IF NOT EXISTS … DEFAULT FAR_FUTURE_EPOCH` (idempotent, metadata-only in ClickHouse)
- `docs/tables.md`: column + derived-status vocabulary

Companion change in bindeth consumes this column.
