### PR TITLE
fix(val-window): guard pool reroll against mid-sync pubkeys truncation

### DIFF
--- a/pkg/validator_window/window.go
+++ b/pkg/validator_window/window.go
@@ -2,6 +2,8 @@ package validatorwindow
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -174,6 +176,23 @@ func (s *ValidatorWindowRunner) maybeRerollPoolSummaries(dbHeadEpoch phase0.Epoc
 	if fingerprint == "" {
 		return
 	}
+	// Sync scripts commonly refresh t_eth2_pubkeys with TRUNCATE + INSERT,
+	// so a checkpoint landing mid-sync would observe an empty or partial
+	// mapping and reroll recent history with most validators as 'unknown'.
+	// Skip (without recording the fingerprint) until the mapping recovers.
+	newCount := fingerprintRowCount(fingerprint)
+	if newCount == 0 {
+		log.Warnf("pool mapping is empty, skipping pool summary reroll (pubkeys sync in progress?)")
+		return
+	}
+	if s.lastPoolsFingerprint != "" {
+		lastCount := fingerprintRowCount(s.lastPoolsFingerprint)
+		if lastCount > 0 && newCount < lastCount/2 {
+			log.Warnf("pool mapping shrank from %d to %d entries, skipping pool summary reroll until it recovers (pubkeys sync in progress?)",
+				lastCount, newCount)
+			return
+		}
+	}
 	if s.lastPoolsFingerprint == "" {
 		// first observation after startup: record without refreshing so a
 		// restart alone does not trigger a reroll
@@ -217,6 +236,20 @@ func (s *ValidatorWindowRunner) maybeRerollPoolSummaries(dbHeadEpoch phase0.Epoc
 		return
 	}
 	s.lastPoolsFingerprint = fingerprint
+}
+
+// fingerprintRowCount extracts the row count from a pools fingerprint,
+// which is formatted as "<rowcount>-<hash>".
+func fingerprintRowCount(fingerprint string) uint64 {
+	parts := strings.SplitN(fingerprint, "-", 2)
+	if len(parts) < 1 {
+		return 0
+	}
+	count, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return count
 }
 
 func (s *ValidatorWindowRunner) Close() {


### PR DESCRIPTION
Follow-up to #278, hardening the automatic pool summary reroll against the way `t_eth2_pubkeys` is refreshed in practice.

## Problem

The sync scripts that feed `t_eth2_pubkeys` do `TRUNCATE TABLE` followed by an `INSERT ... SELECT` from the labeling database, so the table is empty or partial for a window of seconds to minutes on every sync. If a finalized checkpoint lands inside that window, the reroll from #278 would observe a collapsed fingerprint, treat it as a legitimate re-tagging, and rewrite the trailing epochs of `t_pool_summary` with most validators under `unknown`. The next checkpoint would repair it, but in between the recent history is wrong and two full reroll cycles of write load are wasted. With syncs every 6 hours and checkpoints every 6.4 minutes the collision odds are far from negligible.

## Fix

Before comparing fingerprints, extract the row count (the fingerprint is `<rowcount>-<hash>`):

- empty mapping: skip with a warning
- row count dropped by more than half since the last stable observation: skip with a warning

In both cases the previous fingerprint is kept, so once the sync finishes and the table recovers, the fingerprint comparison fires the reroll exactly once with the complete mapping.

A legitimate mass shrink of the mapping is still possible operationally via `pool-summary-refill`; the warning log makes the situation visible either way.

## Note

The structural fix is on the producer side: make the sync atomic (staging table plus `EXCHANGE TABLES`) and versioned, so consumers never observe intermediate states. That work is tracked separately; this guard keeps the reroll safe regardless of how the sync behaves.
