### PR TITLE
perf(analyzer): batch data_column_sidecar persistence off the head loop

### DIFF
--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -215,6 +215,10 @@ func (s *ChainAnalyzer) Run() {
 		// Block requester in finalized slots, not used for now
 		s.wgMainRoutine.Add(1)
 		go s.runHead()
+
+		// Persists data_column_sidecar arrivals in batches, off the head loop (#282).
+		s.wgMainRoutine.Add(1)
+		go s.runDataColumnSidecarsPersister()
 	}
 
 	s.PromMetrics.Start()

--- a/pkg/analyzer/chain_analyzer.go
+++ b/pkg/analyzer/chain_analyzer.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -42,7 +43,7 @@ type ChainAnalyzer struct {
 	// Control Variables
 	wgMainRoutine            *sync.WaitGroup    // wait group for main routine (either historical or head)
 	wgDownload               *sync.WaitGroup    // wait group for download routine
-	stop                     bool               // flag to notify all routine to finish
+	stop                     atomic.Bool        // flag to notify all routine to finish (read and written from several goroutines)
 	routineClosed            chan struct{}      // signal that everything was closed succesfully
 	downloadMode             string             // whether to download historical blocks (defined by user) or follow chain head
 	rewardsAggregationEpochs int                // number of epochs to aggregate rewards
@@ -224,7 +225,7 @@ func (s *ChainAnalyzer) Run() {
 	s.PromMetrics.Start()
 
 	s.wgMainRoutine.Wait()
-	s.stop = true
+	s.stop.Store(true)
 	log.Infof("main routine finished, waiting for downloader...")
 
 	s.wgDownload.Wait()
@@ -242,7 +243,7 @@ func (s *ChainAnalyzer) Run() {
 
 func (s *ChainAnalyzer) Close() {
 	log.Info("Sudden closed detected, closing StateAnalyzer")
-	s.stop = true
+	s.stop.Store(true)
 	s.cancel()
 	<-s.routineClosed // Wait for services to stop before returning
 }

--- a/pkg/analyzer/download.go
+++ b/pkg/analyzer/download.go
@@ -22,7 +22,7 @@ func (s *ChainAnalyzer) DownloadBlock(slot phase0.Slot) {
 	newBlock, err := s.cli.RequestBeaconBlock(slot)
 	if err != nil {
 		log.Errorf("block error at slot %d: %s", slot, err)
-		s.stop = true
+		s.stop.Store(true)
 		s.cancel()
 		return
 	}
@@ -63,7 +63,7 @@ func (s *ChainAnalyzer) DownloadState(slot phase0.Slot) {
 
 	if err != nil {
 		log.Errorf("unable to retrieve beacon state from the beacon node, closing requester routine. %s", err.Error())
-		s.stop = true
+		s.stop.Store(true)
 		s.cancel()
 		return
 	}

--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -73,7 +73,7 @@ func (s *ChainAnalyzer) ProcessStateTransitionMetrics(epoch phase0.Epoch) {
 	if err != nil {
 		s.processerBook.FreePage(routineKey)
 		log.Errorf("could not parse bundle metrics at epoch: %s", err)
-		s.stop = true
+		s.stop.Store(true)
 		s.cancel()
 		return
 	}

--- a/pkg/analyzer/prometheus_metrics.go
+++ b/pkg/analyzer/prometheus_metrics.go
@@ -25,6 +25,12 @@ var (
 		Name:      "block_queue_length",
 		Help:      "The number of blocks int the history queue",
 	})
+	DataColumnSubscriptionActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: strings.ToLower(utils.CliName),
+		Subsystem: modName,
+		Name:      "data_column_subscription_active",
+		Help:      "1 while the data_column_sidecar SSE subscription is established; blob arrival timings are not recorded while 0",
+	})
 )
 
 func (c *ChainAnalyzer) GetPrometheusMetrics() *metrics.MetricsModule {
@@ -36,6 +42,7 @@ func (c *ChainAnalyzer) GetPrometheusMetrics() *metrics.MetricsModule {
 
 	metricsMod.AddIndvMetric(c.getStateHistoryLength())
 	metricsMod.AddIndvMetric(c.getBlockHistoryLength())
+	metricsMod.AddIndvMetric(c.getDataColumnSubscriptionActive())
 
 	return metricsMod
 }
@@ -60,6 +67,39 @@ func (p *ChainAnalyzer) getStateHistoryLength() *metrics.IndvMetrics {
 	)
 	if err != nil {
 		log.Error(errors.Wrap(err, "unable to init state_queue_length"))
+		return nil
+	}
+
+	return indvMetr
+}
+
+// getDataColumnSubscriptionActive makes a silent data_column_sidecar
+// subscription failure visible: the subscribe path logs and skips instead of
+// crashing, so without this gauge an operator could miss that blob arrival
+// timings stopped being recorded (the exact silent-loss failure mode of #280).
+func (p *ChainAnalyzer) getDataColumnSubscriptionActive() *metrics.IndvMetrics {
+
+	initFn := func() error {
+		prometheus.MustRegister(DataColumnSubscriptionActive)
+		return nil
+	}
+
+	updateFn := func() (interface{}, error) {
+		active := 0
+		if p.eventsObj.SubscribedDataColumns.Load() {
+			active = 1
+		}
+		DataColumnSubscriptionActive.Set(float64(active))
+		return active, nil
+	}
+
+	indvMetr, err := metrics.NewIndvMetrics(
+		"data_column_subscription_active",
+		initFn,
+		updateFn,
+	)
+	if err != nil {
+		log.Error(errors.Wrap(err, "unable to init data_column_subscription_active"))
 		return nil
 	}
 

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -117,9 +117,6 @@ func (s *ChainAnalyzer) runHead() {
 			s.dbClient.PersistReorgs([]v1.ChainReorgEvent{newReorg})
 			go s.HandleReorg(newReorg)
 
-		case newDataColumnEvent := <-s.eventsObj.DataColumnSidecarChan:
-			s.dbClient.PersistDataColumnSidecarsEvents([]spec.DataColumnSidecarEventWrapper{newDataColumnEvent})
-
 		case <-s.ctx.Done():
 			log.Info("context has died, closing block requester routine")
 			return
@@ -131,6 +128,104 @@ func (s *ChainAnalyzer) runHead() {
 			}
 		}
 
+	}
+}
+
+// dataColumnMaxBatch flushes as soon as one full-custody per-slot burst
+// (NUMBER_OF_COLUMNS = 128) has accumulated, without waiting for the ticker.
+const dataColumnMaxBatch = 128
+
+// runDataColumnSidecarsPersister drains DataColumnSidecarChan and persists the
+// events in batches, off the head loop. Under PeerDAS a full-custody node emits
+// up to 128 data_column_sidecar events per slot; persisting them one by one from
+// runHead meant one synchronous ClickHouse INSERT per event on the same loop
+// that dispatches block downloads (#282).
+func (s *ChainAnalyzer) runDataColumnSidecarsPersister() {
+	defer s.wgMainRoutine.Done()
+	log.Info("launching data column sidecars persister routine")
+
+	ticker := time.NewTicker(utils.RoutineFlushTimeout)
+	defer ticker.Stop()
+
+	batchDataColumnSidecarEvents(
+		s.eventsObj.DataColumnSidecarChan,
+		ticker.C,
+		s.ctx.Done(),
+		func() bool { return s.stop },
+		dataColumnMaxBatch,
+		func(batch []spec.DataColumnSidecarEventWrapper) {
+			if err := s.dbClient.PersistDataColumnSidecarsEvents(batch); err != nil {
+				log.Errorf("error persisting data column sidecar events batch: %s", err)
+			}
+		},
+	)
+
+	log.Info("data column sidecars persister routine finished")
+}
+
+// batchDataColumnSidecarEvents accumulates events from the channel and flushes
+// them in batches: immediately when maxBatch is reached, and on every tick when
+// the buffer is non-empty. It returns when done fires or when stopped() reports
+// true on a tick; in both cases it first drains whatever sits in the channel and
+// does a best-effort final flush (on the done path the write can fail if the DB
+// context is already cancelled, which the flush callback logs).
+func batchDataColumnSidecarEvents(
+	events <-chan spec.DataColumnSidecarEventWrapper,
+	tick <-chan time.Time,
+	done <-chan struct{},
+	stopped func() bool,
+	maxBatch int,
+	flush func([]spec.DataColumnSidecarEventWrapper),
+) {
+	buffer := make([]spec.DataColumnSidecarEventWrapper, 0, maxBatch)
+
+	// Reusing the backing array is safe: the persist path copies every value
+	// into its insert columns before returning.
+	flushBuffer := func() {
+		if len(buffer) == 0 {
+			return
+		}
+		flush(buffer)
+		buffer = buffer[:0]
+	}
+
+	// drain moves everything currently sitting in the channel into the buffer,
+	// flushing at maxBatch so the final batches stay bounded.
+	drain := func() {
+		for {
+			select {
+			case ev := <-events:
+				buffer = append(buffer, ev)
+				if len(buffer) >= maxBatch {
+					flushBuffer()
+				}
+			default:
+				return
+			}
+		}
+	}
+
+	for {
+		select {
+		case ev := <-events:
+			buffer = append(buffer, ev)
+			if len(buffer) >= maxBatch {
+				flushBuffer()
+			}
+
+		case <-tick:
+			flushBuffer()
+			if stopped() {
+				drain()
+				flushBuffer()
+				return
+			}
+
+		case <-done:
+			drain()
+			flushBuffer()
+			return
+		}
 	}
 }
 

--- a/pkg/analyzer/routines.go
+++ b/pkg/analyzer/routines.go
@@ -37,7 +37,7 @@ downloadRoutine:
 				go s.ProcessStateTransitionMetrics(phase0.Epoch(downloadSlot / spec.SlotsPerEpoch))
 			}
 		case <-ticker.C: // every certain amount of time check if need to finish
-			if s.stop && len(s.downloadTaskChan) == 0 && s.cli.ActiveReqNum() == 0 && s.processerBook.ActivePages() == 0 {
+			if s.stop.Load() && len(s.downloadTaskChan) == 0 && s.cli.ActiveReqNum() == 0 && s.processerBook.ActivePages() == 0 {
 				break downloadRoutine
 			}
 		}
@@ -122,7 +122,7 @@ func (s *ChainAnalyzer) runHead() {
 			return
 
 		case <-ticker.C:
-			if s.stop {
+			if s.stop.Load() {
 				log.Info("sudden shutdown detected, block downloader routine")
 				return
 			}
@@ -151,7 +151,7 @@ func (s *ChainAnalyzer) runDataColumnSidecarsPersister() {
 		s.eventsObj.DataColumnSidecarChan,
 		ticker.C,
 		s.ctx.Done(),
-		func() bool { return s.stop },
+		func() bool { return s.stop.Load() },
 		dataColumnMaxBatch,
 		func(batch []spec.DataColumnSidecarEventWrapper) {
 			if err := s.dbClient.PersistDataColumnSidecarsEvents(batch); err != nil {
@@ -291,7 +291,7 @@ func (s *ChainAnalyzer) fillToHead() phase0.Slot {
 		// runHistorical again — and since the chain keeps advancing,
 		// handoffThreshold is always exceeded and the loop spins
 		// indefinitely on shutdown.
-		if s.stop {
+		if s.stop.Load() {
 			return headSlot
 		}
 
@@ -313,7 +313,7 @@ func (s *ChainAnalyzer) runHistorical(init phase0.Slot, end phase0.Slot) {
 
 	i := init
 	for i <= end {
-		if s.stop {
+		if s.stop.Load() {
 			log.Info("sudden shutdown detected, block downloader routine")
 			return
 		}

--- a/pkg/analyzer/routines_test.go
+++ b/pkg/analyzer/routines_test.go
@@ -1,0 +1,166 @@
+package analyzer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+// flushRecorder is a thread-safe fake flush target for
+// batchDataColumnSidecarEvents. It records call and row counts only; the
+// batch slice itself is reused by the batcher and must not be retained.
+type flushRecorder struct {
+	mu    sync.Mutex
+	calls int
+	rows  int
+}
+
+func (r *flushRecorder) flush(batch []spec.DataColumnSidecarEventWrapper) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	r.rows += len(batch)
+}
+
+func (r *flushRecorder) snapshot() (calls int, rows int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls, r.rows
+}
+
+// waitFor polls cond until it is true or the timeout expires.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+type batcherHarness struct {
+	events   chan spec.DataColumnSidecarEventWrapper
+	tick     chan time.Time
+	done     chan struct{}
+	stopped  func() bool
+	rec      *flushRecorder
+	finished chan struct{}
+}
+
+func startBatcher(maxBatch int, stopped func() bool) *batcherHarness {
+	h := &batcherHarness{
+		events:   make(chan spec.DataColumnSidecarEventWrapper, 1024),
+		tick:     make(chan time.Time),
+		done:     make(chan struct{}),
+		stopped:  stopped,
+		rec:      &flushRecorder{},
+		finished: make(chan struct{}),
+	}
+	go func() {
+		batchDataColumnSidecarEvents(h.events, h.tick, h.done, h.stopped, maxBatch, h.rec.flush)
+		close(h.finished)
+	}()
+	return h
+}
+
+func (h *batcherHarness) sendEvents(n int) {
+	for i := 0; i < n; i++ {
+		h.events <- spec.DataColumnSidecarEventWrapper{Timestamp: time.Now()}
+	}
+}
+
+func (h *batcherHarness) waitFinished(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("batcher did not return")
+	}
+}
+
+// A burst larger than maxBatch flushes in maxBatch-sized batches without any
+// tick, and the tick then flushes the remainder: far fewer flushes than events.
+func TestBatchDataColumnEventsFlushesAtMaxBatch(t *testing.T) {
+	h := startBatcher(128, func() bool { return false })
+	h.sendEvents(300)
+
+	// The two full 128-event batches flush without any tick.
+	waitFor(t, time.Second, func() bool { _, rows := h.rec.snapshot(); return rows == 256 },
+		"two maxBatch flushes (256 rows)")
+
+	// Wait until the loop has consumed the whole burst, then tick to flush the
+	// remaining 44 (sending the tick earlier could reach the select while part
+	// of the burst still sits in the channel, splitting the last flush).
+	waitFor(t, time.Second, func() bool { return len(h.events) == 0 }, "channel drained")
+	h.tick <- time.Time{}
+	waitFor(t, time.Second, func() bool { _, rows := h.rec.snapshot(); return rows == 300 },
+		"tick flush of the remainder (300 rows total)")
+
+	calls, rows := h.rec.snapshot()
+	if rows != 300 {
+		t.Fatalf("expected 300 rows flushed, got %d", rows)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 flush calls (128+128+44), got %d", calls)
+	}
+
+	close(h.done)
+	h.waitFinished(t)
+}
+
+// A partial buffer is flushed once per tick, not once per event.
+func TestBatchDataColumnEventsTickFlushesPartialBuffer(t *testing.T) {
+	h := startBatcher(128, func() bool { return false })
+	h.sendEvents(5)
+
+	// Once the channel is empty every sent event is either appended already or
+	// being appended by the current loop iteration; the blocking tick send below
+	// is only received after that iteration finishes.
+	waitFor(t, time.Second, func() bool { return len(h.events) == 0 }, "channel drained")
+	h.tick <- time.Time{}
+
+	waitFor(t, time.Second, func() bool { calls, rows := h.rec.snapshot(); return calls == 1 && rows == 5 },
+		"single flush of 5 rows")
+
+	close(h.done)
+	h.waitFinished(t)
+}
+
+// When stopped() reports true on a tick, pending channel events are drained and
+// flushed before returning.
+func TestBatchDataColumnEventsStopDrainsChannel(t *testing.T) {
+	var mu sync.Mutex
+	stop := false
+	setStop := func(v bool) { mu.Lock(); stop = v; mu.Unlock() }
+	getStop := func() bool { mu.Lock(); defer mu.Unlock(); return stop }
+
+	h := startBatcher(128, getStop)
+	h.sendEvents(10)
+	setStop(true)
+	h.tick <- time.Time{}
+
+	h.waitFinished(t)
+	_, rows := h.rec.snapshot()
+	if rows != 10 {
+		t.Fatalf("expected all 10 rows flushed on stop, got %d", rows)
+	}
+}
+
+// When done fires, pending channel events are drained and flushed before
+// returning.
+func TestBatchDataColumnEventsDoneDrainsChannel(t *testing.T) {
+	h := startBatcher(128, func() bool { return false })
+	h.sendEvents(7)
+	close(h.done)
+
+	h.waitFinished(t)
+	_, rows := h.rec.snapshot()
+	if rows != 7 {
+		t.Fatalf("expected all 7 rows flushed on done, got %d", rows)
+	}
+}

--- a/pkg/events/blobs.go
+++ b/pkg/events/blobs.go
@@ -30,6 +30,7 @@ func (e *Events) SubscribeToDataColumnSidecarsEvents() {
 		log.Errorf("failed to subscribe to data_column_sidecar events, blob arrival timings will not be recorded: %s", err)
 		return
 	}
+	e.SubscribedDataColumns.Store(true)
 	log.Infof("subscribed to data_column_sidecar events")
 }
 

--- a/pkg/events/standard.go
+++ b/pkg/events/standard.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"sync/atomic"
 
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/migalabs/goteth/pkg/clientapi"
@@ -26,6 +27,12 @@ type Events struct {
 	FinalizedChan         chan apiv1.FinalizedCheckpointEvent
 	ReorgChan             chan apiv1.ChainReorgEvent
 	DataColumnSidecarChan chan spec.DataColumnSidecarEventWrapper
+
+	// SubscribedDataColumns turns true once the data_column_sidecar subscription
+	// is established; while false, blob arrival timings are not being recorded.
+	// Pointer so Events stays copyable (atomic values must not be copied); read
+	// by the prometheus updater goroutine.
+	SubscribedDataColumns *atomic.Bool
 }
 
 func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
@@ -43,5 +50,6 @@ func NewEventsObj(iCtx context.Context, iCli *clientapi.APIClient) Events {
 		// *column*, so a single block can produce up to 128 events (NUMBER_OF_COLUMNS)
 		// instead of the <=6 blob events it used to, all arriving in a burst.
 		DataColumnSidecarChan: make(chan spec.DataColumnSidecarEventWrapper, 1024),
+		SubscribedDataColumns: new(atomic.Bool),
 	}
 }


### PR DESCRIPTION
## Summary

Closes #282. Stacked on #281 (base branch is `fix/data-column-sidecar-events-280`; will be retargeted to `dev` once #281 merges).

Each `data_column_sidecar` event was persisted individually and synchronously inside `runHead`'s select loop. Under PeerDAS a full-custody node emits up to 128 of these events per slot, so a single slot triggered ~128 serialized, mutex-guarded ClickHouse INSERTs on the same loop that reads head events and dispatches block downloads; a slow write could stall block following.

## Changes

- `runHead` no longer touches `DataColumnSidecarChan`: head handling and download dispatch are now independent of data column write latency.
- A dedicated persister goroutine drains the channel and feeds `PersistDataColumnSidecarsEvents` (which always accepted a slice and batches rows into a single INSERT) in batches: immediately at 128 events (one full-custody per-slot burst) and on a 1s ticker otherwise. On a default-custody node the ticker path flushes the small per-slot handful in one call, so behaviour there is unchanged.
- Shutdown: the persister registers on `wgMainRoutine`, so `DBService.Finish()` waits for it; on stop or context cancellation it drains the channel and does a best-effort final flush. Previously up to 1024 queued events were silently dropped on shutdown.
- The batching core is a standalone function with an injected tick channel, covered by deterministic unit tests (no beacon node or database needed): flush at max batch, tick flush of partial buffers, drain on stop, drain on context cancellation. Green with `-race`.

## Verification

- `make build`, `go vet ./...` clean; `go test ./pkg/analyzer -run BatchDataColumn -race -count=5` green; full `go test ./...` shows only the pre-existing node-dependent failures (identical set on `dev`).
- Deployed on a full-custody mainnet node: persist calls for `t_data_column_sidecars_events` drop from ~128 per slot to 1-2 per slot while the row rate and `max(f_slot)` head tracking stay unchanged, and head events keep being processed every slot.

## Follow-up hardening (from internal review)

- `ChainAnalyzer.stop` is now an `atomic.Bool`: it was a plain bool written from `Close()`, `Run()` and two download error paths and read from four routines plus the new persister, all unsynchronized. Benign in practice, but a textbook race-detector hit, and the persister added one more reader.
- New gauge `goteth_analyzer_data_column_subscription_active`: since a subscribe failure now logs and skips instead of crashing, this makes the degraded state visible and alertable instead of a single startup log line (the silent-loss failure mode of #280).
