### PR TITLE
fix(blobs): record p2p arrival timings again via data_column_sidecar (PeerDAS)

### DIFF
--- a/cmd/blocks_cmd.go
+++ b/cmd/blocks_cmd.go
@@ -81,7 +81,7 @@ var BlocksCommand = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:        "metrics",
-			Usage:       "Metrics to be persisted to the database: epoch,block,rewards,transactions,api_rewards,blob_sidecars",
+			Usage:       "Metrics to be persisted to the database: epoch,block,rewards,transactions,api_rewards,blob_sidecars. blob_sidecars covers blob metadata (t_blob_sidecars); blob p2p arrival timings are always recorded in head mode via the data_column_sidecar event into t_data_column_sidecars_events (the post-Fulu replacement of the dead blob_sidecar event)",
 			EnvVars:     []string{"ANALYZER_METRICS"},
 			DefaultText: "epoch,block",
 		},

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -327,18 +327,24 @@ Config: `engine = ReplacingMergeTree ORDER BY f_slot, f_index`
 | f_kzg_proof      | string       | kzg proof of the blob                                                                                                         |
 | f_ending_0s      | uint64       | amount of consecutive 0s at the end of the blob bytes                                                                         |
 
-# Blob Sidecars Events (`t_blob_sidecars_events`)
+# Data Column Sidecars Events (`t_data_column_sidecars_events`)
 
-Config: `engine = ReplacingMergeTree ORDER BY f_arrival_timestamp_ms, f_blob_hash, f_slot`
+Config: `engine = ReplacingMergeTree PARTITION BY intDiv(f_slot, 100000) ORDER BY (f_slot, f_column_index, f_block_root)`
 
-| Column Name            | Type of Data | Description                                       |     |     |
-| ---------------------- | ------------ | ------------------------------------------------- | --- | --- |
-| f_arrival_timestamp_ms | uint64       | timestamp at which goteth received the blob event |
-| f_blob_hash            | string       | hash of the blob                                  |
-| f_slot                 | uint64       | slot at which the blob was sent                   |
-| f_block_root           | string       | block root hash                                   |
-| f_index                | uint8        | index of the blob                                 |
-| f_kzg_commitment       | string       | kzg commitment of the blob                        |
+P2P arrival timings for blob data. Since the Fulu fork (PeerDAS) blobs are no longer gossiped whole: they are erasure-coded into columns and each node custodies a subset, so beacon nodes emit `data_column_sidecar` instead of the now-dead `blob_sidecar` event. One row per **column** arrival (up to 128 per slot), which also exposes the reconstruction curve of each blob rather than a single arrival timestamp.
+
+Blob *metadata* is unaffected and still comes from the block itself (`t_blob_sidecars`).
+
+| Column Name            | Type of Data  | Description                                                    |     |     |
+| ---------------------- | ------------- | -------------------------------------------------------------- | --- | --- |
+| f_arrival_timestamp_ms | uint64        | timestamp at which goteth received the data column event       |
+| f_slot                 | uint64        | slot the data column belongs to                                |
+| f_block_root           | string        | block root hash                                                |
+| f_column_index         | uint16        | index of the data column (0..127)                              |
+| f_kzg_commitments      | array(string) | kzg commitments of the blobs this column carries a piece of    |
+| f_num_commitments      | uint16        | number of commitments (denormalised from the array for queries)|
+
+> `t_blob_sidecars_events` is the pre-Fulu predecessor of this table (one row per whole blob). It can no longer receive rows because the `blob_sidecar` event is never emitted post-Fulu; migration `000038` renames it to `t_blob_sidecars_events_pre_fulu` to preserve its history.
 
 # Block Rewards (`t_block_rewards`)
 

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -78,7 +78,7 @@ func (s *ChainAnalyzer) runHead() {
 	s.eventsObj.SubscribeToHeadEvents()
 	s.eventsObj.SubscribeToFinalizedCheckpointEvents()
 	s.eventsObj.SubscribeToReorgsEvents()
-	s.eventsObj.SubscribeToBlobSidecarsEvents()
+	s.eventsObj.SubscribeToDataColumnSidecarsEvents()
 	ticker := time.NewTicker(utils.RoutineFlushTimeout)
 	// loop over the list of slots that we need to analyze
 
@@ -117,8 +117,8 @@ func (s *ChainAnalyzer) runHead() {
 			s.dbClient.PersistReorgs([]v1.ChainReorgEvent{newReorg})
 			go s.HandleReorg(newReorg)
 
-		case newBlobSidecarEvent := <-s.eventsObj.BlobSidecarChan:
-			s.dbClient.PersistBlobSidecarsEvents([]spec.BlobSideCarEventWraper{newBlobSidecarEvent})
+		case newDataColumnEvent := <-s.eventsObj.DataColumnSidecarChan:
+			s.dbClient.PersistDataColumnSidecarsEvents([]spec.DataColumnSidecarEventWrapper{newDataColumnEvent})
 
 		case <-s.ctx.Done():
 			log.Info("context has died, closing block requester routine")

--- a/pkg/db/blob_events.go
+++ b/pkg/db/blob_events.go
@@ -6,55 +6,60 @@ import (
 )
 
 var (
-	blobEventsTable               = "t_blob_sidecars_events"
-	insertBlobSideCarsEventsQuery = `
+	dataColumnEventsTable               = "t_data_column_sidecars_events"
+	insertDataColumnSidecarsEventsQuery = `
 	INSERT INTO %s (
 		f_arrival_timestamp_ms,
-		f_blob_hash,
 		f_slot,
 		f_block_root,
-		f_index,
-		f_kzg_commitment)
+		f_column_index,
+		f_kzg_commitments,
+		f_num_commitments)
 		VALUES`
 )
 
-func blobSidecarsEventInput(blobSidecarsEvents []spec.BlobSideCarEventWraper) proto.Input {
+func dataColumnSidecarsEventInput(events []spec.DataColumnSidecarEventWrapper) proto.Input {
 	// one object per column
 	var (
 		f_arrival_timestamp_ms proto.ColUInt64
-		f_blob_hash            proto.ColStr
 		f_slot                 proto.ColUInt64
 		f_block_root           proto.ColStr
-		f_index                proto.ColUInt8
-		f_kzg_commitment       proto.ColStr
+		f_column_index         proto.ColUInt16
+		f_kzg_commitments      = proto.NewArray[string](new(proto.ColStr))
+		f_num_commitments      proto.ColUInt16
 	)
 
-	for _, blobSidecar := range blobSidecarsEvents {
+	for _, ev := range events {
+		commitments := make([]string, 0, len(ev.DataColumnSidecarEvent.KZGCommitments))
+		for _, c := range ev.DataColumnSidecarEvent.KZGCommitments {
+			commitments = append(commitments, c.String())
+		}
 
-		f_arrival_timestamp_ms.Append(uint64(blobSidecar.Timestamp.UnixMilli()))
-		f_blob_hash.Append(blobSidecar.BlobSidecarEvent.VersionedHash.String())
-		f_slot.Append(uint64(blobSidecar.BlobSidecarEvent.Slot))
-		f_block_root.Append(blobSidecar.BlobSidecarEvent.BlockRoot.String())
-		f_index.Append(uint8(blobSidecar.BlobSidecarEvent.Index))
-		f_kzg_commitment.Append(blobSidecar.BlobSidecarEvent.KZGCommitment.String())
+		f_arrival_timestamp_ms.Append(uint64(ev.Timestamp.UnixMilli()))
+		f_slot.Append(uint64(ev.DataColumnSidecarEvent.Slot))
+		f_block_root.Append(ev.DataColumnSidecarEvent.BlockRoot.String())
+		f_column_index.Append(uint16(ev.DataColumnSidecarEvent.Index))
+		f_kzg_commitments.Append(commitments)
+		// Denormalised so "how many blobs did this block carry" does not have to
+		// unnest the array on a table that takes ~128 rows per slot.
+		f_num_commitments.Append(uint16(len(commitments)))
 	}
 
 	return proto.Input{
-
 		{Name: "f_arrival_timestamp_ms", Data: f_arrival_timestamp_ms},
-		{Name: "f_blob_hash", Data: f_blob_hash},
 		{Name: "f_slot", Data: f_slot},
 		{Name: "f_block_root", Data: f_block_root},
-		{Name: "f_index", Data: f_index},
-		{Name: "f_kzg_commitment", Data: f_kzg_commitment},
+		{Name: "f_column_index", Data: f_column_index},
+		{Name: "f_kzg_commitments", Data: f_kzg_commitments},
+		{Name: "f_num_commitments", Data: f_num_commitments},
 	}
 }
 
-func (p *DBService) PersistBlobSidecarsEvents(data []spec.BlobSideCarEventWraper) error {
-	persistObj := PersistableObject[spec.BlobSideCarEventWraper]{
-		input: blobSidecarsEventInput,
-		table: blobEventsTable,
-		query: insertBlobSideCarsEventsQuery,
+func (p *DBService) PersistDataColumnSidecarsEvents(data []spec.DataColumnSidecarEventWrapper) error {
+	persistObj := PersistableObject[spec.DataColumnSidecarEventWrapper]{
+		input: dataColumnSidecarsEventInput,
+		table: dataColumnEventsTable,
+		query: insertDataColumnSidecarsEventsQuery,
 	}
 
 	for _, item := range data {
@@ -63,7 +68,7 @@ func (p *DBService) PersistBlobSidecarsEvents(data []spec.BlobSideCarEventWraper
 
 	err := p.Persist(persistObj.ExportPersist())
 	if err != nil {
-		log.Errorf("error persisting blob events: %s", err.Error())
+		log.Errorf("error persisting data column events: %s", err.Error())
 	}
 	return err
 }

--- a/pkg/db/migrations/000038_data_column_sidecar_events.down.sql
+++ b/pkg/db/migrations/000038_data_column_sidecar_events.down.sql
@@ -1,0 +1,2 @@
+RENAME TABLE t_blob_sidecars_events_pre_fulu TO t_blob_sidecars_events;
+DROP TABLE IF EXISTS t_data_column_sidecars_events;

--- a/pkg/db/migrations/000038_data_column_sidecar_events.up.sql
+++ b/pkg/db/migrations/000038_data_column_sidecar_events.up.sql
@@ -1,0 +1,31 @@
+-- PeerDAS (Fulu) replaced blob-level p2p propagation with column-level propagation:
+-- a node no longer receives whole blobs, it receives DataColumnSidecars. The
+-- beacon API's `blob_sidecar` event stopped firing at the Fulu fork, so
+-- t_blob_sidecars_events silently stopped filling (last row 2025-12-03) while
+-- every other blob table kept working. This table is its replacement: one row per
+-- column arrival, which is the finest-grained propagation signal available now
+-- (and strictly richer than the old one: it exposes the reconstruction curve of
+-- each blob, not just a single arrival timestamp).
+--
+-- Note: blob *metadata* still comes from the block itself (t_blob_sidecars) and is
+-- unaffected. Only the p2p arrival timing moved here.
+CREATE TABLE t_data_column_sidecars_events (
+	f_arrival_timestamp_ms UInt64 CODEC(DoubleDelta, ZSTD(3)),
+	f_slot                 UInt64 CODEC(DoubleDelta, ZSTD(3)),
+	f_block_root           String CODEC(ZSTD(3)),
+	f_column_index         UInt16 CODEC(T64, ZSTD(3)),
+	f_kzg_commitments      Array(String) CODEC(ZSTD(3)),
+	f_num_commitments      UInt16 CODEC(T64, ZSTD(3))
+	)
+	ENGINE = ReplacingMergeTree()
+	PARTITION BY intDiv(f_slot, 100000)
+	ORDER BY (f_slot, f_column_index, f_block_root);
+
+-- The blob_sidecar event no longer exists post-Fulu, so this table can never
+-- receive another row. Its historical rows (pre-2025-12-03) are preserved by
+-- renaming rather than dropping.
+--
+-- Deploy note: any bindeth serving this database must already include bindeth
+-- PR #352 (which re-points the blob queries to t_data_column_sidecars_events),
+-- otherwise its blob endpoints break on the renamed table.
+RENAME TABLE t_blob_sidecars_events TO t_blob_sidecars_events_pre_fulu;

--- a/pkg/db/migrations/000038_data_column_sidecar_events.up.sql
+++ b/pkg/db/migrations/000038_data_column_sidecar_events.up.sql
@@ -9,7 +9,7 @@
 --
 -- Note: blob *metadata* still comes from the block itself (t_blob_sidecars) and is
 -- unaffected. Only the p2p arrival timing moved here.
-CREATE TABLE t_data_column_sidecars_events (
+CREATE TABLE IF NOT EXISTS t_data_column_sidecars_events (
 	f_arrival_timestamp_ms UInt64 CODEC(DoubleDelta, ZSTD(3)),
 	f_slot                 UInt64 CODEC(DoubleDelta, ZSTD(3)),
 	f_block_root           String CODEC(ZSTD(3)),

--- a/pkg/db/prometheus_metrics.go
+++ b/pkg/db/prometheus_metrics.go
@@ -76,7 +76,7 @@ func (r *DBService) initMonitorMetrics() {
 
 	tablesArr := []string{
 		blobsTable,
-		blobEventsTable,
+		dataColumnEventsTable,
 		blockRewardsTable,
 		blocksTable,
 		epochsTable,

--- a/pkg/db/service.go
+++ b/pkg/db/service.go
@@ -145,7 +145,7 @@ type PersistableObject[
 		spec.Withdrawal |
 		HeadEvent |
 		spec.AgnosticBlobSidecar |
-		spec.BlobSideCarEventWraper |
+		spec.DataColumnSidecarEventWrapper |
 		BlockReward |
 		spec.AgnosticSlashing |
 		spec.BLSToExecutionChange |

--- a/pkg/events/blobs.go
+++ b/pkg/events/blobs.go
@@ -15,13 +15,20 @@ import (
 // longer emit `blob_sidecar` at all: the topic is still accepted (HTTP 200) but
 // never fires. That is why blob arrival timings silently stopped being recorded at
 // the fork while every other blob table kept working.
+//
+// A subscription failure is logged and skipped rather than crashing the process:
+// the analyzer can keep indexing everything else without this data source. Note
+// that Events() only returns errors synchronously for client-side conditions;
+// node-side rejections surface asynchronously inside go-eth2-client's own
+// goroutine, which logs and retries every second.
 func (e *Events) SubscribeToDataColumnSidecarsEvents() {
 	err := e.cli.Api.Events(e.ctx, &eth2api.EventsOpts{
 		Topics:  []string{"data_column_sidecar"},
 		Handler: e.HandleDataColumnSidecarEvent,
 	})
 	if err != nil {
-		log.Panicf("failed to subscribe to data_column_sidecar events: %s", err)
+		log.Errorf("failed to subscribe to data_column_sidecar events, blob arrival timings will not be recorded: %s", err)
+		return
 	}
 	log.Infof("subscribed to data_column_sidecar events")
 }

--- a/pkg/events/blobs.go
+++ b/pkg/events/blobs.go
@@ -8,28 +8,34 @@ import (
 	"github.com/migalabs/goteth/pkg/spec"
 )
 
-func (e *Events) SubscribeToBlobSidecarsEvents() {
-	// subscribe to head event
+// SubscribeToDataColumnSidecarsEvents subscribes to the p2p arrival of data columns.
+//
+// This replaces the old `blob_sidecar` subscription. Since the Fulu fork (PeerDAS)
+// blobs are erasure-coded into columns and gossiped per column, so beacon nodes no
+// longer emit `blob_sidecar` at all: the topic is still accepted (HTTP 200) but
+// never fires. That is why blob arrival timings silently stopped being recorded at
+// the fork while every other blob table kept working.
+func (e *Events) SubscribeToDataColumnSidecarsEvents() {
 	err := e.cli.Api.Events(e.ctx, &eth2api.EventsOpts{
-		Topics:  []string{"blob_sidecar"},
-		Handler: e.HandleBlobSidecarEvent,
-	}) // every reorg
+		Topics:  []string{"data_column_sidecar"},
+		Handler: e.HandleDataColumnSidecarEvent,
+	})
 	if err != nil {
-		log.Panicf("failed to subscribe to blob_sidecar events: %s", err)
+		log.Panicf("failed to subscribe to data_column_sidecar events: %s", err)
 	}
-	log.Infof("subscribed to blob_sidecar events")
+	log.Infof("subscribed to data_column_sidecar events")
 }
 
-func (e *Events) HandleBlobSidecarEvent(event *apiv1.Event) {
+func (e *Events) HandleDataColumnSidecarEvent(event *apiv1.Event) {
 	timestamp := time.Now()
 	if event.Data == nil {
 		return
 	}
 
-	data := spec.BlobSideCarEventWraper{
-		Timestamp:        timestamp,
-		BlobSidecarEvent: *event.Data.(*apiv1.BlobSidecarEvent),
+	data := spec.DataColumnSidecarEventWrapper{
+		Timestamp:              timestamp,
+		DataColumnSidecarEvent: *event.Data.(*apiv1.DataColumnSidecarEvent),
 	}
 
-	e.BlobSidecarChan <- data
+	e.DataColumnSidecarChan <- data
 }

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -22,10 +22,10 @@ type Events struct {
 	SubscribedHead bool
 	HeadChan       chan db.HeadEvent
 
-	SubscribedFinalized bool
-	FinalizedChan       chan apiv1.FinalizedCheckpointEvent
-	ReorgChan           chan apiv1.ChainReorgEvent
-	BlobSidecarChan     chan spec.BlobSideCarEventWraper
+	SubscribedFinalized   bool
+	FinalizedChan         chan apiv1.FinalizedCheckpointEvent
+	ReorgChan             chan apiv1.ChainReorgEvent
+	DataColumnSidecarChan chan spec.DataColumnSidecarEventWrapper
 }
 
 func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
@@ -37,6 +37,11 @@ func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 		SubscribedFinalized: false,
 		FinalizedChan:       make(chan apiv1.FinalizedCheckpointEvent),
 		ReorgChan:           make(chan apiv1.ChainReorgEvent),
-		BlobSidecarChan:     make(chan spec.BlobSideCarEventWraper),
+		// Buffered like HeadChan: HandleDataColumnSidecarEvent does a blocking send, so
+		// a full channel stalls the SSE reader and with it head ingestion. Sized much
+		// larger than the old blob channel on purpose: PeerDAS emits one event per data
+		// *column*, so a single block can produce up to 128 events (NUMBER_OF_COLUMNS)
+		// instead of the <=6 blob events it used to, all arriving in a burst.
+		DataColumnSidecarChan: make(chan spec.DataColumnSidecarEventWrapper, 1024),
 	}
 }

--- a/pkg/spec/blob.go
+++ b/pkg/spec/blob.go
@@ -61,9 +61,14 @@ func (b *AgnosticBlobSidecar) GetTxHash(txs []AgnosticTransaction) {
 	}
 }
 
-type BlobSideCarEventWraper struct {
-	Timestamp        time.Time
-	BlobSidecarEvent api.BlobSidecarEvent
+// DataColumnSidecarEventWrapper carries a data-column arrival plus the local time
+// we observed it. Since the Fulu fork (PeerDAS) blobs are no longer gossiped whole:
+// they are erasure-coded into columns and each node custodies a subset, so
+// `data_column_sidecar` replaced the now-dead `blob_sidecar` event as the p2p
+// propagation signal.
+type DataColumnSidecarEventWrapper struct {
+	Timestamp              time.Time
+	DataColumnSidecarEvent api.DataColumnSidecarEvent
 }
 
 func KZGCommitmentToVersionedHash(input deneb.KZGCommitment) string {


### PR DESCRIPTION
## Summary

Backport of the goteth-v4 fix. Closes #280.

Post-Fulu (PeerDAS), beacon nodes never emit `blob_sidecar` events again: blobs are erasure-coded into columns and gossiped per column, so the topic is still accepted (HTTP 200) but silently never fires. `t_blob_sidecars_events` froze at slot 13162611 (2025-12-03) on every v3 deployment. Verified on a synced Lighthouse v8.2.1: 128 `data_column_sidecar` events vs 0 `blob_sidecar` events over the same 15s window.

This replaces the dead subscription with `data_column_sidecar` and persists arrivals to a new `t_data_column_sidecars_events` table (one row per column arrival, up to 128 per slot), with the same shape and column names as v4, so bindeth #352 works against it unchanged.

- Migration `000038` (renumbered from v4's `000039`; v3 migrations end at `000037`, and both production databases are at version 37) creates the new table and renames `t_blob_sidecars_events` to `t_blob_sidecars_events_pre_fulu`, preserving history.
- Channel buffered at 1024: the SSE handler does a blocking send and PeerDAS bursts one event per column instead of <=6 per block.
- `--metrics` help in `cmd/blocks_cmd.go` documents where arrival timings live now. As before, arrival events are recorded unconditionally in head mode; `blob_sidecars` keeps gating blob metadata.

## Verification (mainnet, empty scratch database)

Built this branch and ran `blocks --download-mode finalized --metrics block` against a synced mainnet archive node for ~3.5 minutes, zero errors in the log:

- Migrations applied through 000038; `t_blob_sidecars_events_pre_fulu` present.
- `subscribed to data_column_sidecar events` on switch to head mode.
- 1534 rows over 12 slots; final check: beacon `head_slot` 14961048 vs table `max(f_slot)` 14961048.
- The three bindeth #352 queries (blob propagation, average arrival time, first/last spread) return sensible rows against the new table (blocks up to 17 blobs, avg propagation ~2s).

## Deploy notes

- bindeth must already include #352 when this migration runs, otherwise its blob endpoints break on the renamed table (they are already broken today against any DB where bindeth dev is deployed, since the new table does not exist yet).
- Subscribing to `data_column_sidecar` on a pre-Fulu beacon node may fail at startup. All current deployments (mainnet, hoodi, sepolia) are post-Fulu.
