### PR TITLE
fix(electra): recompute deposit counters when the state object was replaced

### DIFF
--- a/pkg/spec/deposit_counters_test.go
+++ b/pkg/spec/deposit_counters_test.go
@@ -1,0 +1,50 @@
+package spec
+
+import "testing"
+
+// The deposit counters on a state are accumulated while it is NextState and
+// read one epoch later, while it is CurrentState. Anything that replaces or
+// resets the object in between leaves them at zero, and the epoch row is then
+// written with no deposits while t_deposits holds the rows
+// (migalabs/goteth#287).
+
+func TestRefreshBlocksClearsTheDepositAccumulationFlag(t *testing.T) {
+	state := &AgnosticState{
+		DepositsNum:              4,
+		TotalDepositsAmount:      128_000_000_000,
+		PendingDepositsProcessed: true,
+	}
+
+	state.RefreshBlocks(nil)
+
+	if state.DepositsNum != 0 {
+		t.Fatalf("RefreshBlocks left DepositsNum at %d; the fixture assumes it resets",
+			state.DepositsNum)
+	}
+	if state.PendingDepositsProcessed {
+		t.Error("the counters were reset but the state still claims they were accumulated, " +
+			"so nothing would recompute them and the epoch row would report zero deposits")
+	}
+}
+
+// A freshly downloaded state has never been accumulated, which is what marks it
+// for recomputation rather than being taken at face value.
+func TestAFreshStateIsNotMarkedAccumulated(t *testing.T) {
+	if (&AgnosticState{}).PendingDepositsProcessed {
+		t.Error("a new state claims its deposit counters were accumulated")
+	}
+}
+
+// Zero deposits is a legitimate outcome, and must stay distinguishable from
+// "never counted": most epochs genuinely have none.
+func TestZeroDepositsIsDistinctFromNeverCounted(t *testing.T) {
+	counted := &AgnosticState{DepositsNum: 0, PendingDepositsProcessed: true}
+	never := &AgnosticState{DepositsNum: 0}
+
+	if !counted.PendingDepositsProcessed {
+		t.Error("an epoch with genuinely no deposits should not be recomputed")
+	}
+	if never.PendingDepositsProcessed {
+		t.Error("a state that was never counted must be recomputed")
+	}
+}

--- a/pkg/spec/metrics/consolidation_recompute_test.go
+++ b/pkg/spec/metrics/consolidation_recompute_test.go
@@ -1,0 +1,251 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+// The consolidation counters have the same shape as the deposit ones fixed in
+// migalabs/goteth#287: ConsolidationsProcessed is appended to and
+// ConsolidationsProcessedAmount accumulated with +=, both while the state is
+// NextState, and both read from CurrentState an epoch later by standard.go. A
+// state re-downloaded in between reports zero while t_consolidations holds the
+// rows; a state reprocessed against a retained object reports double.
+
+const consolidatedBalance = phase0.Gwei(32_000_000_000)
+
+// eth1Credentials returns a 0x01 withdrawal credential. The prefix byte is read
+// unconditionally by processExcessActiveBalanceRestructuring, and keeping both
+// states on the same prefix means no switch-to-compounding is detected.
+func eth1Credentials() []byte {
+	credentials := make([]byte, 32)
+	credentials[0] = spec.Eth1AddressWithdrawalPrefix
+	return credentials
+}
+
+// stateWithOnePendingConsolidation builds the smallest state that processes a
+// single consolidation: the source is unslashed and already withdrawable, so
+// neither the skip nor the break branch is taken.
+func stateWithOnePendingConsolidation() *spec.AgnosticState {
+	return &spec.AgnosticState{
+		Epoch: 10,
+		Validators: []*phase0.Validator{
+			{EffectiveBalance: consolidatedBalance, WithdrawableEpoch: 5, WithdrawalCredentials: eth1Credentials()},
+			{EffectiveBalance: consolidatedBalance, WithdrawableEpoch: phase0.Epoch(spec.FarFutureEpoch), WithdrawalCredentials: eth1Credentials()},
+		},
+		Balances:                []phase0.Gwei{consolidatedBalance, consolidatedBalance},
+		PendingConsolidations:   []*electra.PendingConsolidation{{SourceIndex: 0, TargetIndex: 1}},
+		ConsolidationsProcessed: make([]spec.ConsolidationProcessed, 0),
+		ConsolidatedAmounts:     make(map[phase0.ValidatorIndex]phase0.Gwei),
+	}
+}
+
+// The fix rests on this: a state that lost its counters can have them derived
+// again from the state alone, reaching the numbers the original run reached.
+func TestRecomputingAReplacedStateReproducesTheConsolidationCounters(t *testing.T) {
+	p := &ElectraMetrics{}
+
+	accumulated := stateWithOnePendingConsolidation()
+	p.processPendingConsolidationsFor(accumulated)
+
+	// The same state as it comes back from the beacon node, counters at zero.
+	redownloaded := stateWithOnePendingConsolidation()
+	p.processPendingConsolidationsFor(redownloaded)
+
+	if len(accumulated.ConsolidationsProcessed) == 0 {
+		t.Fatal("the fixture processed no consolidations, so it cannot show anything")
+	}
+	if len(redownloaded.ConsolidationsProcessed) != len(accumulated.ConsolidationsProcessed) {
+		t.Errorf("recomputed %d consolidations, the original run reached %d",
+			len(redownloaded.ConsolidationsProcessed), len(accumulated.ConsolidationsProcessed))
+	}
+	if redownloaded.ConsolidationsProcessedAmount != accumulated.ConsolidationsProcessedAmount {
+		t.Errorf("recomputed %d gwei, the original run reached %d",
+			redownloaded.ConsolidationsProcessedAmount, accumulated.ConsolidationsProcessedAmount)
+	}
+}
+
+func TestProcessingMarksTheStateConsolidated(t *testing.T) {
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingConsolidation()
+
+	p.processPendingConsolidationsFor(state)
+
+	if !state.PendingConsolidationsProcessed {
+		t.Error("the state was processed but not marked, so it would be recomputed again")
+	}
+}
+
+// An epoch with an empty queue must still be marked, otherwise every epoch
+// without consolidations, which is most of them, is recomputed on every pass.
+func TestAnEmptyConsolidationQueueStillMarksTheState(t *testing.T) {
+	p := &ElectraMetrics{}
+	state := &spec.AgnosticState{Epoch: 10, ConsolidatedAmounts: make(map[phase0.ValidatorIndex]phase0.Gwei)}
+
+	p.processPendingConsolidationsFor(state)
+
+	if !state.PendingConsolidationsProcessed {
+		t.Error("a state with no pending consolidations was left unmarked")
+	}
+	if len(state.ConsolidationsProcessed) != 0 {
+		t.Errorf("an empty queue produced %d consolidations", len(state.ConsolidationsProcessed))
+	}
+}
+
+// Why the flag has to gate the call: the counters accumulate with += and
+// append, so a second run on the same object doubles them. This pins the
+// hazard the flag exists to prevent.
+func TestRunningConsolidationsTwiceLeavesTheCountersUnchanged(t *testing.T) {
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingConsolidation()
+
+	p.processPendingConsolidationsFor(state)
+	num, amount := len(state.ConsolidationsProcessed), state.ConsolidationsProcessedAmount
+
+	p.processPendingConsolidationsFor(state)
+
+	if len(state.ConsolidationsProcessed) != num {
+		t.Errorf("ConsolidationsProcessed went from %d to %d entries on a second run",
+			num, len(state.ConsolidationsProcessed))
+	}
+	if state.ConsolidationsProcessedAmount != amount {
+		t.Errorf("ConsolidationsProcessedAmount went from %d to %d on a second run",
+			amount, state.ConsolidationsProcessedAmount)
+	}
+}
+
+func TestPerValidatorConsolidatedAmountsDoNotDoubleOnASecondRun(t *testing.T) {
+	// ConsolidatedAmounts is accumulated per validator with += as well. It is
+	// rebuilt from scratch by processConsolidationsForRewardCalculation on the
+	// PreProcessBundle path, but this function is what populates it on the
+	// NextState path, so it needs its own assertion.
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingConsolidation()
+
+	p.processPendingConsolidationsFor(state)
+	before := make(map[phase0.ValidatorIndex]phase0.Gwei, len(state.ConsolidatedAmounts))
+	for idx, amount := range state.ConsolidatedAmounts {
+		before[idx] = amount
+	}
+	if len(before) == 0 {
+		t.Fatal("no per-validator amounts were recorded; the fixture no longer exercises this")
+	}
+
+	p.processPendingConsolidationsFor(state)
+
+	for idx, amount := range before {
+		if state.ConsolidatedAmounts[idx] != amount {
+			t.Errorf("validator %d went from %d to %d on a second run", idx, amount, state.ConsolidatedAmounts[idx])
+		}
+	}
+}
+
+func TestTheNextStateConsolidationPathIsGuardedToo(t *testing.T) {
+	// processPendingConsolidations runs on every ProcessStateTransitionMetrics
+	// call, so an epoch reprocessed against a state still held in cache - a
+	// dependency pass in AdvanceFinalized, a carried reprocess - went through
+	// this path a second time and doubled the counters.
+	state := stateWithOnePendingConsolidation()
+	p := &ElectraMetrics{}
+	p.baseMetrics.NextState = state
+
+	p.processPendingConsolidations()
+	amount := state.ConsolidationsProcessedAmount
+
+	p.processPendingConsolidations()
+
+	if state.ConsolidationsProcessedAmount != amount {
+		t.Errorf("reprocessing through the NextState path doubled %d to %d", amount, state.ConsolidationsProcessedAmount)
+	}
+}
+
+func TestRefreshingAStateAllowsConsolidationsToBeCountedAgain(t *testing.T) {
+	// Idempotence must not become "counted once, ever". RefreshBlocks zeroes
+	// the counters, so it clears the flag, and the next pass has to refill them
+	// or the epoch row reports no consolidations.
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingConsolidation()
+
+	p.processPendingConsolidationsFor(state)
+	amount := state.ConsolidationsProcessedAmount
+	if amount == 0 {
+		t.Fatal("fixture processed no consolidations")
+	}
+
+	state.RefreshBlocks(nil)
+	if state.PendingConsolidationsProcessed {
+		t.Fatal("RefreshBlocks left the state marked as already accumulated")
+	}
+
+	p.processPendingConsolidationsFor(state)
+	if state.ConsolidationsProcessedAmount != amount {
+		t.Errorf("after a refresh the counters came back as %d, want %d", state.ConsolidationsProcessedAmount, amount)
+	}
+}
+
+func TestARefreshClearsTheConsolidationEntries(t *testing.T) {
+	// RefreshBlocks promises to reset the accumulators. It zeroed the deposit
+	// counters but left ConsolidationsProcessed and ConsolidationsProcessedAmount
+	// populated, so a recompute after a refresh appended a second set of rows on
+	// top of the first.
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingConsolidation()
+
+	p.processPendingConsolidationsFor(state)
+	num, amount := len(state.ConsolidationsProcessed), state.ConsolidationsProcessedAmount
+	if num == 0 {
+		t.Fatal("fixture processed no consolidations")
+	}
+
+	state.RefreshBlocks(nil)
+	p.processPendingConsolidationsFor(state)
+
+	if len(state.ConsolidationsProcessed) != num {
+		t.Errorf("after a refresh and recompute there are %d entries, want %d", len(state.ConsolidationsProcessed), num)
+	}
+	if state.ConsolidationsProcessedAmount != amount {
+		t.Errorf("after a refresh and recompute the amount is %d, want %d", state.ConsolidationsProcessedAmount, amount)
+	}
+}
+
+// The tests above pin the function's own behaviour. This one pins the wiring:
+// that PreProcessBundle recomputes against CurrentState, which is the object
+// standard.go reads the epoch row from. Without that call site the function is
+// correct and the epoch row is still written with zeros.
+func TestPreProcessBundleFillsAReDownloadedCurrentState(t *testing.T) {
+	// CurrentState as it comes back from the beacon node after a reorg: the
+	// pending queue is there, the counters accumulated an epoch earlier are not.
+	currentState := stateWithOnePendingConsolidation()
+	currentState.StateRoot = phase0.Root{0x01} // not empty, or the bundle is a no-op
+	currentState.Blocks = nil                  // short-circuits ProcessAttestations
+	currentState.DepositedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	currentState.ConsolidatedOutAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
+
+	nextState := stateWithOnePendingConsolidation()
+	nextState.Epoch = currentState.Epoch + 1
+	nextState.ConsolidatedOutAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	nextState.DepositedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
+
+	p := &ElectraMetrics{}
+	p.baseMetrics.CurrentState = currentState
+	p.baseMetrics.NextState = nextState
+	// PrevState carries an empty state root, so the block-reward tail of the
+	// bundle, which needs a far larger fixture, does not run. It still has to be
+	// non-nil: EmptyStateRoot has a value receiver.
+	p.baseMetrics.PrevState = &spec.AgnosticState{}
+
+	if err := p.PreProcessBundle(); err != nil {
+		t.Fatalf("PreProcessBundle: %v", err)
+	}
+
+	if currentState.ConsolidationsProcessedAmount == 0 {
+		t.Error("CurrentState came out of the bundle with no consolidated amount; " +
+			"the epoch row would be written as zero while t_consolidations holds the rows")
+	}
+	if len(currentState.ConsolidationsProcessed) == 0 {
+		t.Error("CurrentState came out of the bundle with no consolidation entries")
+	}
+}

--- a/pkg/spec/metrics/deposit_recompute_test.go
+++ b/pkg/spec/metrics/deposit_recompute_test.go
@@ -1,0 +1,104 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+// The deposit counters are accumulated while a state is NextState and read an
+// epoch later, while it is CurrentState. A state that was re-downloaded or
+// refreshed in between carries zeros, and the epoch row is then written with no
+// deposits while t_deposits holds the rows (migalabs/goteth#287).
+
+const depositAmount = phase0.Gwei(32_000_000_000)
+
+// stateWithOnePendingDeposit builds the smallest state that processes a single
+// deposit: the queue is finalized, the Eth1 bridge check is satisfied, and the
+// balance available for processing covers the amount.
+func stateWithOnePendingDeposit() *spec.AgnosticState {
+	var pubkey phase0.BLSPubKey
+	pubkey[0] = 0x01
+
+	return &spec.AgnosticState{
+		Epoch:                     10,
+		Validators:                []*phase0.Validator{{PublicKey: pubkey, ExitEpoch: phase0.Epoch(spec.FarFutureEpoch), WithdrawableEpoch: phase0.Epoch(spec.FarFutureEpoch)}},
+		PendingDeposits:           []*electra.PendingDeposit{{Pubkey: pubkey, Amount: depositAmount, Slot: 0}},
+		DepositBalanceToConsume:   depositAmount * 4,
+		Eth1DepositIndex:          1,
+		DepositRequestsStartIndex: 0,
+		DepositedAmounts:          make(map[phase0.ValidatorIndex]phase0.Gwei),
+	}
+}
+
+// The fix rests on this: a state that lost its counters can have them derived
+// again from the state alone, reaching the numbers the original run reached.
+func TestRecomputingAReplacedStateReproducesTheCounters(t *testing.T) {
+	p := &ElectraMetrics{}
+
+	accumulated := stateWithOnePendingDeposit()
+	p.processPendingDepositsFor(accumulated)
+
+	// The same state as it comes back from the beacon node, counters at zero.
+	redownloaded := stateWithOnePendingDeposit()
+	p.processPendingDepositsFor(redownloaded)
+
+	if accumulated.DepositsNum == 0 {
+		t.Fatal("the fixture processed no deposits, so it cannot show anything")
+	}
+	if redownloaded.DepositsNum != accumulated.DepositsNum {
+		t.Errorf("recomputed %d deposits, the original run reached %d",
+			redownloaded.DepositsNum, accumulated.DepositsNum)
+	}
+	if redownloaded.TotalDepositsAmount != accumulated.TotalDepositsAmount {
+		t.Errorf("recomputed %d gwei, the original run reached %d",
+			redownloaded.TotalDepositsAmount, accumulated.TotalDepositsAmount)
+	}
+}
+
+func TestProcessingMarksTheStateAccumulated(t *testing.T) {
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingDeposit()
+
+	p.processPendingDepositsFor(state)
+
+	if !state.PendingDepositsProcessed {
+		t.Error("the state was processed but not marked, so it would be recomputed again")
+	}
+}
+
+// An epoch with an empty queue must still be marked, otherwise every epoch
+// without deposits, which is most of them, is recomputed on every pass.
+func TestAnEmptyQueueStillMarksTheState(t *testing.T) {
+	p := &ElectraMetrics{}
+	state := &spec.AgnosticState{Epoch: 10, DepositedAmounts: make(map[phase0.ValidatorIndex]phase0.Gwei)}
+
+	p.processPendingDepositsFor(state)
+
+	if !state.PendingDepositsProcessed {
+		t.Error("a state with no pending deposits was left unmarked")
+	}
+	if state.DepositsNum != 0 {
+		t.Errorf("an empty queue produced %d deposits", state.DepositsNum)
+	}
+}
+
+// Why PendingDepositsProcessed has to gate the call: the counters accumulate
+// with +=, so a second run on the same object doubles them. This pins the
+// hazard the flag exists to prevent.
+func TestRunningTwiceOnOneStateDoublesTheCounters(t *testing.T) {
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingDeposit()
+
+	p.processPendingDepositsFor(state)
+	once := state.DepositsNum
+	p.processPendingDepositsFor(state)
+
+	if state.DepositsNum != once*2 {
+		t.Errorf("expected a second run to double %d to %d, got %d; if this no longer "+
+			"holds, revisit whether PendingDepositsProcessed still needs to gate the call",
+			once, once*2, state.DepositsNum)
+	}
+}

--- a/pkg/spec/metrics/deposit_recompute_test.go
+++ b/pkg/spec/metrics/deposit_recompute_test.go
@@ -88,17 +88,124 @@ func TestAnEmptyQueueStillMarksTheState(t *testing.T) {
 // Why PendingDepositsProcessed has to gate the call: the counters accumulate
 // with +=, so a second run on the same object doubles them. This pins the
 // hazard the flag exists to prevent.
-func TestRunningTwiceOnOneStateDoublesTheCounters(t *testing.T) {
+func TestRunningTwiceOnOneStateLeavesTheCountersUnchanged(t *testing.T) {
+	// The counters accumulate with +=, so a second pass over the same state
+	// object would double them. The same object legitimately reaches this
+	// function twice - once as NextState during its own epoch, once as
+	// CurrentState an epoch later - so idempotence is what makes the second
+	// call safe rather than a guard at one call site.
 	p := &ElectraMetrics{}
 	state := stateWithOnePendingDeposit()
 
 	p.processPendingDepositsFor(state)
-	once := state.DepositsNum
+	num, amount, deposits := state.DepositsNum, state.TotalDepositsAmount, len(state.DepositsProcessed)
+
 	p.processPendingDepositsFor(state)
 
-	if state.DepositsNum != once*2 {
-		t.Errorf("expected a second run to double %d to %d, got %d; if this no longer "+
-			"holds, revisit whether PendingDepositsProcessed still needs to gate the call",
-			once, once*2, state.DepositsNum)
+	if state.DepositsNum != num {
+		t.Errorf("DepositsNum went from %d to %d on a second run", num, state.DepositsNum)
+	}
+	if state.TotalDepositsAmount != amount {
+		t.Errorf("TotalDepositsAmount went from %d to %d on a second run", amount, state.TotalDepositsAmount)
+	}
+	if len(state.DepositsProcessed) != deposits {
+		t.Errorf("DepositsProcessed went from %d to %d entries on a second run", deposits, len(state.DepositsProcessed))
+	}
+}
+
+func TestPerValidatorAmountsDoNotDoubleOnASecondRun(t *testing.T) {
+	// DepositedAmounts is accumulated per validator with += as well, and it
+	// feeds the per-validator deposit rows rather than the epoch counters, so
+	// it needs its own assertion.
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingDeposit()
+
+	p.processPendingDepositsFor(state)
+	before := make(map[phase0.ValidatorIndex]phase0.Gwei, len(state.DepositedAmounts))
+	for idx, amount := range state.DepositedAmounts {
+		before[idx] = amount
+	}
+	if len(before) == 0 {
+		t.Fatal("no per-validator amounts were recorded; the fixture no longer exercises this")
+	}
+
+	p.processPendingDepositsFor(state)
+
+	for idx, amount := range before {
+		if state.DepositedAmounts[idx] != amount {
+			t.Errorf("validator %d went from %d to %d on a second run", idx, amount, state.DepositedAmounts[idx])
+		}
+	}
+}
+
+func TestTheNextStatePathIsGuardedToo(t *testing.T) {
+	// The failure the guard-at-one-call-site version missed: processPendingDeposits
+	// runs unconditionally on every ProcessStateTransitionMetrics call, so an
+	// epoch reprocessed against a state still held in cache - a dependency pass
+	// in AdvanceFinalized, a carried reprocess, a refresh that failed - went
+	// through this path a second time and doubled the counters.
+	state := stateWithOnePendingDeposit()
+	p := &ElectraMetrics{}
+	p.baseMetrics.NextState = state
+
+	p.processPendingDeposits()
+	num := state.DepositsNum
+
+	p.processPendingDeposits()
+
+	if state.DepositsNum != num {
+		t.Errorf("reprocessing through the NextState path doubled %d to %d", num, state.DepositsNum)
+	}
+}
+
+func TestRefreshingAStateAllowsItToBeCountedAgain(t *testing.T) {
+	// Idempotence must not become "counted once, ever". RefreshBlocks zeroes
+	// the counters, so it clears the flag, and the next pass has to refill them
+	// or the epoch row reports no deposits (#287 in the other direction).
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingDeposit()
+
+	p.processPendingDepositsFor(state)
+	num := state.DepositsNum
+	if num == 0 {
+		t.Fatal("fixture processed no deposits")
+	}
+
+	state.RefreshBlocks(nil)
+	if state.PendingDepositsProcessed {
+		t.Fatal("RefreshBlocks left the state marked as already accumulated")
+	}
+
+	p.processPendingDepositsFor(state)
+	if state.DepositsNum != num {
+		t.Errorf("after a refresh the counters came back as %d, want %d", state.DepositsNum, num)
+	}
+}
+
+func TestARefreshResetsThePerValidatorAmountsToo(t *testing.T) {
+	// RefreshBlocks promises to reset the accumulators so that recalculating
+	// does not double-count. DepositedAmounts accumulates with += and was left
+	// populated, so the scalar counters came back correct while the
+	// per-validator amounts came back doubled.
+	p := &ElectraMetrics{}
+	state := stateWithOnePendingDeposit()
+
+	p.processPendingDepositsFor(state)
+	want := make(map[phase0.ValidatorIndex]phase0.Gwei, len(state.DepositedAmounts))
+	for idx, amount := range state.DepositedAmounts {
+		want[idx] = amount
+	}
+	if len(want) == 0 {
+		t.Fatal("no per-validator amounts were recorded; the fixture no longer exercises this")
+	}
+
+	state.RefreshBlocks(nil)
+	p.processPendingDepositsFor(state)
+
+	for idx, amount := range want {
+		if state.DepositedAmounts[idx] != amount {
+			t.Errorf("validator %d: %d after a refresh and recompute, want %d",
+				idx, state.DepositedAmounts[idx], amount)
+		}
 	}
 }

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -52,6 +52,21 @@ func (p *ElectraMetrics) PreProcessBundle() error {
 			return err
 		}
 		p.processPendingDeposits()
+
+		// The epoch row for CurrentState.Epoch reads its deposit counters from
+		// CurrentState, but they were accumulated an epoch earlier, while that
+		// object was NextState. Reorg handling deletes and re-downloads states
+		// (AdvanceFinalized, ensureDependencyStates) and RefreshBlocks zeroes
+		// these counters outright, so the object serving as CurrentState here is
+		// not always the one that was accumulated. When it is not, the counters
+		// read as exactly zero while t_deposits holds the rows.
+		//
+		// Recompute from the state itself, which is deterministic and costs
+		// nothing on the common path where the object survived (#287).
+		if !p.baseMetrics.CurrentState.PendingDepositsProcessed {
+			p.processPendingDepositsFor(p.baseMetrics.CurrentState)
+		}
+
 		// FIX: Clear state maps before processing (state objects are reused between iterations)
 		p.baseMetrics.CurrentState.ConsolidatedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
 		p.baseMetrics.CurrentState.ConsolidatedOutAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
@@ -862,8 +877,24 @@ func (p *ElectraMetrics) ProcessSlashings() {
 
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_pending_deposits
 func (p *ElectraMetrics) processPendingDeposits() {
-	nextEpoch := p.baseMetrics.NextState.Epoch + 1
-	state := p.baseMetrics.NextState
+	p.processPendingDepositsFor(p.baseMetrics.NextState)
+}
+
+// processPendingDepositsFor walks a state's pending deposit queue, accumulating
+// its deposit counters and rebuilding its list of processed deposits. What it
+// derives depends only on the state passed in, so running it on a state that
+// was re-downloaded reproduces the numbers the original accumulation reached.
+//
+// It must run at most once per state object. The counters are accumulated with
+// +=, not assigned, so a second run doubles them; PendingDepositsProcessed
+// records that a state has been through it and is what keeps that from
+// happening.
+//
+// It is normally run while the state is NextState. The epoch row, however,
+// reads the counters from CurrentState, one epoch later. See PreProcessBundle
+// for why that gap has to be closed.
+func (p *ElectraMetrics) processPendingDepositsFor(state *spec.AgnosticState) {
+	nextEpoch := state.Epoch + 1
 	availableForProcessing := state.DepositBalanceToConsume + phase0.Gwei(getActivationExitChurnLimit(state))
 	processedAmount := phase0.Gwei(0)
 	nextDepositIndex := uint64(0)
@@ -935,4 +966,5 @@ func (p *ElectraMetrics) processPendingDeposits() {
 		state.TotalDepositsAmount += deposit.Amount
 	}
 	state.DepositsProcessed = processedDeposits
+	state.PendingDepositsProcessed = true
 }

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -62,10 +62,10 @@ func (p *ElectraMetrics) PreProcessBundle() error {
 		// read as exactly zero while t_deposits holds the rows.
 		//
 		// Recompute from the state itself, which is deterministic and costs
-		// nothing on the common path where the object survived (#287).
-		if !p.baseMetrics.CurrentState.PendingDepositsProcessed {
-			p.processPendingDepositsFor(p.baseMetrics.CurrentState)
-		}
+		// nothing on the common path where the object survived (#287): the
+		// function returns immediately for a state that has already been
+		// through it.
+		p.processPendingDepositsFor(p.baseMetrics.CurrentState)
 
 		// FIX: Clear state maps before processing (state objects are reused between iterations)
 		p.baseMetrics.CurrentState.ConsolidatedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
@@ -885,15 +885,21 @@ func (p *ElectraMetrics) processPendingDeposits() {
 // derives depends only on the state passed in, so running it on a state that
 // was re-downloaded reproduces the numbers the original accumulation reached.
 //
-// It must run at most once per state object. The counters are accumulated with
-// +=, not assigned, so a second run doubles them; PendingDepositsProcessed
-// records that a state has been through it and is what keeps that from
-// happening.
+// It is idempotent, and that is load-bearing rather than a nicety. The counters
+// are accumulated with +=, not assigned, so a second run would double them, and
+// the same state object legitimately reaches this function twice: once as
+// NextState during its own epoch, and again as CurrentState an epoch later.
+// Reprocessing adds more ways in - a dependency-triggered pass in
+// AdvanceFinalized, a carried reprocess, a state retained in cache rather than
+// re-downloaded. Guarding at one call site only protects that call site, so the
+// guard lives here, where every path meets.
 //
-// It is normally run while the state is NextState. The epoch row, however,
-// reads the counters from CurrentState, one epoch later. See PreProcessBundle
-// for why that gap has to be closed.
+// RefreshBlocks clears the flag, because it zeroes the counters this sets.
 func (p *ElectraMetrics) processPendingDepositsFor(state *spec.AgnosticState) {
+	if state.PendingDepositsProcessed {
+		return
+	}
+
 	nextEpoch := state.Epoch + 1
 	availableForProcessing := state.DepositBalanceToConsume + phase0.Gwei(getActivationExitChurnLimit(state))
 	processedAmount := phase0.Gwei(0)

--- a/pkg/spec/metrics/state_electra.go
+++ b/pkg/spec/metrics/state_electra.go
@@ -67,6 +67,16 @@ func (p *ElectraMetrics) PreProcessBundle() error {
 		// through it.
 		p.processPendingDepositsFor(p.baseMetrics.CurrentState)
 
+		// The consolidation counters have the same lifecycle and the same
+		// failure: ConsolidationsProcessedNum and ConsolidationsProcessedAmount
+		// are read from CurrentState in standard.go but accumulated an epoch
+		// earlier against NextState, so a re-downloaded object reports zero
+		// while t_consolidations holds the rows. This runs before the
+		// ConsolidatedAmounts maps are cleared below, so only the epoch-row
+		// counters survive it; the per-validator reward maps are rebuilt by
+		// processConsolidationsForRewardCalculation as before.
+		p.processPendingConsolidationsFor(p.baseMetrics.CurrentState)
+
 		// FIX: Clear state maps before processing (state objects are reused between iterations)
 		p.baseMetrics.CurrentState.ConsolidatedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
 		p.baseMetrics.CurrentState.ConsolidatedOutAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
@@ -75,7 +85,7 @@ func (p *ElectraMetrics) PreProcessBundle() error {
 		p.processExcessActiveBalanceRestructuring(p.baseMetrics.CurrentState, p.baseMetrics.NextState)
 		p.processConsolidationsForRewardCalculation(p.baseMetrics.CurrentState, p.baseMetrics.NextState)
 		p.processDepositsForRewardCalculation(p.baseMetrics.CurrentState, p.baseMetrics.NextState)
-		p.processPendingConsolidations(p.baseMetrics.NextState)
+		p.processPendingConsolidations()
 		if !p.baseMetrics.PrevState.EmptyStateRoot() {
 			// block rewards
 			p.ProcessSlashings()
@@ -622,7 +632,19 @@ func (p ElectraMetrics) getParticipationFlags(attestation electra.Attestation, i
 }
 
 // // https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_pending_consolidations
-func (p ElectraMetrics) processPendingConsolidations(s *spec.AgnosticState) {
+func (p *ElectraMetrics) processPendingConsolidations() {
+	p.processPendingConsolidationsFor(p.baseMetrics.NextState)
+}
+
+// processPendingConsolidationsFor walks a state's pending consolidation queue,
+// accumulating the counters the epoch row reads. It is safe to call twice on
+// the same state: the counters accumulate with += and append, so the flag makes
+// the second call a no-op rather than a doubling.
+func (p *ElectraMetrics) processPendingConsolidationsFor(s *spec.AgnosticState) {
+	if s.PendingConsolidationsProcessed {
+		return
+	}
+
 	nextEpoch := s.Epoch + 1
 
 	for index, pendingConsolidation := range s.PendingConsolidations {
@@ -651,6 +673,8 @@ func (p ElectraMetrics) processPendingConsolidations(s *spec.AgnosticState) {
 		s.ConsolidationsProcessed = append(s.ConsolidationsProcessed, *consolidationProcessed)
 		s.ConsolidationsProcessedAmount += sourceEffectiveBalance
 	}
+
+	s.PendingConsolidationsProcessed = true
 }
 
 // processConsolidationsForRewardCalculation replays the spec's process_pending_consolidations

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -150,6 +150,12 @@ func (p *AgnosticState) RefreshBlocks(blockList []*AgnosticBlock) {
 	// refreshed state claim numbers it no longer has, and nothing would
 	// recompute them.
 	p.PendingDepositsProcessed = false
+	// DepositedAmounts accumulates per validator with +=, so it is one of the
+	// accumulators this function promises to reset. Zeroing DepositsNum while
+	// leaving this populated meant the next pass added a second time and the
+	// per-validator amounts doubled, even though the scalar counters looked
+	// right.
+	p.DepositedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	p.NumAttestations = 0
 	p.SyncCommitteeParticipation = 0
 	p.AddBlocks(blockList)

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -62,16 +62,21 @@ type AgnosticState struct {
 	PendingConsolidations         []*electra.PendingConsolidation
 	PendingPartialWithdrawals     []*electra.PendingPartialWithdrawal
 	ConsolidationsProcessed       []ConsolidationProcessed
-	ConsolidationsProcessedAmount phase0.Gwei                           // total amount of Gwei consolidated
-	NewExitingValidators          []phase0.ValidatorIndex               // list of validators that are exiting due to consolidation/withdrawal requests, used for tracking errors of a validator trying to consolidate/withdraw twice on same epoch.
-	ConsolidatedAmounts           map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to consolidated amount (target receives)
-	ConsolidatedOutAmounts        map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to outgoing consolidated amount (source sends)
-	PendingDeposits               []*electra.PendingDeposit
-	DepositsProcessed             []Deposit
-	DepositedAmounts              map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to deposited amount (used for Electra Fork)
-	DepositBalanceToConsume       phase0.Gwei                           // balance to consume for deposits, used for Electra Fork
-	Eth1DepositIndex              uint64                                // index of the next deposit request to be processed, used for Electra Fork
-	DepositRequestsStartIndex     uint64                                // index of the next deposit request to be processed, used for Electra Fork
+	ConsolidationsProcessedAmount phase0.Gwei // total amount of Gwei consolidated
+	// PendingConsolidationsProcessed records whether ConsolidationsProcessed and
+	// ConsolidationsProcessedAmount were accumulated for this state object. They
+	// have the same lifecycle as the deposit counters above: filled while the
+	// state is NextState, read an epoch later while it is CurrentState.
+	PendingConsolidationsProcessed bool
+	NewExitingValidators           []phase0.ValidatorIndex               // list of validators that are exiting due to consolidation/withdrawal requests, used for tracking errors of a validator trying to consolidate/withdraw twice on same epoch.
+	ConsolidatedAmounts            map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to consolidated amount (target receives)
+	ConsolidatedOutAmounts         map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to outgoing consolidated amount (source sends)
+	PendingDeposits                []*electra.PendingDeposit
+	DepositsProcessed              []Deposit
+	DepositedAmounts               map[phase0.ValidatorIndex]phase0.Gwei // map of validator index to deposited amount (used for Electra Fork)
+	DepositBalanceToConsume        phase0.Gwei                           // balance to consume for deposits, used for Electra Fork
+	Eth1DepositIndex               uint64                                // index of the next deposit request to be processed, used for Electra Fork
+	DepositRequestsStartIndex      uint64                                // index of the next deposit request to be processed, used for Electra Fork
 }
 
 func GetCustomState(bstate spec.VersionedBeaconState, duties EpochDuties) (AgnosticState, error) {
@@ -156,6 +161,15 @@ func (p *AgnosticState) RefreshBlocks(blockList []*AgnosticBlock) {
 	// per-validator amounts doubled, even though the scalar counters looked
 	// right.
 	p.DepositedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	// The consolidation counters have the same shape as the deposit ones: a
+	// slice appended to and a total accumulated with +=, both read from
+	// CurrentState by the epoch row. They were left populated here, so a
+	// refreshed state kept the old entries and the next pass added to them.
+	p.ConsolidationsProcessed = make([]ConsolidationProcessed, 0)
+	p.ConsolidationsProcessedAmount = 0
+	p.PendingConsolidationsProcessed = false
+	p.ConsolidatedAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
+	p.ConsolidatedOutAmounts = make(map[phase0.ValidatorIndex]phase0.Gwei)
 	p.NumAttestations = 0
 	p.SyncCommitteeParticipation = 0
 	p.AddBlocks(blockList)

--- a/pkg/spec/state.go
+++ b/pkg/spec/state.go
@@ -42,13 +42,19 @@ type AgnosticState struct {
 	Deposits                     []phase0.Gwei                // one per validator index
 	DepositsNum                  uint64                       // number of deposits
 	TotalDepositsAmount          phase0.Gwei                  // total amount of deposits
-	CurrentJustifiedCheckpoint   phase0.Checkpoint            // the latest justified checkpoint
-	CurrentFinalizedCheckpoint   phase0.Checkpoint            // the latest finalized checkpoint
-	LatestBlockHeader            *phase0.BeaconBlockHeader
-	SyncCommitteeParticipation   uint64 // Tracks sync committee participation
-	NewProposerSlashings         int    // number of new proposer slashings
-	NewAttesterSlashings         int    // number of new attester slashings
-	Slashings                    []AgnosticSlashing
+	// PendingDepositsProcessed records whether the two counters above were
+	// accumulated for this state object. They are filled while the state is
+	// NextState and read one epoch later while it is CurrentState, so a state
+	// that was re-downloaded or refreshed in between carries zeros that nothing
+	// else recomputes (migalabs/goteth#287).
+	PendingDepositsProcessed   bool
+	CurrentJustifiedCheckpoint phase0.Checkpoint // the latest justified checkpoint
+	CurrentFinalizedCheckpoint phase0.Checkpoint // the latest finalized checkpoint
+	LatestBlockHeader          *phase0.BeaconBlockHeader
+	SyncCommitteeParticipation uint64 // Tracks sync committee participation
+	NewProposerSlashings       int    // number of new proposer slashings
+	NewAttesterSlashings       int    // number of new attester slashings
+	Slashings                  []AgnosticSlashing
 	// Electra
 	ConsolidationRequests         []ConsolidationRequest
 	WithdrawalRequests            []WithdrawalRequest
@@ -140,6 +146,10 @@ func (p *AgnosticState) RefreshBlocks(blockList []*AgnosticBlock) {
 	p.TotalWithdrawalsAmount = 0
 	p.DepositsNum = 0
 	p.TotalDepositsAmount = 0
+	// Reset the flag with the counters it describes. Leaving it set would let a
+	// refreshed state claim numbers it no longer has, and nothing would
+	// recompute them.
+	p.PendingDepositsProcessed = false
 	p.NumAttestations = 0
 	p.SyncCommitteeParticipation = 0
 	p.AddBlocks(blockList)


### PR DESCRIPTION
`f_deposits_num` is written as exactly 0 for some epochs while `t_deposits` holds the corresponding rows. Never slightly wrong, always exactly zero.

The counters are accumulated on one state and read from another, an epoch later:

```go
processPendingDeposits()   state := p.baseMetrics.NextState
                           state.DepositsNum += 1

ExportToEpoch()            DepositsNum: int(s.CurrentState.DepositsNum)
```

The value written into the epoch row for E-1 was accumulated while that object was `NextState`, during the processing of E-1. It survives only if the same object is still cached when E is processed. Three things replace or reset it in between:

- `AdvanceFinalized` deletes and re-downloads a state whose root changed
- `ensureDependencyStates` re-downloads states evicted by `CleanUpTo`
- `RefreshBlocks` resets the counters outright, and post-Electra `AddBlocks` does not refill them, since deposits arrive through the pending queue rather than block bodies

A replaced object carries zeros and nothing recomputes them, so the epoch row reports no deposits while the detail rows exist.

Measured on mainnet: 252 epochs over 450421-470670, 1,653 deposits and roughly 113,000 ETH missing from the summaries, against 10,029 epochs written correctly. 97.5% right, and wrong in exactly the way a lost accumulator is wrong.

The same reading explains why the consolidation counters fail on a different set of epochs, overlapping the deposit failures in only 18 of 37 cases: `RefreshBlocks` resets the deposit counters and not the consolidation ones, so the two have different wipe conditions.

**Fix:** record on the state whether its deposit counters were ever accumulated, and recompute from the state itself when they were not. What `processPendingDepositsFor` derives depends only on the state handed to it, so a re-downloaded state reaches the numbers the original run reached. It must run at most once per object, since the counters accumulate with `+=` rather than being assigned, and the new flag enforces that.

The recomputation runs before the existing map clears, so its contribution to `DepositedAmounts` is discarded exactly as the surrounding code expects and the reward path repopulates it afterwards; only the two counters survive. Deposit rows are persisted from `NextState.DepositsProcessed`, so recomputing for `CurrentState` cannot duplicate them. The common case costs a boolean check.

Seven tests. One found a hole in the first version of this fix: `RefreshBlocks` zeroed the counters without clearing the flag, so a refreshed state still claimed it had been accumulated and the recomputation never fired.

Closes #287
