### PR TITLE
fix: consistent pool summaries (untagged bucket, duty join guard, refresh on re-tagging)

### DIFF
--- a/cmd/pool_summary_refill_cmd.go
+++ b/cmd/pool_summary_refill_cmd.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/migalabs/goteth/pkg/db"
+	"github.com/migalabs/goteth/pkg/utils"
+	"github.com/sirupsen/logrus"
+	cli "github.com/urfave/cli/v2"
+)
+
+var PoolSummaryRefillCommand = &cli.Command{
+	Name:   "pool-summary-refill",
+	Usage:  "Recomputes t_pool_summary for an epoch range from the current rewards and pool tags. Deletes the range first so pool renames do not leave ghost rows. Use after pool re-tagging or rewards backfills.",
+	Action: LaunchPoolSummaryRefill,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:        "log-level",
+			Usage:       "Log level: debug, warn, info, error",
+			EnvVars:     []string{"ANALYZER_LOG_LEVEL"},
+			DefaultText: "info",
+		},
+		&cli.StringFlag{
+			Name:        "db-url",
+			Usage:       "Database where the pool summaries are persisted",
+			EnvVars:     []string{"ANALYZER_DB_URL"},
+			DefaultText: "clickhouse://username:password@localhost:9000/goteth?x-multi-statement=true&max_memory_usage=10000000000",
+		},
+		&cli.Uint64Flag{
+			Name:     "from-epoch",
+			Usage:    "First epoch of the range to recompute (inclusive)",
+			Required: true,
+		},
+		&cli.Uint64Flag{
+			Name:     "to-epoch",
+			Usage:    "Last epoch of the range to recompute (inclusive)",
+			Required: true,
+		},
+	},
+}
+
+func LaunchPoolSummaryRefill(c *cli.Context) error {
+
+	if c.IsSet("log-level") {
+		logrus.SetLevel(utils.ParseLogLevel(c.String("log-level")))
+	}
+
+	dbUrl := c.String("db-url")
+	if dbUrl == "" {
+		return fmt.Errorf("db-url is required")
+	}
+
+	fromEpoch := phase0.Epoch(c.Uint64("from-epoch"))
+	toEpoch := phase0.Epoch(c.Uint64("to-epoch"))
+	if toEpoch < fromEpoch {
+		return fmt.Errorf("to-epoch (%d) must be greater or equal than from-epoch (%d)", toEpoch, fromEpoch)
+	}
+
+	dbClient, err := db.New(c.Context, dbUrl)
+	if err != nil {
+		return err
+	}
+	err = dbClient.Connect()
+	if err != nil {
+		return err
+	}
+	defer dbClient.Finish()
+
+	return dbClient.RefreshPoolSummaryRange(fromEpoch, toEpoch)
+}

--- a/cmd/validator_window_cmd.go
+++ b/cmd/validator_window_cmd.go
@@ -43,6 +43,12 @@ var ValidatorWindowCommand = &cli.Command{
 			EnvVars:     []string{"DELETE_CADENCE_EPOCHS"},
 			DefaultText: "32",
 		},
+		&cli.IntFlag{
+			Name:        "pool-reroll-epochs",
+			Usage:       "Refresh t_pool_summary for the last N epochs whenever the validator->pool mapping in t_eth2_pubkeys changes, so late-tagged validators and pool renames propagate to recent history. Set to 0 to disable.",
+			EnvVars:     []string{"POOL_REROLL_EPOCHS"},
+			DefaultText: "0",
+		},
 		&cli.StringFlag{
 			Name:        "bn-endpoint",
 			Usage:       "Beacon node endpoint (to request the Beacon States and Blocks)",

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 		Commands: []*cli.Command{
 			cmd.BlocksCommand,
 			cmd.ValidatorWindowCommand,
+			cmd.PoolSummaryRefillCommand,
 		},
 	}
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -15,6 +15,7 @@ var (
 	DefaultPrometheusPort               int    = 9080
 	DefaultValidatorWindowEpochs        int    = 100
 	DefaultValidatorWindowDeleteCadence int    = 32
+	DefaultValidatorWindowPoolReroll    int    = 0
 	DefaultMaxRequestRetries            int    = 3
 	DefaultBeaconContractAddress        string = "mainnet"
 )

--- a/pkg/config/validator_window.go
+++ b/pkg/config/validator_window.go
@@ -9,6 +9,7 @@ type ValidatorWindowConfig struct {
 	DBUrl               string `json:"db-url"`
 	NumEpochs           int    `json:"num-epochs"`
 	DeleteCadenceEpochs int    `json:"delete-cadence-epochs"`
+	PoolRerollEpochs    int    `json:"pool-reroll-epochs"`
 	BnEndpoint          string `json:"bn-endpoint"`
 	MaxRequestRetries   int    `json:"max-request-retries"`
 }
@@ -21,6 +22,7 @@ func NewValidatorWindowConfig() *ValidatorWindowConfig {
 		DBUrl:               DefaultDBUrl,
 		NumEpochs:           DefaultValidatorWindowEpochs,
 		DeleteCadenceEpochs: DefaultValidatorWindowDeleteCadence,
+		PoolRerollEpochs:    DefaultValidatorWindowPoolReroll,
 		BnEndpoint:          DefaultBnEndpoint,
 		MaxRequestRetries:   DefaultMaxRequestRetries,
 	}
@@ -43,6 +45,10 @@ func (c *ValidatorWindowConfig) Apply(ctx *cli.Context) {
 	// delete cadence (batch retention deletes every N epochs)
 	if ctx.IsSet("delete-cadence-epochs") {
 		c.DeleteCadenceEpochs = ctx.Int("delete-cadence-epochs")
+	}
+	// pool summary reroll window (0 disables the automatic refresh)
+	if ctx.IsSet("pool-reroll-epochs") {
+		c.PoolRerollEpochs = ctx.Int("pool-reroll-epochs")
 	}
 	// cl url
 	if ctx.IsSet("bn-endpoint") {

--- a/pkg/db/pools_summary.go
+++ b/pkg/db/pools_summary.go
@@ -7,13 +7,30 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
+const (
+	// UnknownPoolName groups validators that have no entry (or an empty pool
+	// name) in t_eth2_pubkeys at aggregation time. Keeping them in a synthetic
+	// pool instead of dropping them guarantees that the sum across pools
+	// always matches the network totals in t_epoch_metrics_summary.
+	UnknownPoolName = "unknown"
+
+	// poolSummaryRefreshBatchEpochs is the number of epochs recomputed per
+	// INSERT when refreshing a range. Bounds the memory used by the
+	// aggregation while keeping the refresh fast (a batch takes seconds).
+	poolSummaryRefreshBatchEpochs = 250
+)
+
 var (
 	poolsTables = "t_pool_summary"
 
-	insertPoolSummary = `
-		INSERT INTO %s
-			SELECT 
-				t_eth2_pubkeys.f_pool_name, f_epoch,
+	// The missed-blocks condition re-checks that the joined proposer duty row
+	// really belongs to this validator and epoch: ClickHouse fills the right
+	// side of a non-matched LEFT JOIN with type defaults (f_val_idx = 0,
+	// f_proposed = false), which validator index 0 satisfies spuriously and
+	// gets a fake missed block on every epoch it does not propose.
+	poolSummarySelect = `
+			SELECT
+				if(t_eth2_pubkeys.f_pool_name = '', '%s', t_eth2_pubkeys.f_pool_name) as f_pool_name, f_epoch,
 				SUM(CASE WHEN (f_reward <= f_max_reward) THEN f_reward ELSE 0 END) as aggregated_rewards,
 				SUM(CASE WHEN (f_reward <= f_max_reward) THEN f_max_reward ELSE 0 END) as aggregated_max_rewards,
 				SUM(f_effective_balance) as aggregated_effective_balance,
@@ -25,7 +42,9 @@ var (
 				COUNT(*) as count_expected_attestations,
 				SUM(CASE WHEN f_attestation_included = TRUE THEN 1 ELSE 0 END) as count_included_attestations,
 				SUM(CASE WHEN t_proposer_duties.f_proposed = TRUE THEN 1 ELSE 0 END) as proposed_blocks_performance,
-				SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE and t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx THEN 1 ELSE 0 END) as missed_blocks_performance,
+				SUM(CASE WHEN t_proposer_duties.f_proposed = FALSE
+					AND t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx
+					AND t_validator_rewards_summary.f_epoch = toUInt64(t_proposer_duties.f_proposer_slot/32) THEN 1 ELSE 0 END) as missed_blocks_performance,
 				count(distinct(t_validator_rewards_summary.f_val_idx)) as number_active_vals,
 				count(CASE WHEN f_withdrawal_prefix = 2 THEN 1 ELSE null END) as number_compounding_vals,
 				AVG(f_inclusion_delay) as avg_inclusion_delay
@@ -33,15 +52,31 @@ var (
 			LEFT JOIN t_eth2_pubkeys final
 				ON t_validator_rewards_summary.f_val_idx = t_eth2_pubkeys.f_val_idx
 			LEFT JOIN t_proposer_duties final
-				ON t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx 
+				ON t_validator_rewards_summary.f_val_idx = t_proposer_duties.f_val_idx
 				AND t_validator_rewards_summary.f_epoch = toUInt64(t_proposer_duties.f_proposer_slot/32)
-			WHERE f_epoch = $1 AND f_status = 1 AND f_pool_name != ''
-			GROUP BY t_eth2_pubkeys.f_pool_name, f_epoch`
+			WHERE %s AND f_status = 1
+			GROUP BY if(t_eth2_pubkeys.f_pool_name = '', '%s', t_eth2_pubkeys.f_pool_name), f_epoch`
+
+	deletePoolSummaryRangeQuery = `
+		DELETE FROM %s
+		WHERE f_epoch >= $1 AND f_epoch <= $2;
+	`
+
+	// Order-independent fingerprint of the validator->pool mapping, used to
+	// detect pool re-tagging so recent pool summaries can be refreshed.
+	selectPoolsFingerprintQuery = `
+		SELECT concat(toString(count()), '-', toString(sum(cityHash64(f_val_idx, f_pool_name)))) as f_fingerprint
+		FROM t_eth2_pubkeys FINAL`
 )
+
+func insertPoolSummaryQuery(whereClause string) string {
+	selectStmt := fmt.Sprintf(poolSummarySelect, UnknownPoolName, whereClause, UnknownPoolName)
+	return fmt.Sprintf("INSERT INTO %s%s", poolsTables, selectStmt)
+}
 
 func (p *DBService) InsertPoolSummary(epoch phase0.Epoch) error {
 
-	query := fmt.Sprintf(insertPoolSummary, poolsTables)
+	query := insertPoolSummaryQuery("f_epoch = $1")
 	var err error
 	startTime := time.Now()
 
@@ -55,4 +90,86 @@ func (p *DBService) InsertPoolSummary(epoch phase0.Epoch) error {
 	}
 
 	return err
+}
+
+func (p *DBService) insertPoolSummaryRange(fromEpoch phase0.Epoch, toEpoch phase0.Epoch) error {
+
+	query := insertPoolSummaryQuery("f_epoch >= $1 AND f_epoch <= $2")
+	var err error
+
+	p.highMu.Lock()
+	err = p.highLevelClient.Exec(p.ctx, query, fromEpoch, toEpoch)
+	p.highMu.Unlock()
+
+	return err
+}
+
+func (p *DBService) DeletePoolSummaryRange(fromEpoch phase0.Epoch, toEpoch phase0.Epoch) error {
+
+	deleteObj := DeletableObject{
+		query: deletePoolSummaryRangeQuery,
+		table: poolsTables,
+		args:  []any{fromEpoch, toEpoch},
+	}
+
+	err := p.Delete(deleteObj)
+	if err != nil {
+		log.Errorf("error deleting pool summaries: %s", err.Error())
+	}
+
+	return err
+}
+
+// RefreshPoolSummaryRange recomputes t_pool_summary for [fromEpoch, toEpoch]
+// from the current contents of t_validator_rewards_summary and
+// t_eth2_pubkeys. Existing rows in the range are deleted first: the table is
+// a ReplacingMergeTree keyed on (f_epoch, f_pool_name), so re-inserting after
+// a pool was renamed or split would leave ghost rows under the old pool name
+// and double count its validators.
+func (p *DBService) RefreshPoolSummaryRange(fromEpoch phase0.Epoch, toEpoch phase0.Epoch) error {
+
+	if toEpoch < fromEpoch {
+		return fmt.Errorf("invalid pool summary refresh range: %d-%d", fromEpoch, toEpoch)
+	}
+
+	startTime := time.Now()
+
+	err := p.DeletePoolSummaryRange(fromEpoch, toEpoch)
+	if err != nil {
+		return err
+	}
+
+	for batchStart := fromEpoch; batchStart <= toEpoch; batchStart += poolSummaryRefreshBatchEpochs {
+		batchEnd := batchStart + poolSummaryRefreshBatchEpochs - 1
+		if batchEnd > toEpoch {
+			batchEnd = toEpoch
+		}
+		err = p.insertPoolSummaryRange(batchStart, batchEnd)
+		if err != nil {
+			return fmt.Errorf("refreshing pool summaries %d-%d: %w", batchStart, batchEnd, err)
+		}
+		log.Debugf("pool summaries refreshed for epochs %d-%d", batchStart, batchEnd)
+	}
+
+	log.Infof("pool summaries refreshed for epochs %d-%d, %f seconds",
+		fromEpoch, toEpoch, time.Since(startTime).Seconds())
+
+	return nil
+}
+
+// RetrievePoolsFingerprint returns a cheap fingerprint of the current
+// validator->pool mapping. It changes whenever t_eth2_pubkeys gains rows or
+// any validator is re-tagged, and is used to trigger pool summary refreshes.
+func (p *DBService) RetrievePoolsFingerprint() (string, error) {
+
+	var dest []struct {
+		F_fingerprint string `ch:"f_fingerprint"`
+	}
+
+	err := p.highSelect(selectPoolsFingerprintQuery, &dest)
+
+	if len(dest) > 0 {
+		return dest[0].F_fingerprint, err
+	}
+	return "", err
 }

--- a/pkg/validator_window/window.go
+++ b/pkg/validator_window/window.go
@@ -22,15 +22,17 @@ var (
 )
 
 type ValidatorWindowRunner struct {
-	ctx                 context.Context
-	dbClient            *db.DBService  // client to communicate with psql
-	eventsObj           events.Events  // object to receive signals from beacon node (needed to trigger the deletes)
-	stop                bool           // used to know if the tool should stop
-	windowEpochSize     int            // number of epochs of data to maintain in the database
-	deleteCadenceEpochs int            // only emit DELETE once the boundary has advanced by this many epochs
-	lastDeletedBoundary phase0.Epoch   // last boundary we successfully sent a DELETE for
-	deleteFiredOnce     bool           // becomes true after the first DELETE so the cadence check kicks in
-	routineSyncGroup    sync.WaitGroup // to check if the routine is running
+	ctx                  context.Context
+	dbClient             *db.DBService  // client to communicate with psql
+	eventsObj            events.Events  // object to receive signals from beacon node (needed to trigger the deletes)
+	stop                 bool           // used to know if the tool should stop
+	windowEpochSize      int            // number of epochs of data to maintain in the database
+	deleteCadenceEpochs  int            // only emit DELETE once the boundary has advanced by this many epochs
+	lastDeletedBoundary  phase0.Epoch   // last boundary we successfully sent a DELETE for
+	deleteFiredOnce      bool           // becomes true after the first DELETE so the cadence check kicks in
+	poolRerollEpochs     int            // refresh t_pool_summary for the last N epochs when the pool mapping changes (0 disables)
+	lastPoolsFingerprint string         // last observed fingerprint of t_eth2_pubkeys
+	routineSyncGroup     sync.WaitGroup // to check if the routine is running
 }
 
 func NewValidatorWindow(
@@ -73,6 +75,7 @@ func NewValidatorWindow(
 		eventsObj:           events.NewEventsObj(pCtx, cli),
 		windowEpochSize:     iConfig.NumEpochs,
 		deleteCadenceEpochs: cadence,
+		poolRerollEpochs:    iConfig.PoolRerollEpochs,
 		routineSyncGroup:    sync.WaitGroup{},
 	}, nil
 }
@@ -97,48 +100,123 @@ func (s *ValidatorWindowRunner) Run() {
 				return
 			}
 
-			if dbHeadEpoch < phase0.Epoch(s.windowEpochSize) {
-				log.Infof("database head epoch: %d is less than window epoch size: %d", dbHeadEpoch, s.windowEpochSize)
-				continue
-			}
-			windowLowerEpochBoundary := dbHeadEpoch - phase0.Epoch(s.windowEpochSize)
-
-			// Each DELETE FROM t_validator_rewards_summary becomes a ClickHouse
-			// mutation that rewrites every part holding in-window epochs. On
-			// networks with ~1M validators that mutation takes minutes per fire;
-			// firing on every finalized checkpoint (~6:24 min) saturates the
-			// merge thread and stalls the head. Only emit the DELETE once the
-			// boundary has advanced by deleteCadenceEpochs since the last fire.
-			if s.deleteFiredOnce {
-				if windowLowerEpochBoundary <= s.lastDeletedBoundary {
-					log.Debugf("skipping delete: boundary %d not advanced past last fire %d",
-						windowLowerEpochBoundary, s.lastDeletedBoundary)
-					continue
-				}
-				advanced := windowLowerEpochBoundary - s.lastDeletedBoundary
-				if advanced < phase0.Epoch(s.deleteCadenceEpochs) {
-					log.Debugf("skipping delete: boundary advanced %d/%d epochs since last fire (boundary=%d)",
-						advanced, s.deleteCadenceEpochs, windowLowerEpochBoundary)
-					continue
-				}
-			}
-
-			log.Infof("database head epoch: %d", dbHeadEpoch)
-			log.Infof("deleting validator rewards from %d epoch backwards", windowLowerEpochBoundary)
-			err = s.dbClient.DeleteValidatorRewardsUntil(windowLowerEpochBoundary)
-			if err != nil {
-				log.Errorf("could not delete the validators: %s", err)
+			if !s.runRetention(dbHeadEpoch) {
 				s.EndProcesses()
 				return
 			}
-			s.lastDeletedBoundary = windowLowerEpochBoundary
-			s.deleteFiredOnce = true
+
+			s.maybeRerollPoolSummaries(dbHeadEpoch)
 		case <-ticker.C:
 			if s.stop {
 				return
 			}
 		}
 	}
+}
+
+// runRetention applies the sliding-window delete on the rewards table.
+// Returns false on a fatal error that should stop the runner.
+func (s *ValidatorWindowRunner) runRetention(dbHeadEpoch phase0.Epoch) bool {
+
+	if dbHeadEpoch < phase0.Epoch(s.windowEpochSize) {
+		log.Infof("database head epoch: %d is less than window epoch size: %d", dbHeadEpoch, s.windowEpochSize)
+		return true
+	}
+	windowLowerEpochBoundary := dbHeadEpoch - phase0.Epoch(s.windowEpochSize)
+
+	// Each DELETE FROM t_validator_rewards_summary becomes a ClickHouse
+	// mutation that rewrites every part holding in-window epochs. On
+	// networks with ~1M validators that mutation takes minutes per fire;
+	// firing on every finalized checkpoint (~6:24 min) saturates the
+	// merge thread and stalls the head. Only emit the DELETE once the
+	// boundary has advanced by deleteCadenceEpochs since the last fire.
+	if s.deleteFiredOnce {
+		if windowLowerEpochBoundary <= s.lastDeletedBoundary {
+			log.Debugf("skipping delete: boundary %d not advanced past last fire %d",
+				windowLowerEpochBoundary, s.lastDeletedBoundary)
+			return true
+		}
+		advanced := windowLowerEpochBoundary - s.lastDeletedBoundary
+		if advanced < phase0.Epoch(s.deleteCadenceEpochs) {
+			log.Debugf("skipping delete: boundary advanced %d/%d epochs since last fire (boundary=%d)",
+				advanced, s.deleteCadenceEpochs, windowLowerEpochBoundary)
+			return true
+		}
+	}
+
+	log.Infof("database head epoch: %d", dbHeadEpoch)
+	log.Infof("deleting validator rewards from %d epoch backwards", windowLowerEpochBoundary)
+	err := s.dbClient.DeleteValidatorRewardsUntil(windowLowerEpochBoundary)
+	if err != nil {
+		log.Errorf("could not delete the validators: %s", err)
+		return false
+	}
+	s.lastDeletedBoundary = windowLowerEpochBoundary
+	s.deleteFiredOnce = true
+	return true
+}
+
+// maybeRerollPoolSummaries refreshes t_pool_summary for the trailing
+// poolRerollEpochs epochs whenever the validator->pool mapping changes, so
+// late-tagged validators and pool renames propagate into recent history
+// instead of freezing the tagging snapshot taken at ingestion time.
+func (s *ValidatorWindowRunner) maybeRerollPoolSummaries(dbHeadEpoch phase0.Epoch) {
+
+	if s.poolRerollEpochs <= 0 {
+		return
+	}
+
+	fingerprint, err := s.dbClient.RetrievePoolsFingerprint()
+	if err != nil {
+		log.Errorf("could not retrieve pools fingerprint: %s", err)
+		return
+	}
+	if fingerprint == "" {
+		return
+	}
+	if s.lastPoolsFingerprint == "" {
+		// first observation after startup: record without refreshing so a
+		// restart alone does not trigger a reroll
+		s.lastPoolsFingerprint = fingerprint
+		return
+	}
+	if fingerprint == s.lastPoolsFingerprint {
+		return
+	}
+
+	// leave a margin below the database head: the analyzer may still be
+	// writing the most recent epochs
+	const headMarginEpochs = 3
+	if dbHeadEpoch <= headMarginEpochs {
+		return
+	}
+	toEpoch := dbHeadEpoch - headMarginEpochs
+
+	fromEpoch := phase0.Epoch(0)
+	if toEpoch > phase0.Epoch(s.poolRerollEpochs) {
+		fromEpoch = toEpoch - phase0.Epoch(s.poolRerollEpochs) + 1
+	}
+	// never refresh below the rewards retention window: those epochs have no
+	// source rows anymore, so delete+reinsert there would wipe their summaries
+	if dbHeadEpoch > phase0.Epoch(s.windowEpochSize) {
+		rewardsFloor := dbHeadEpoch - phase0.Epoch(s.windowEpochSize) + 1
+		if fromEpoch < rewardsFloor {
+			fromEpoch = rewardsFloor
+		}
+	}
+	if toEpoch < fromEpoch {
+		return
+	}
+
+	log.Infof("pool mapping changed, refreshing pool summaries for epochs %d-%d", fromEpoch, toEpoch)
+	err = s.dbClient.RefreshPoolSummaryRange(fromEpoch, toEpoch)
+	if err != nil {
+		// keep the old fingerprint so the refresh is retried on the next
+		// finalized checkpoint
+		log.Errorf("could not refresh pool summaries: %s", err)
+		return
+	}
+	s.lastPoolsFingerprint = fingerprint
 }
 
 func (s *ValidatorWindowRunner) Close() {


### PR DESCRIPTION
Implements fixes 1, 2 and 4 from #277 and resolves the ghost-row mechanism plus the "33 duties" bug from #254. The Prometheus coverage gauge (fix 3 of #277) will come in a separate PR.

## Changes

**1. Untagged validators are no longer dropped from `t_pool_summary`**

Validators with no entry (or an empty pool name) in `t_eth2_pubkeys` are now grouped under a synthetic `unknown` pool instead of being filtered out by `f_pool_name != ''`. With this, `sum(number_active_vals)` across pools matches the active set by construction, regardless of tagging lag. Consumers that do not want to show the bucket can filter `f_pool_name != 'unknown'`.

**2. Proposer duties join no longer fabricates a missed block for validator 0**

ClickHouse fills the right side of a non-matched LEFT JOIN with type defaults (`f_val_idx = 0`, `f_proposed = false`), so the previous missed-block condition matched validator index 0 spuriously on every epoch it did not propose. The condition now also requires the duty row to belong to the epoch. Full analysis in #254.

**3. Pool summaries can be refreshed, automatically and manually**

- `RefreshPoolSummaryRange(from, to)`: deletes the range first (mandatory: the ReplacingMergeTree key is `(f_epoch, f_pool_name)`, so re-inserting after a pool rename leaves ghost rows under the old name and double counts validators), then recomputes in 250-epoch batches.
- val-window: new `--pool-reroll-epochs` / `POOL_REROLL_EPOCHS` option (default 0, disabled). On each finalized checkpoint it fingerprints `t_eth2_pubkeys` (row count plus an order-independent hash) and, when the mapping changed, refreshes the trailing N epochs, clamped to the rewards retention window so summaries older than the window are never wiped. The first observation after startup only records the fingerprint, so restarts do not trigger refreshes.
- New `pool-summary-refill --from-epoch X --to-epoch Y` command for manual repairs after re-taggings or rewards backfills.

## Validation

Ran the new aggregation over 100 recent mainnet epochs and compared against `t_epoch_metrics_summary` and the source tables:

- `sum(proposed + missed)` is exactly 32 in 100/100 epochs (previously 33 on virtually every epoch in the table's history).
- The `unknown` bucket picks up exactly the currently untagged validators.
- `sum(number_active_vals)` equals the number of active-status rows in `t_validator_rewards_summary` exactly, in every epoch. The only residual difference against `t_epoch_metrics_summary` (up to ~16 validators on very recent epochs) is a pre-existing status-timing difference between the two source tables, unrelated to this change.

## Operational notes

- The automatic reroll is opt-in: set `POOL_REROLL_EPOCHS` (around 3400 epochs, ~15 days, covers typical tagging lag) on deployments that want it.
- Historic ghost rows outside any refreshed range remain until that range is refilled with `pool-summary-refill`.
- A refresh batch of 250 epochs takes single-digit seconds on a ~1M validator network.

Refs #277. Closes #254.
