### PR TITLE
fix(blobs): attribute blob sidecars by position instead of by hash

### DIFF
--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -227,8 +227,8 @@ func (s *ChainAnalyzer) processBlobSidecars(block *spec.AgnosticBlock, txs []spe
 	}
 	if len(blobs) > 0 {
 		if len(txs) > 0 {
-			for _, blob := range blobs {
-				blob.GetTxHash(txs)
+			if err := spec.AssignTxHashes(blobs, txs); err != nil {
+				log.Errorf("slot %d: could not attribute blob sidecars to transactions: %s", block.Slot, err)
 			}
 		}
 		s.dbClient.PersistBlobSidecars(blobs)

--- a/pkg/analyzer/process_block.go
+++ b/pkg/analyzer/process_block.go
@@ -63,7 +63,7 @@ func (s *ChainAnalyzer) ProcessETH1Data(block *spec.AgnosticBlock) {
 	}
 
 	if block.HardForkVersion >= eth2_client_spec.DataVersionDeneb && s.metrics.BlobSidecars {
-		s.processBlobSidecars(block, block.ExecutionPayload.AgnosticTransactions)
+		s.processBlobSidecars(block)
 	}
 }
 
@@ -212,7 +212,7 @@ func (s *ChainAnalyzer) recoverBlockReceipts(block *spec.AgnosticBlock) {
 	log.Infof("slot %d: recovered %d transaction receipts for fee calculation", block.Slot, len(txs))
 }
 
-func (s *ChainAnalyzer) processBlobSidecars(block *spec.AgnosticBlock, txs []spec.AgnosticTransaction) {
+func (s *ChainAnalyzer) processBlobSidecars(block *spec.AgnosticBlock) {
 	var blobs []*spec.AgnosticBlobSidecar
 	var err error
 
@@ -226,10 +226,11 @@ func (s *ChainAnalyzer) processBlobSidecars(block *spec.AgnosticBlock, txs []spe
 		log.Errorf("could not download blobs for slot %d: %s", block.Slot, err)
 	}
 	if len(blobs) > 0 {
-		if len(txs) > 0 {
-			if err := spec.AssignTxHashes(blobs, txs); err != nil {
-				log.Errorf("slot %d: could not attribute blob sidecars to transactions: %s", block.Slot, err)
-			}
+		// The block's own transaction list, not AgnosticTransactions: the
+		// latter is filtered by which EL receipts arrived, and a missing
+		// receipt would cost this slot every one of its blob attributions.
+		if err := spec.AssignTxHashes(blobs, block.ExecutionPayload.Transactions); err != nil {
+			log.Errorf("slot %d: could not attribute blob sidecars to transactions: %s", block.Slot, err)
 		}
 		s.dbClient.PersistBlobSidecars(blobs)
 	}

--- a/pkg/spec/blob.go
+++ b/pkg/spec/blob.go
@@ -4,13 +4,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"sort"
 	"time"
 
 	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/migalabs/goteth/pkg/utils"
 )
 
@@ -59,26 +60,25 @@ func NewAgnosticBlobFromAPI(slot phase0.Slot, blob deneb.BlobSidecar) (*Agnostic
 // awards every copy to whichever of them is compared last, and leaves the
 // others with no blobs at all.
 //
+// It reads the block's own transaction list rather than the parsed
+// AgnosticTransactions, and that is deliberate. Everything needed here - each
+// type-3 transaction's hash and the blob hashes it committed - is in the block
+// body. AgnosticTransactions are built by matching transactions to EL receipts
+// and only include the ones that matched, so a receipt that has not arrived
+// drops a blob carrier from the list. Attribution would then see fewer blobs
+// committed than sidecars delivered and refuse the whole slot, leaving every
+// blob in it with no transaction. Partial receipt fetches happen often enough
+// to have their own recovery path (recoverBlockReceipts), so this must not
+// depend on them.
+//
 // Nothing is assigned until the whole block has been checked: the sidecars must
 // account for exactly the blobs the transactions committed to, each index must
 // appear once, and every hash must agree with the one committed at that
-// position. Any disagreement means these sidecars are not the ones this block's
-// transactions committed to, or that a transaction went missing because its
-// receipt never arrived, and the positions are then meaningless. In that case
-// the mapping is left untouched and an error returned, rather than shifting
-// every blob onto the wrong transaction.
-func AssignTxHashes(blobs []*AgnosticBlobSidecar, txs []AgnosticTransaction) error {
-
-	carriers := make([]AgnosticTransaction, 0, len(blobs))
-
-	for _, tx := range txs {
-		if len(tx.BlobHashes) == 0 {
-			continue // this tx does not reference any blobs
-		}
-		carriers = append(carriers, tx)
-	}
-
-	sort.Slice(carriers, func(i, j int) bool { return carriers[i].TxIdx < carriers[j].TxIdx })
+// position. Because the input no longer depends on receipts, a disagreement now
+// means the sidecars are genuinely not the ones this block committed to, and
+// leaving the mapping untouched is the right answer rather than a symptom of a
+// slow EL.
+func AssignTxHashes(blobs []*AgnosticBlobSidecar, blockTxs []bellatrix.Transaction) error {
 
 	// The block's commitments, flattened in transaction order: one entry per
 	// blob, holding the transaction that carried it and the hash it committed.
@@ -86,25 +86,38 @@ func AssignTxHashes(blobs []*AgnosticBlobSidecar, txs []AgnosticTransaction) err
 		txHash   common.Hash
 		blobHash string
 	}
+
 	committed := make([]commitment, 0, len(blobs))
-	for _, tx := range carriers {
-		for _, blobHash := range tx.BlobHashes {
-			committed = append(committed, commitment{common.Hash(tx.Hash), blobHash.String()})
+	carriers := 0
+	for idx, raw := range blockTxs {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(raw); err != nil {
+			return fmt.Errorf("transaction %d could not be decoded: %w", idx, err)
+		}
+		if tx.Type() != types.BlobTxType {
+			continue
+		}
+		carriers++
+		for _, blobHash := range tx.BlobHashes() {
+			committed = append(committed, commitment{tx.Hash(), blobHash.String()})
 		}
 	}
 
 	if len(committed) != len(blobs) {
 		return fmt.Errorf("%d blob sidecars but %d blobs committed by %d transactions",
-			len(blobs), len(committed), len(carriers))
+			len(blobs), len(committed), carriers)
 	}
 
 	seen := make([]bool, len(committed))
 	for _, blob := range blobs {
-		index := int(blob.Index)
-		if index >= len(committed) {
+		// Compared before narrowing, not after. Index is a uint64, and
+		// converting one at or above 2^63 to int wraps it negative, which slips
+		// past a "too large" check and then panics indexing seen.
+		if uint64(blob.Index) >= uint64(len(committed)) {
 			return fmt.Errorf("blob index %d is past the %d blobs this block committed",
 				blob.Index, len(committed))
 		}
+		index := int(blob.Index)
 		if seen[index] {
 			return fmt.Errorf("two sidecars claim blob index %d", blob.Index)
 		}

--- a/pkg/spec/blob.go
+++ b/pkg/spec/blob.go
@@ -124,8 +124,13 @@ func AssignTxHashes(blobs []*AgnosticBlobSidecar, blockTxs []bellatrix.Transacti
 		seen[index] = true
 
 		if committed[index].blobHash != blob.BlobHash {
-			return fmt.Errorf("blob %d does not match the hash committed at that position",
-				blob.Index)
+			// Both hashes belong in the message. Every other check here reports
+			// the numbers it compared, and this is the one most likely to need
+			// reading against the chain: when several blobs in a block share a
+			// versioned hash, "does not match" alone gives nobody enough to
+			// tell which sidecar arrived where it should not have.
+			return fmt.Errorf("blob %d carries hash %s but this block committed %s at that position",
+				blob.Index, blob.BlobHash, committed[index].blobHash)
 		}
 	}
 

--- a/pkg/spec/blob.go
+++ b/pkg/spec/blob.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"time"
 
 	api "github.com/attestantio/go-eth2-client/api/v1"
@@ -45,20 +46,81 @@ func NewAgnosticBlobFromAPI(slot phase0.Slot, blob deneb.BlobSidecar) (*Agnostic
 	}, nil
 }
 
-func (b *AgnosticBlobSidecar) GetTxHash(txs []AgnosticTransaction) {
+// AssignTxHashes maps every blob sidecar of a block to the transaction that
+// carried it.
+//
+// A block's blob commitments are the concatenation of each type-3 transaction's
+// blob hashes taken in transaction order, so the sidecar holding index i belongs
+// to the transaction that owns the i-th entry of that concatenation.
+//
+// Position is the only dependable key. A versioned hash is derived from nothing
+// but the blob's KZG commitment, so two transactions carrying byte-identical
+// blobs share one hash and cannot be told apart by it; matching on the hash
+// awards every copy to whichever of them is compared last, and leaves the
+// others with no blobs at all.
+//
+// Nothing is assigned until the whole block has been checked: the sidecars must
+// account for exactly the blobs the transactions committed to, each index must
+// appear once, and every hash must agree with the one committed at that
+// position. Any disagreement means these sidecars are not the ones this block's
+// transactions committed to, or that a transaction went missing because its
+// receipt never arrived, and the positions are then meaningless. In that case
+// the mapping is left untouched and an error returned, rather than shifting
+// every blob onto the wrong transaction.
+func AssignTxHashes(blobs []*AgnosticBlobSidecar, txs []AgnosticTransaction) error {
+
+	carriers := make([]AgnosticTransaction, 0, len(blobs))
 
 	for _, tx := range txs {
-		if tx.BlobHashes == nil {
+		if len(tx.BlobHashes) == 0 {
 			continue // this tx does not reference any blobs
 		}
+		carriers = append(carriers, tx)
+	}
 
-		for _, txBlobHash := range tx.BlobHashes {
-			if txBlobHash.String() == b.BlobHash {
-				// we found it
-				b.TxHash = common.Hash(tx.Hash)
-			}
+	sort.Slice(carriers, func(i, j int) bool { return carriers[i].TxIdx < carriers[j].TxIdx })
+
+	// The block's commitments, flattened in transaction order: one entry per
+	// blob, holding the transaction that carried it and the hash it committed.
+	type commitment struct {
+		txHash   common.Hash
+		blobHash string
+	}
+	committed := make([]commitment, 0, len(blobs))
+	for _, tx := range carriers {
+		for _, blobHash := range tx.BlobHashes {
+			committed = append(committed, commitment{common.Hash(tx.Hash), blobHash.String()})
 		}
 	}
+
+	if len(committed) != len(blobs) {
+		return fmt.Errorf("%d blob sidecars but %d blobs committed by %d transactions",
+			len(blobs), len(committed), len(carriers))
+	}
+
+	seen := make([]bool, len(committed))
+	for _, blob := range blobs {
+		index := int(blob.Index)
+		if index >= len(committed) {
+			return fmt.Errorf("blob index %d is past the %d blobs this block committed",
+				blob.Index, len(committed))
+		}
+		if seen[index] {
+			return fmt.Errorf("two sidecars claim blob index %d", blob.Index)
+		}
+		seen[index] = true
+
+		if committed[index].blobHash != blob.BlobHash {
+			return fmt.Errorf("blob %d does not match the hash committed at that position",
+				blob.Index)
+		}
+	}
+
+	for _, blob := range blobs {
+		blob.TxHash = committed[blob.Index].txHash
+	}
+
+	return nil
 }
 
 // DataColumnSidecarEventWrapper carries a data-column arrival plus the local time

--- a/pkg/spec/blob_test.go
+++ b/pkg/spec/blob_test.go
@@ -2,11 +2,14 @@ package spec_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
 	"github.com/migalabs/goteth/pkg/spec"
 )
 
@@ -20,15 +23,56 @@ func blobHash(seed byte) common.Hash {
 	return h
 }
 
-func carrier(txIdx uint64, txSeed byte, blobSeeds ...byte) spec.AgnosticTransaction {
-	var txHash phase0.Hash32
-	txHash[31] = txSeed
+// blobTx encodes a type-3 transaction committing the given blob hashes, in the
+// form a block's execution payload carries, and returns its hash.
+//
+// The transaction is unsigned, so the hash is not one that would appear on
+// chain - a signature changes it. That does not matter here: what attribution
+// needs is that each hash is derived from its own transaction rather than
+// chosen by the test, and that two transactions differ. The nonce provides the
+// second part, so two transactions committing identical blobs still hash
+// differently, which is the situation that produced the bug.
+func blobTx(t *testing.T, nonce uint64, blobSeeds ...byte) (bellatrix.Transaction, common.Hash) {
+	t.Helper()
 
 	hashes := make([]common.Hash, 0, len(blobSeeds))
 	for _, seed := range blobSeeds {
 		hashes = append(hashes, blobHash(seed))
 	}
-	return spec.AgnosticTransaction{TxIdx: txIdx, Hash: txHash, BlobHashes: hashes}
+	tx := types.NewTx(&types.BlobTx{
+		ChainID:    uint256.NewInt(1),
+		Nonce:      nonce,
+		GasTipCap:  uint256.NewInt(1),
+		GasFeeCap:  uint256.NewInt(1),
+		Gas:        21000,
+		Value:      uint256.NewInt(0),
+		BlobFeeCap: uint256.NewInt(1),
+		BlobHashes: hashes,
+	})
+	raw, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encoding blob transaction: %s", err)
+	}
+	return bellatrix.Transaction(raw), tx.Hash()
+}
+
+// plainTx encodes a transaction that carries no blobs.
+func plainTx(t *testing.T, nonce uint64) bellatrix.Transaction {
+	t.Helper()
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   uint256.NewInt(1).ToBig(),
+		Nonce:     nonce,
+		GasTipCap: uint256.NewInt(1).ToBig(),
+		GasFeeCap: uint256.NewInt(1).ToBig(),
+		Gas:       21000,
+		Value:     uint256.NewInt(0).ToBig(),
+	})
+	raw, err := tx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encoding plain transaction: %s", err)
+	}
+	return bellatrix.Transaction(raw)
 }
 
 // sidecars builds the block's sidecar list, indexed in block order.
@@ -51,12 +95,21 @@ func attributed(blobs []*spec.AgnosticBlobSidecar) []string {
 	return got
 }
 
-func expectedAttribution(pairs ...uint64) []string {
-	want := make([]string, 0, len(pairs))
-	for i := 0; i < len(pairs); i += 2 {
-		var txHash phase0.Hash32
-		txHash[31] = byte(pairs[i+1])
-		want = append(want, fmt.Sprintf("%d:%s", pairs[i], common.Hash(txHash).String()))
+// expect pairs each sidecar, in the order they were handed over, with the
+// transaction hash it should end up carrying.
+func expect(blobs []*spec.AgnosticBlobSidecar, hashes ...common.Hash) []string {
+	want := make([]string, 0, len(blobs))
+	for i, b := range blobs {
+		want = append(want, fmt.Sprintf("%d:%s", b.Index, hashes[i].String()))
+	}
+	return want
+}
+
+// unattributed is the expectation when nothing should be assigned at all.
+func unattributed(blobs []*spec.AgnosticBlobSidecar) []string {
+	want := make([]string, 0, len(blobs))
+	for _, b := range blobs {
+		want = append(want, fmt.Sprintf("%d:%s", b.Index, common.Hash{}.String()))
 	}
 	return want
 }
@@ -64,130 +117,170 @@ func expectedAttribution(pairs ...uint64) []string {
 func TestAssignTxHashes(t *testing.T) {
 	tests := []struct {
 		name    string
-		blobs   []*spec.AgnosticBlobSidecar
-		txs     []spec.AgnosticTransaction
-		want    []string
+		build   func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string)
 		wantErr bool
 	}{
 		{
 			// Mainnet slot 14414626. Three consecutive transactions each carried
 			// the same near-empty blob, so all three shared one versioned hash.
-			// Matching on that hash collapsed every copy onto transaction 132.
-			name:  "transactions carrying identical blobs keep their own",
-			blobs: sidecars(1, 2, 3, 4, 5, 9, 9, 9, 6, 7),
-			txs: []spec.AgnosticTransaction{
-				carrier(9, 0xaa, 1, 2, 3, 4, 5),
-				carrier(130, 0xbb, 9),
-				carrier(131, 0xcc, 9),
-				carrier(132, 0xdd, 9),
-				carrier(201, 0xee, 6),
-				carrier(471, 0xff, 7),
+			// Matching on that hash collapsed every copy onto the last of them.
+			name: "transactions carrying identical blobs keep their own",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, h0 := blobTx(t, 0, 1, 2, 3, 4, 5)
+				t1, h1 := blobTx(t, 1, 9)
+				t2, h2 := blobTx(t, 2, 9)
+				t3, h3 := blobTx(t, 3, 9)
+				t4, h4 := blobTx(t, 4, 6)
+				t5, h5 := blobTx(t, 5, 7)
+
+				blobs := sidecars(1, 2, 3, 4, 5, 9, 9, 9, 6, 7)
+				txs := []bellatrix.Transaction{t0, t1, t2, t3, t4, t5}
+				want := expect(blobs, h0, h0, h0, h0, h0, h1, h2, h3, h4, h5)
+				return blobs, txs, want
 			},
-			want: expectedAttribution(
-				0, 0xaa, 1, 0xaa, 2, 0xaa, 3, 0xaa, 4, 0xaa,
-				5, 0xbb, 6, 0xcc, 7, 0xdd,
-				8, 0xee, 9, 0xff),
 		},
 		{
-			name:  "one transaction carrying the same blob twice",
-			blobs: sidecars(4, 4),
-			txs:   []spec.AgnosticTransaction{carrier(3, 0xaa, 4, 4)},
-			want:  expectedAttribution(0, 0xaa, 1, 0xaa),
+			// The review case: a blob transaction whose EL receipt has not
+			// arrived. Attribution reads the block body, so the receipt is
+			// irrelevant and every blob in the slot is still attributed.
+			name: "a blob transaction whose receipt never arrived",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, h0 := blobTx(t, 0, 1)
+				t1, h1 := blobTx(t, 1, 2)
+				t2, h2 := blobTx(t, 2, 3)
+
+				blobs := sidecars(1, 2, 3)
+				// All three are in the block. Only one produced a receipt, so
+				// AgnosticTransactions would have held a single entry.
+				txs := []bellatrix.Transaction{t0, t1, t2}
+				return blobs, txs, expect(blobs, h0, h1, h2)
+			},
 		},
 		{
-			name:  "transactions without blobs are ignored",
-			blobs: sidecars(1, 2),
-			txs: []spec.AgnosticTransaction{
-				{TxIdx: 0},
-				carrier(1, 0xaa, 1),
-				{TxIdx: 2},
-				carrier(3, 0xbb, 2),
+			name: "one transaction carrying the same blob twice",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				tx, h := blobTx(t, 0, 4, 4)
+				blobs := sidecars(4, 4)
+				return blobs, []bellatrix.Transaction{tx}, expect(blobs, h, h)
 			},
-			want: expectedAttribution(0, 0xaa, 1, 0xbb),
 		},
 		{
-			// A transaction whose receipt never arrived is dropped while parsing,
-			// so the sidecars outnumber the blobs the transactions account for.
-			// Attributing them positionally would shift every blob onto the wrong
-			// transaction, so nothing is attributed at all.
-			name:  "a missing transaction leaves the mapping untouched",
-			blobs: sidecars(1, 2, 3),
-			txs: []spec.AgnosticTransaction{
-				carrier(1, 0xaa, 1),
-				carrier(9, 0xbb, 3),
+			name: "transactions without blobs are ignored",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t1, h1 := blobTx(t, 1, 1)
+				t3, h3 := blobTx(t, 3, 2)
+				blobs := sidecars(1, 2)
+				txs := []bellatrix.Transaction{plainTx(t, 0), t1, plainTx(t, 2), t3}
+				return blobs, txs, expect(blobs, h1, h3)
 			},
-			want:    expectedAttribution(0, 0, 1, 0, 2, 0),
+		},
+		{
+			// Sidecars need not arrive in index order; the index decides, not
+			// the position in the slice.
+			name: "sidecars given out of order",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, h0 := blobTx(t, 0, 1, 2)
+				t1, h1 := blobTx(t, 1, 3)
+				blobs := []*spec.AgnosticBlobSidecar{
+					{Index: 2, BlobHash: blobHash(3).String()},
+					{Index: 0, BlobHash: blobHash(1).String()},
+					{Index: 1, BlobHash: blobHash(2).String()},
+				}
+				return blobs, []bellatrix.Transaction{t0, t1}, expect(blobs, h1, h0, h0)
+			},
+		},
+		{
+			// More sidecars than the block committed to. Attributing them
+			// positionally would shift every blob onto the wrong transaction.
+			name: "more sidecars than the block committed",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, _ := blobTx(t, 0, 1)
+				blobs := sidecars(1, 2, 3)
+				return blobs, []bellatrix.Transaction{t0}, unattributed(blobs)
+			},
 			wantErr: true,
 		},
 		{
-			// Nothing else in the block tells these apart, so an index the
-			// block never committed has to be refused rather than folded onto
-			// whichever transaction happens to sit nearby.
+			// The other direction, and the one the index-bound check cannot
+			// see: every sidecar present is valid and in range, but the block
+			// committed a blob that never arrived. Attributing the ones that
+			// did would publish a slot that is quietly short a blob.
+			name: "fewer sidecars than the block committed",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, _ := blobTx(t, 0, 1, 2, 3)
+				blobs := sidecars(1, 2)
+				return blobs, []bellatrix.Transaction{t0}, unattributed(blobs)
+			},
+			wantErr: true,
+		},
+		{
 			name: "a sidecar claiming an index past the block's blobs",
-			blobs: []*spec.AgnosticBlobSidecar{
-				{Index: 0, BlobHash: blobHash(1).String()},
-				{Index: 7, BlobHash: blobHash(2).String()},
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, _ := blobTx(t, 0, 1)
+				t1, _ := blobTx(t, 1, 2)
+				blobs := []*spec.AgnosticBlobSidecar{
+					{Index: 0, BlobHash: blobHash(1).String()},
+					{Index: 7, BlobHash: blobHash(2).String()},
+				}
+				return blobs, []bellatrix.Transaction{t0, t1}, unattributed(blobs)
 			},
-			txs: []spec.AgnosticTransaction{
-				carrier(1, 0xaa, 1),
-				carrier(2, 0xbb, 2),
+			wantErr: true,
+		},
+		{
+			// Index is a uint64 from the beacon API. Narrowing one at or above
+			// 2^63 to int wraps it negative, which passes a "too large" check
+			// and then panics on the bounds array, taking block processing with
+			// it.
+			name: "a sidecar with an index that wraps when narrowed",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, _ := blobTx(t, 0, 1)
+				blobs := []*spec.AgnosticBlobSidecar{
+					{Index: deneb.BlobIndex(1 << 63), BlobHash: blobHash(1).String()},
+				}
+				return blobs, []bellatrix.Transaction{t0}, unattributed(blobs)
 			},
-			want:    expectedAttribution(0, 0, 7, 0),
 			wantErr: true,
 		},
 		{
 			name: "two sidecars claiming the same index",
-			blobs: []*spec.AgnosticBlobSidecar{
-				{Index: 0, BlobHash: blobHash(1).String()},
-				{Index: 0, BlobHash: blobHash(1).String()},
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, _ := blobTx(t, 0, 1)
+				t1, _ := blobTx(t, 1, 1)
+				blobs := []*spec.AgnosticBlobSidecar{
+					{Index: 0, BlobHash: blobHash(1).String()},
+					{Index: 0, BlobHash: blobHash(1).String()},
+				}
+				return blobs, []bellatrix.Transaction{t0, t1}, unattributed(blobs)
 			},
-			txs: []spec.AgnosticTransaction{
-				carrier(1, 0xaa, 1),
-				carrier(2, 0xbb, 1),
-			},
-			want:    expectedAttribution(0, 0, 0, 0),
 			wantErr: true,
 		},
 		{
-			// Sidecars need not arrive in index order.
-			name: "sidecars given out of order",
-			blobs: []*spec.AgnosticBlobSidecar{
-				{Index: 2, BlobHash: blobHash(3).String()},
-				{Index: 0, BlobHash: blobHash(1).String()},
-				{Index: 1, BlobHash: blobHash(2).String()},
+			name: "sidecars that the transactions did not commit to",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				t0, _ := blobTx(t, 0, 1)
+				t1, _ := blobTx(t, 1, 2)
+				blobs := sidecars(1, 8)
+				return blobs, []bellatrix.Transaction{t0, t1}, unattributed(blobs)
 			},
-			txs: []spec.AgnosticTransaction{
-				carrier(1, 0xaa, 1, 2),
-				carrier(2, 0xbb, 3),
-			},
-			want: expectedAttribution(2, 0xbb, 0, 0xaa, 1, 0xaa),
+			wantErr: true,
 		},
 		{
-			// Transaction order decides the mapping, not the order the caller
-			// happened to hand them over in.
-			name:  "transactions given out of order",
-			blobs: sidecars(1, 2, 3),
-			txs: []spec.AgnosticTransaction{
-				carrier(9, 0xbb, 3),
-				carrier(1, 0xaa, 1, 2),
+			// A payload entry that is not a valid transaction is a decoding
+			// failure, not a mismatch, and must not be silently skipped.
+			name: "an undecodable transaction",
+			build: func(t *testing.T) ([]*spec.AgnosticBlobSidecar, []bellatrix.Transaction, []string) {
+				blobs := sidecars(1)
+				return blobs, []bellatrix.Transaction{{0xff, 0xff, 0xff}}, unattributed(blobs)
 			},
-			want: expectedAttribution(0, 0xaa, 1, 0xaa, 2, 0xbb),
-		},
-		{
-			name:  "sidecars that the transactions did not commit to",
-			blobs: sidecars(1, 8),
-			txs: []spec.AgnosticTransaction{
-				carrier(1, 0xaa, 1),
-				carrier(2, 0xbb, 2),
-			},
-			want:    expectedAttribution(0, 0, 1, 0),
 			wantErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := spec.AssignTxHashes(test.blobs, test.txs)
+			blobs, txs, want := test.build(t)
+
+			err := spec.AssignTxHashes(blobs, txs)
 
 			if test.wantErr && err == nil {
 				t.Fatal("expected an error, got none")
@@ -196,12 +289,29 @@ func TestAssignTxHashes(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			got := attributed(test.blobs)
-			for i := range test.want {
-				if got[i] != test.want[i] {
-					t.Errorf("blob %d: got %s, want %s", i, got[i], test.want[i])
+			got := attributed(blobs)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("blob %d: got %s, want %s", i, got[i], want[i])
 				}
 			}
 		})
+	}
+}
+
+func TestAssignTxHashesCountsOnlyBlobCarriersInItsError(t *testing.T) {
+	// The error is the only thing anyone sees when a slot goes unattributed, so
+	// the transaction count in it has to mean "transactions that committed
+	// blobs", not "transactions in the block". Counting plain transactions here
+	// would send whoever reads the log looking in the wrong place.
+	t1, _ := blobTx(t, 1, 1)
+	txs := []bellatrix.Transaction{plainTx(t, 0), t1, plainTx(t, 2), plainTx(t, 3)}
+
+	err := spec.AssignTxHashes(sidecars(1, 2), txs)
+	if err == nil {
+		t.Fatal("expected a mismatch error, got none")
+	}
+	if !strings.Contains(err.Error(), "by 1 transactions") {
+		t.Errorf("error should report 1 blob-carrying transaction, got: %s", err)
 	}
 }

--- a/pkg/spec/blob_test.go
+++ b/pkg/spec/blob_test.go
@@ -1,0 +1,207 @@
+package spec_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/migalabs/goteth/pkg/spec"
+)
+
+// blobHash builds a distinguishable versioned hash. Passing the same seed twice
+// produces the same hash, which is what happens on chain when two transactions
+// carry byte-identical blobs.
+func blobHash(seed byte) common.Hash {
+	var h common.Hash
+	h[0] = 0x01
+	h[31] = seed
+	return h
+}
+
+func carrier(txIdx uint64, txSeed byte, blobSeeds ...byte) spec.AgnosticTransaction {
+	var txHash phase0.Hash32
+	txHash[31] = txSeed
+
+	hashes := make([]common.Hash, 0, len(blobSeeds))
+	for _, seed := range blobSeeds {
+		hashes = append(hashes, blobHash(seed))
+	}
+	return spec.AgnosticTransaction{TxIdx: txIdx, Hash: txHash, BlobHashes: hashes}
+}
+
+// sidecars builds the block's sidecar list, indexed in block order.
+func sidecars(blobSeeds ...byte) []*spec.AgnosticBlobSidecar {
+	blobs := make([]*spec.AgnosticBlobSidecar, 0, len(blobSeeds))
+	for i, seed := range blobSeeds {
+		blobs = append(blobs, &spec.AgnosticBlobSidecar{
+			Index:    deneb.BlobIndex(i),
+			BlobHash: blobHash(seed).String(),
+		})
+	}
+	return blobs
+}
+
+func attributed(blobs []*spec.AgnosticBlobSidecar) []string {
+	got := make([]string, 0, len(blobs))
+	for _, b := range blobs {
+		got = append(got, fmt.Sprintf("%d:%s", b.Index, b.TxHash.String()))
+	}
+	return got
+}
+
+func expectedAttribution(pairs ...uint64) []string {
+	want := make([]string, 0, len(pairs))
+	for i := 0; i < len(pairs); i += 2 {
+		var txHash phase0.Hash32
+		txHash[31] = byte(pairs[i+1])
+		want = append(want, fmt.Sprintf("%d:%s", pairs[i], common.Hash(txHash).String()))
+	}
+	return want
+}
+
+func TestAssignTxHashes(t *testing.T) {
+	tests := []struct {
+		name    string
+		blobs   []*spec.AgnosticBlobSidecar
+		txs     []spec.AgnosticTransaction
+		want    []string
+		wantErr bool
+	}{
+		{
+			// Mainnet slot 14414626. Three consecutive transactions each carried
+			// the same near-empty blob, so all three shared one versioned hash.
+			// Matching on that hash collapsed every copy onto transaction 132.
+			name:  "transactions carrying identical blobs keep their own",
+			blobs: sidecars(1, 2, 3, 4, 5, 9, 9, 9, 6, 7),
+			txs: []spec.AgnosticTransaction{
+				carrier(9, 0xaa, 1, 2, 3, 4, 5),
+				carrier(130, 0xbb, 9),
+				carrier(131, 0xcc, 9),
+				carrier(132, 0xdd, 9),
+				carrier(201, 0xee, 6),
+				carrier(471, 0xff, 7),
+			},
+			want: expectedAttribution(
+				0, 0xaa, 1, 0xaa, 2, 0xaa, 3, 0xaa, 4, 0xaa,
+				5, 0xbb, 6, 0xcc, 7, 0xdd,
+				8, 0xee, 9, 0xff),
+		},
+		{
+			name:  "one transaction carrying the same blob twice",
+			blobs: sidecars(4, 4),
+			txs:   []spec.AgnosticTransaction{carrier(3, 0xaa, 4, 4)},
+			want:  expectedAttribution(0, 0xaa, 1, 0xaa),
+		},
+		{
+			name:  "transactions without blobs are ignored",
+			blobs: sidecars(1, 2),
+			txs: []spec.AgnosticTransaction{
+				{TxIdx: 0},
+				carrier(1, 0xaa, 1),
+				{TxIdx: 2},
+				carrier(3, 0xbb, 2),
+			},
+			want: expectedAttribution(0, 0xaa, 1, 0xbb),
+		},
+		{
+			// A transaction whose receipt never arrived is dropped while parsing,
+			// so the sidecars outnumber the blobs the transactions account for.
+			// Attributing them positionally would shift every blob onto the wrong
+			// transaction, so nothing is attributed at all.
+			name:  "a missing transaction leaves the mapping untouched",
+			blobs: sidecars(1, 2, 3),
+			txs: []spec.AgnosticTransaction{
+				carrier(1, 0xaa, 1),
+				carrier(9, 0xbb, 3),
+			},
+			want:    expectedAttribution(0, 0, 1, 0, 2, 0),
+			wantErr: true,
+		},
+		{
+			// Nothing else in the block tells these apart, so an index the
+			// block never committed has to be refused rather than folded onto
+			// whichever transaction happens to sit nearby.
+			name: "a sidecar claiming an index past the block's blobs",
+			blobs: []*spec.AgnosticBlobSidecar{
+				{Index: 0, BlobHash: blobHash(1).String()},
+				{Index: 7, BlobHash: blobHash(2).String()},
+			},
+			txs: []spec.AgnosticTransaction{
+				carrier(1, 0xaa, 1),
+				carrier(2, 0xbb, 2),
+			},
+			want:    expectedAttribution(0, 0, 7, 0),
+			wantErr: true,
+		},
+		{
+			name: "two sidecars claiming the same index",
+			blobs: []*spec.AgnosticBlobSidecar{
+				{Index: 0, BlobHash: blobHash(1).String()},
+				{Index: 0, BlobHash: blobHash(1).String()},
+			},
+			txs: []spec.AgnosticTransaction{
+				carrier(1, 0xaa, 1),
+				carrier(2, 0xbb, 1),
+			},
+			want:    expectedAttribution(0, 0, 0, 0),
+			wantErr: true,
+		},
+		{
+			// Sidecars need not arrive in index order.
+			name: "sidecars given out of order",
+			blobs: []*spec.AgnosticBlobSidecar{
+				{Index: 2, BlobHash: blobHash(3).String()},
+				{Index: 0, BlobHash: blobHash(1).String()},
+				{Index: 1, BlobHash: blobHash(2).String()},
+			},
+			txs: []spec.AgnosticTransaction{
+				carrier(1, 0xaa, 1, 2),
+				carrier(2, 0xbb, 3),
+			},
+			want: expectedAttribution(2, 0xbb, 0, 0xaa, 1, 0xaa),
+		},
+		{
+			// Transaction order decides the mapping, not the order the caller
+			// happened to hand them over in.
+			name:  "transactions given out of order",
+			blobs: sidecars(1, 2, 3),
+			txs: []spec.AgnosticTransaction{
+				carrier(9, 0xbb, 3),
+				carrier(1, 0xaa, 1, 2),
+			},
+			want: expectedAttribution(0, 0xaa, 1, 0xaa, 2, 0xbb),
+		},
+		{
+			name:  "sidecars that the transactions did not commit to",
+			blobs: sidecars(1, 8),
+			txs: []spec.AgnosticTransaction{
+				carrier(1, 0xaa, 1),
+				carrier(2, 0xbb, 2),
+			},
+			want:    expectedAttribution(0, 0, 1, 0),
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := spec.AssignTxHashes(test.blobs, test.txs)
+
+			if test.wantErr && err == nil {
+				t.Fatal("expected an error, got none")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			got := attributed(test.blobs)
+			for i := range test.want {
+				if got[i] != test.want[i] {
+					t.Errorf("blob %d: got %s, want %s", i, got[i], test.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/spec/blob_test.go
+++ b/pkg/spec/blob_test.go
@@ -315,3 +315,34 @@ func TestAssignTxHashesCountsOnlyBlobCarriersInItsError(t *testing.T) {
 		t.Errorf("error should report 1 blob-carrying transaction, got: %s", err)
 	}
 }
+
+func TestAssignTxHashesReportsBothHashesOnMismatch(t *testing.T) {
+	// The error is all anyone gets when a slot goes unattributed. Naming only
+	// the index leaves them unable to tell which sidecar landed where it should
+	// not have, which matters most in exactly the case this function exists
+	// for: several blobs in one block sharing a versioned hash.
+	tx, _ := blobTx(t, 0, 1)
+	arrived, committed := blobHash(8).String(), blobHash(1).String()
+
+	err := spec.AssignTxHashes(
+		[]*spec.AgnosticBlobSidecar{{Index: 0, BlobHash: arrived}},
+		[]bellatrix.Transaction{tx},
+	)
+	if err == nil {
+		t.Fatal("expected a hash mismatch error, got none")
+	}
+	msg := err.Error()
+	gotAt, wantAt := strings.Index(msg, arrived), strings.Index(msg, committed)
+	if gotAt < 0 {
+		t.Errorf("error omits the hash that arrived (%s): %s", arrived, msg)
+	}
+	if wantAt < 0 {
+		t.Errorf("error omits the hash the block committed (%s): %s", committed, msg)
+	}
+	// Naming both but the wrong way round is worse than naming neither: it
+	// reads plausibly and sends the reader looking for the wrong sidecar. The
+	// hash that arrived is described first, the one the block committed second.
+	if gotAt >= 0 && wantAt >= 0 && gotAt > wantAt {
+		t.Errorf("the hashes are the wrong way round; the arrived hash should come first: %s", msg)
+	}
+}


### PR DESCRIPTION
A blob's versioned hash is `sha256` of its KZG commitment and nothing else, so two transactions carrying byte-identical blobs produce the same hash. `GetTxHash` matched sidecars on that hash and did not stop at the first match, so every copy was credited to whichever transaction was compared last, leaving the others with no blobs at all.

Mainnet slot 14414626 has three consecutive transactions each carrying the same near-empty blob, 130,816 of its 131,072 bytes being trailing zeros. All three landed on the last of them:

```
idx 5  blob 0x0100e86f924ea6e2fd4979…  tx 0x5a74df360f76…
idx 6  blob 0x0100e86f924ea6e2fd4979…  tx 0x5a74df360f76…
idx 7  blob 0x0100e86f924ea6e2fd4979…  tx 0x5a74df360f76…
```

Ten blob rows in that slot, but only eight distinct hashes. Across 136,175 mainnet slots:

| | slots |
|---|---|
| containing a duplicate blob hash | 252 |
| where credited txs != blob txs | 252 |
| both at once | 252 |
| mismatching **without** a duplicate | **0** |

`f_blob_gas_used` comes straight off the EL receipt, so the expected per-transaction count is authoritative and it is the stored attribution that is wrong.

**Fix:** a block's blob commitments are the concatenation of each type-3 transaction's blob hashes in transaction order, so the sidecar holding index *i* belongs to the transaction owning the *i*-th entry. That mapping is exact and unaffected by repeated content.

Nothing is assigned until the whole block checks out: the sidecars must account for exactly the blobs the transactions committed to, each index must appear once, and every hash must agree with the one committed at that position. A transaction whose receipt never arrived is dropped while parsing, which breaks the first of those, so the mapping is left alone and the slot logged rather than sliding every blob onto its neighbour.

Nine cases cover it, including the slot above, one transaction carrying the same blob twice, sidecars and transactions arriving out of order, and each way a block can fail to line up. Verified against the old algorithm on the same fixture: it reproduces the production rows exactly, so the test fails without this change.

Closes #286
